### PR TITLE
Tgoodhew/master/high contrast in app notification

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
@@ -357,20 +357,22 @@
             </ControlTemplate>
 
             <Style x:Key="VisualStudioCodeNotificationButtonStyle" TargetType="ButtonBase">
-                <Setter Property="Background" Value="#0E639C" />
-                <Setter Property="Foreground" Value="White" />
+                <Setter Property="Background" Value="{ThemeResource SystemControlVSNotificationButtonBackgroundBrush}" />
+                <Setter Property="Foreground" Value="{ThemeResource SystemControlVSNotificationButtonTextBrush}" />
                 <Setter Property="VerticalAlignment" Value="Stretch" />
                 <Setter Property="FontSize" Value="14" />
                 <Setter Property="Padding" Value="10 0" />
                 <Setter Property="Height" Value="35" />
-                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="BorderThickness" Value="2" />
+                <Setter Property="BorderBrush" Value="{ThemeResource SystemControlVSNotificationButtonBorderBrush}" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="ButtonBase">
-                            <Grid x:Name="RootGrid" Padding="{TemplateBinding Padding}" Margin="{TemplateBinding Margin}" Background="{TemplateBinding Background}">
+                            <Grid x:Name="RootGrid" Padding="{TemplateBinding Padding}" Margin="{TemplateBinding Margin}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
                                 <ContentPresenter Content="{TemplateBinding Content}"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Foreground="{TemplateBinding Foreground}" />
                                 
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
@@ -378,14 +380,14 @@
                                         <VisualState x:Name="PointerOver">
                                             <Storyboard>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="#1177BB" />
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlPointerOverChromeBrush}" />
                                                 </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                         </VisualState>
                                         <VisualState x:Name="Pressed">
                                             <Storyboard>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="#1177BB" />
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlPointerOverChromeBrush}" />
                                                 </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                         </VisualState>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
@@ -9,37 +9,10 @@
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <ResourceDictionary.ThemeDictionaries>
-        <ResourceDictionary x:Key="Default">
-            <contract5Present:AcrylicBrush x:Key="InAppNotificationAcrylicBackgroundBrush"
-                                           BackgroundSource="Backdrop"
-                                           FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
-                                           TintColor="{ThemeResource SystemChromeMediumLowColor}"
-                                           TintOpacity="0.8" />
-        </ResourceDictionary>
-
-        <ResourceDictionary x:Key="HighContrast">
-            <contract5Present:AcrylicBrush x:Key="InAppNotificationAcrylicBackgroundBrush"
-                                           BackgroundSource="Backdrop"
-                                           FallbackColor="{ThemeResource SystemColorButtonFaceColor}"
-                                           TintColor="{ThemeResource SystemColorButtonFaceColor}"
-                                           TintOpacity="0.8" />
-        </ResourceDictionary>
-
-        <ResourceDictionary x:Key="Light">
-            <contract5Present:AcrylicBrush x:Key="InAppNotificationAcrylicBackgroundBrush"
-                                           BackgroundSource="Backdrop"
-                                           FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
-                                           TintColor="{ThemeResource SystemChromeMediumLowColor}"
-                                           TintOpacity="0.8" />
-        </ResourceDictionary>
-    </ResourceDictionary.ThemeDictionaries>
-
-    <Style x:Key="BaseInAppNotificationsStyle"
-           TargetType="local:InAppNotification">
+    <Style TargetType="local:InAppNotification" x:Key="BaseInAppNotificationsStyle">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
         <Setter Property="Visibility" Value="Collapsed" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -57,13 +30,11 @@
         <Setter Property="Template" Value="{StaticResource MSEdgeNotificationTemplate}" />
     </Style>
 
-    <contract5NotPresent:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
-                               TargetType="local:InAppNotification">
+    <contract5NotPresent:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
     </contract5NotPresent:Style>
 
-    <contract5Present:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
-                            TargetType="local:InAppNotification">
-        <Setter Property="Background" Value="{ThemeResource InAppNotificationAcrylicBackgroundBrush}" />
+    <contract5Present:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+        <Setter Property="Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />
     </contract5Present:Style>
 </ResourceDictionary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml
@@ -3,24 +3,54 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
+    <ResourceDictionary.ThemeDictionaries>
+        <!-- Default is a fallback if a more precise theme isn't called
+            out below -->
+        <ResourceDictionary x:Key="Default">
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBackgroundBrush" Color="#0E639C" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBorderBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonTextBrush" Color="White" />
+            <SolidColorBrush x:Key="SystemControlGridBackgroundBrush" Color="#007ACC" />
+            <SolidColorBrush x:Key="SystemControlBackgroundBrush" Color="#333333" />
+            <SolidColorBrush x:Key="SystemControlForegroundBrush" Color="White" />
+            <SolidColorBrush x:Key="SystemControlPointerOverChromeBrush" Color="#1177BB" />
+        </ResourceDictionary>
+
+        <!-- HighContrast is used in all high contrast themes -->
+        <ResourceDictionary x:Key="HighContrast">
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonTextBrush" Color="Red" />
+            <SolidColorBrush x:Key="SystemControlGridBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SystemControlBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SystemControlForegroundBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="SystemControlPointerOverChromeBrush" Color="{ThemeResource SystemControlBackgroundListLowBrush}" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    
     <Style x:Key="VisualStudioCodeNotificationButtonStyle" TargetType="ButtonBase">
-        <Setter Property="Background" Value="#0E639C" />
-        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Background" Value="{ThemeResource SystemControlVSNotificationButtonBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{ThemeResource SystemControlVSNotificationButtonTextBrush}" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="Padding" Value="10 0" />
         <Setter Property="Height" Value="35" />
-        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlVSNotificationButtonBorderBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ButtonBase">
                     <Grid x:Name="RootGrid" 
                           Padding="{TemplateBinding Padding}" 
                           Margin="{TemplateBinding Margin}" 
-                          Background="{TemplateBinding Background}">
+                          Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}">
                         <ContentPresenter Content="{TemplateBinding Content}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                                          Foreground="{TemplateBinding Foreground}"/>
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -28,14 +58,14 @@
                                 <VisualState x:Name="PointerOver">
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="#1177BB" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlPointerOverChromeBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="#1177BB" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlPointerOverChromeBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -49,8 +79,8 @@
     </Style>
 
     <Style x:Key="VSCodeNotificationStyle" TargetType="local:InAppNotification">
-        <Setter Property="Background" Value="#333333" />
-        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="ShowDismissButton" Value="False" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -134,7 +164,7 @@
                     <ColumnDefinition />
                 </Grid.ColumnDefinitions>
 
-                <Grid Margin="10 5" Height="20" Background="#007ACC">
+                <Grid Margin="10 5" Height="20" Background="{ThemeResource SystemControlGridBackgroundBrush}">
                     <TextBlock Text="info"
                                Padding="5 0"
                                FontWeight="Bold"


### PR DESCRIPTION
Issue: #2276 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
InAppNotification currently doesn't respect High Contrast mode. When applied it doesn't change correct and it doesn't render either the Edge or VSCode notifications properly for High Contrast.

## What is the new behavior?
InAppNotification control now changes with High Contrast mode for both Edge & VS Code styles. Additionally the sample app page now applies the correct styles to the control to show it working when the mode changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [X] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information

Please be aware that this was tested against 15063 using a branch based off Rel-4 rather than Master.
