### PR TITLE
Composition update

### DIFF
--- a/Microsoft.Windows.Toolkit.SampleApp/SamplePages/OffsetBehavior/OffsetBehaviorXaml.bind
+++ b/Microsoft.Windows.Toolkit.SampleApp/SamplePages/OffsetBehavior/OffsetBehaviorXaml.bind
@@ -17,7 +17,7 @@
 				OffsetX="@[OffsetX:DoubleSlider:0.0:0.0-500.0]" 
 				OffsetY="@[OffsetY:DoubleSlider:0.0:0.0-500.0]" 
 				OffsetZ="@[OffsetZ:DoubleSlider:0.0:0.0-500.0]" 
-				Duration="@[Duration:DoubleSlider:1.0:0.1-5.0]" 
+				Duration="@[Duration:DoubleSlider:1.0:0.0-5.0]" 
 				Delay="@[Delay:DoubleSlider:0.0:0.0-5.0]" 
 				AutomaticallyStart="@[AutomaticallyStart:Bool:True]"/>
             </interactivity:Interaction.Behaviors>

--- a/Microsoft.Windows.Toolkit.SampleApp/SamplePages/OpacityBehavior/OpacityBehaviorXaml.bind
+++ b/Microsoft.Windows.Toolkit.SampleApp/SamplePages/OpacityBehavior/OpacityBehaviorXaml.bind
@@ -13,7 +13,7 @@
             <interactivity:Interaction.Behaviors>
                 <behaviors:Opacity x:Name="Opacity" 
 				Value="@[Value:DoubleSlider:0.0:0.0-1.0]" 
-				Duration="@[Duration:DoubleSlider:1.0:0.1-5.0]" 
+				Duration="@[Duration:DoubleSlider:1.0:0.0-5.0]" 
 				Delay="@[Delay:DoubleSlider:0.0:0.0-5.0]" 
 				AutomaticallyStart="@[AutomaticallyStart:Bool:True]"/>
             </interactivity:Interaction.Behaviors>

--- a/Microsoft.Windows.Toolkit.SampleApp/SamplePages/RotationBehavior/RotationBehaviorXaml.bind
+++ b/Microsoft.Windows.Toolkit.SampleApp/SamplePages/RotationBehavior/RotationBehaviorXaml.bind
@@ -17,7 +17,7 @@
 				CenterX="@[CenterX:DoubleSlider:0.0:0.0-100.0]" 
 				CenterY="@[CenterY:DoubleSlider:0.0:0.0-100.0]" 
 				CenterZ="@[CenterZ:DoubleSlider:0.0:0.0-100.0]" 
-				Duration="@[Duration:DoubleSlider:1.0:0.1-5.0]" 
+				Duration="@[Duration:DoubleSlider:1.0:0.0-5.0]" 
 				Delay="@[Delay:DoubleSlider:0.0:0.0-5.0]" 
 				AutomaticallyStart="@[AutomaticallyStart:Bool:True]"/>
             </interactivity:Interaction.Behaviors>

--- a/Microsoft.Windows.Toolkit.SampleApp/SamplePages/ScaleBehavior/ScaleBehaviorXaml.bind
+++ b/Microsoft.Windows.Toolkit.SampleApp/SamplePages/ScaleBehavior/ScaleBehaviorXaml.bind
@@ -20,7 +20,7 @@
 				CenterX="@[CenterX:DoubleSlider:0.0:0.0-100.0]" 
 				CenterY="@[CenterY:DoubleSlider:0.0:0.0-100.0]" 
 				CenterZ="@[CenterZ:DoubleSlider:0.0:0.0-100.0]" 
-				Duration="@[Duration:DoubleSlider:1.0:0.1-5.0]" 
+				Duration="@[Duration:DoubleSlider:1.0:0.0-5.0]" 
 				Delay="@[Delay:DoubleSlider:0.0:0.0-5.0]" 
 				AutomaticallyStart="@[AutomaticallyStart:Bool:True]"/>
             </interactivity:Interaction.Behaviors>

