### PR TITLE
Prevents exception on hovering / pressing GridSplitter when its background isn't a SolidColorBrush. Fixes #2262

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.xaml
@@ -20,20 +20,14 @@
                             <VisualStateGroup x:Name="GridSplitterStates">
                                 <VisualState x:Name="Normal" />
                                 <VisualState x:Name="PointerOver">
-                                    <Storyboard>
-                                        <ColorAnimation Duration="0"
-                                                        To="{ThemeResource SystemBaseLowColor}"
-                                                        Storyboard.TargetProperty="(Grid.Background).(SolidColorBrush.Color)"
-                                                        Storyboard.TargetName="RootGrid" />
-                                    </Storyboard>
+                                    <VisualState.Setters>
+                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+                                    </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
-                                    <Storyboard>
-                                        <ColorAnimation Duration="0"
-                                                        To="{ThemeResource SystemBaseHighColor}"
-                                                        Storyboard.TargetProperty="(Grid.Background).(SolidColorBrush.Color)"
-                                                        Storyboard.TargetName="RootGrid" />
-                                    </Storyboard>
+                                    <VisualState.Setters>
+                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SystemControlBackgroundBaseHighBrush}" />
+                                    </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>


### PR DESCRIPTION
The existing code assumes that the background is a SolidColorBrush, whose color is animated using ColorAnimations. The fixes replace the ColorAnimations with setters that set the background.

Issue: #2262 

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
When the background of a `GridSplitter` is assigned to a Brush that isn't a `SolidColorBrush`, a `COMException` is thrown upon hovering it. More details at #2262.

## What is the new behavior?
The background of the GridSplitter changes to the specified `Brush`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes

(The criteria below aren't applicable)

- [x] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
