### PR TITLE
Add OS build check when initializing the control

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlProcess.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlProcess.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
 
             var os = NativeMethods.RtlGetVersion();
 
-            WebViewControl wvc = null;
+            WebViewControl wvc;
 
             if (IsRs4(os.BuildNumber))
             {
@@ -113,18 +113,6 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
                                 .AsTask()
                                 .ConfigureAwait(false);
             }
-
-            return new WebViewControlHost(wvc);
-        }
-
-        internal async Task<WebViewControlHost> CreateWebViewControlHostAsync2(IntPtr hostWindowHandle, Rect bounds)
-        {
-            if (hostWindowHandle == IntPtr.Zero)
-            {
-                throw new ArgumentNullException(nameof(hostWindowHandle));
-            }
-
-            var wvc = await CreateWebViewControlAsync(hostWindowHandle, bounds).AsTask().ConfigureAwait(false);
 
             return new WebViewControlHost(wvc);
         }


### PR DESCRIPTION
Issue: #2411
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is an issue when initializing the control in some circumstances that cause thread to not complete initializing the underlying control.

## What is the new behavior?
Updated to fetch the OS build and check for RS4 range. If not RS4, don't use RS4 work around.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
NOTE: the issue does not reproduce for me, and the code works in both code paths on OS builds 17134, 17744, and 18227. However, according to report in #2411 the issue was investigated by @MichaelVach and replacing the initialization on L97 with a simpler await resolves the issue for his RS5 build, but not RS4.