--- a/Microsoft.Windows.Toolkit.SampleApp/SamplePages/samples.json
+++ b/Microsoft.Windows.Toolkit.SampleApp/SamplePages/samples.json
@@ -137,7 +137,7 @@
         "Name": "OpacityBehavior",
         "Type": "OpacityBehaviorPage",
         "About": "Opacity of XAML elements using composition",
-        "CodeUrl": "https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Windows.Toolkit.UI.Animations/Behaviorst",
+        "CodeUrl": "https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Windows.Toolkit.UI.Animations/Behaviors",
         "CodeFile": "OpacityBehaviorCode.bind",
         "XamlCodeFile": "OpacityBehaviorXaml.bind",
         "Icon": "/SamplePages/OpacityBehavior/opacityBehavior.gif"
@@ -147,7 +147,8 @@
         "Type": "ScaleBehaviorPage",
         "About": "Scale of XAML elements using composition",
         "CodeUrl": "https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Windows.Toolkit.UI.Animations/Behaviors",
-        "XamlCodeFile": "ScaleBehaviorCode.bind",
+        "CodeFile": "ScaleBehaviorCode.bind",
+        "XamlCodeFile": "ScaleBehaviorXaml.bind",
         "Icon": "/SamplePages/ScaleBehavior/scaleBehavior.gif"
       },
       {

--- a/Microsoft.Windows.Toolkit.UI.Animations/Extensions/Composition.cs
+++ b/Microsoft.Windows.Toolkit.UI.Animations/Extensions/Composition.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
         /// <returns>The visual of the UIElement.</returns>
         public static Visual Scale(
             this UIElement associatedObject,
-            double duration = 0.1d,
+            double duration = 0.5d,
             double delay = 0d,
             float centerX = 0f,
             float centerY = 0f,
@@ -54,21 +54,29 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
             }
 
             var visual = ElementCompositionPreview.GetElementVisual(associatedObject);
-            var compositor = visual?.Compositor;
-
-            if (compositor == null)
-            {
-                return null;
-            }
-
-            var animation = compositor.CreateVector3KeyFrameAnimation();
-            animation.Duration = TimeSpan.FromSeconds(duration);
-            animation.DelayTime = TimeSpan.FromSeconds(delay);
-            animation.InsertKeyFrame(1f, new Vector3(scaleX, scaleY, scaleZ));
-
             visual.CenterPoint = new Vector3(centerX, centerY, centerZ);
+            var scaleVector = new Vector3(scaleX, scaleY, scaleZ);
 
-            visual.StartAnimation("Scale", animation);
+            if (duration > 0)
+            {
+                var compositor = visual?.Compositor;
+
+                if (compositor == null)
+                {
+                    return null;
+                }
+
+                var animation = compositor.CreateVector3KeyFrameAnimation();
+                animation.Duration = TimeSpan.FromSeconds(duration);
+                animation.DelayTime = TimeSpan.FromSeconds(delay);
+                animation.InsertKeyFrame(1f, scaleVector);
+
+                visual.StartAnimation("Scale", animation);
+            }
+            else
+            {
+                visual.Scale = scaleVector;
+            }
 
             return visual;
         }
@@ -86,7 +94,7 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
         /// <returns>The visual of the UIElement.</returns>
         public static Visual Rotate(
             this UIElement associatedObject,
-            double duration = 0.1d,
+            double duration = 0.5d,
             double delay = 0d,
             float value = 0f,
             float centerX = 0f,
@@ -99,21 +107,28 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
             }
 
             var visual = ElementCompositionPreview.GetElementVisual(associatedObject);
-            var compositor = visual?.Compositor;
-
-            if (compositor == null)
-            {
-                return null;
-            }
-
-            var animation = compositor.CreateScalarKeyFrameAnimation();
-            animation.Duration = TimeSpan.FromSeconds(duration);
-            animation.DelayTime = TimeSpan.FromSeconds(delay);
-            animation.InsertKeyFrame(1f, value);
-
             visual.CenterPoint = new Vector3(centerX, centerY, centerZ);
 
-            visual.StartAnimation("RotationAngleInDegrees", animation);
+            if (duration > 0)
+            {
+                var compositor = visual?.Compositor;
+
+                if (compositor == null)
+                {
+                    return null;
+                }
+
+                var animation = compositor.CreateScalarKeyFrameAnimation();
+                animation.Duration = TimeSpan.FromSeconds(duration);
+                animation.DelayTime = TimeSpan.FromSeconds(delay);
+                animation.InsertKeyFrame(1f, value);
+
+                visual.StartAnimation("RotationAngleInDegrees", animation);
+            }
+            else
+            {
+                visual.RotationAngleInDegrees = value;
+            }
 
             return visual;
         }
@@ -128,7 +143,7 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
         /// <returns>The visual of the UIElement.</returns>
         public static Visual Opacity(
             this UIElement associatedObject,
-            double duration = 0.1d,
+            double duration = 0.5d,
             double delay = 0d,
             float value = 0f)
         {
@@ -138,19 +153,27 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
             }
 
             var visual = ElementCompositionPreview.GetElementVisual(associatedObject);
-            var compositor = visual?.Compositor;
 
-            if (compositor == null)
+            if (duration > 0)
             {
-                return null;
+                var compositor = visual?.Compositor;
+
+                if (compositor == null)
+                {
+                    return null;
+                }
+
+                var animation = compositor.CreateScalarKeyFrameAnimation();
+                animation.Duration = TimeSpan.FromSeconds(duration);
+                animation.DelayTime = TimeSpan.FromSeconds(delay);
+                animation.InsertKeyFrame(1f, value);
+
+                visual.StartAnimation("Opacity", animation);
             }
-
-            var animation = compositor.CreateScalarKeyFrameAnimation();
-            animation.Duration = TimeSpan.FromSeconds(duration);
-            animation.DelayTime = TimeSpan.FromSeconds(delay);
-            animation.InsertKeyFrame(1f, value);
-
-            visual.StartAnimation("Opacity", animation);
+            else
+            {
+                visual.Opacity = value;
+            }
 
             return visual;
         }
@@ -167,7 +190,7 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
         /// <returns>The visual of the UIElement.</returns>
         public static Visual Offset(
             this UIElement associatedObject,
-            double duration = 0.1d,
+            double duration = 0.5d,
             double delay = 0d,
             float offsetX = 0f,
             float offsetY = 0f,
@@ -179,19 +202,28 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
             }
 
             var visual = ElementCompositionPreview.GetElementVisual(associatedObject);
-            var compositor = visual?.Compositor;
+            var offsetVector = new Vector3(offsetX, offsetY, offsetZ);
 
-            if (compositor == null)
+            if (duration > 0)
             {
-                return null;
+                var compositor = visual?.Compositor;
+
+                if (compositor == null)
+                {
+                    return null;
+                }
+
+                var animation = compositor.CreateVector3KeyFrameAnimation();
+                animation.Duration = TimeSpan.FromSeconds(duration);
+                animation.DelayTime = TimeSpan.FromSeconds(delay);
+                animation.InsertKeyFrame(1f, offsetVector);
+
+                visual.StartAnimation("Offset", animation);
             }
-
-            var animation = compositor.CreateVector3KeyFrameAnimation();
-            animation.Duration = TimeSpan.FromSeconds(duration);
-            animation.DelayTime = TimeSpan.FromSeconds(delay);
-            animation.InsertKeyFrame(1f, new Vector3(offsetX, offsetY, offsetZ));
-
-            visual.StartAnimation("Offset", animation);
+            else
+            {
+                visual.Offset = offsetVector;
+            }
 
             return visual;
         }
@@ -223,7 +255,7 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
         /// <seealso cref="IsBlurSupported" />
         public static CompositionEffectBrush Blur(
             this FrameworkElement associatedObject,
-            double duration = 0.1d,
+            double duration = 0.5d,
             double delay = 0d,
             double blurAmount = 0d)
         {
@@ -241,6 +273,7 @@ namespace Microsoft.Windows.Toolkit.UI.Animations.Extensions
             }
 
             var visual = ElementCompositionPreview.GetElementVisual(associatedObject);
+
             var compositor = visual?.Compositor;
             const string blurName = "Blur";
 


### PR DESCRIPTION
Based on feedback composition extensions now return visuals so you can get control over the animation. Duration of composition visuals can now be set to 0, performs a direct manipulation without animating. Also some small fixes to Sample app.
