### PR TITLE
Use a render transform to support dpi scaling in windows forms xaml host

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/WindowsXamlHostBaseExt.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/WindowsXamlHostBaseExt.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         internal virtual void InitializeElement()
         {
             XamlElement = UWPTypeFactory.CreateXamlContentByType(initialTypeName);
-            _xamlSource.Content = XamlElement;
+            ChildInternal = XamlElement;
             XamlElement.SetWrapper(this);
         }
 

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/DpiScalingPanel.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/DpiScalingPanel.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Toolkit.Forms.UI.XamlHost
+{
+    /// <summary>
+    /// Panel that implements a scale factor for the XAML content using a render transform
+    /// </summary>
+    internal class DpiScalingPanel : Windows.UI.Xaml.Controls.Panel
+    {
+        public DpiScalingPanel()
+        {
+        }
+
+        /// <summary>
+        /// Measures wrapped UWP XAML content using passed in size availableSize
+        /// </summary>
+        /// <param name="availableSize">Available Size</param>
+        /// <returns>XAML DesiredSize</returns>
+        protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
+        {
+            Windows.Foundation.Size desiredSize = new Windows.Foundation.Size(0, 0);
+
+            Windows.UI.Xaml.UIElement element = Child;
+
+            if (element != null)
+            {
+                element.Measure(new Windows.Foundation.Size(availableSize.Width / _scalingFactor, availableSize.Height / _scalingFactor));
+                desiredSize.Width = element.DesiredSize.Width * _scalingFactor;
+                desiredSize.Height = element.DesiredSize.Height * _scalingFactor;
+            }
+
+            desiredSize.Width = Math.Min(desiredSize.Width, availableSize.Width);
+            desiredSize.Height = Math.Min(desiredSize.Height, availableSize.Height);
+
+            return desiredSize;
+        }
+
+        /// <summary>
+        /// Arranges wrapped UWP XAML content using passed in size constraint
+        /// </summary>
+        /// <param name="finalSize">Final Size</param>
+        /// <returns>Size</returns>
+        protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
+        {
+            Windows.UI.Xaml.UIElement element = Child;
+
+            if (element != null)
+            {
+                Windows.Foundation.Rect finalRect = new Windows.Foundation.Rect(0, 0, finalSize.Width / _scalingFactor, finalSize.Height / _scalingFactor);
+                element.Arrange(finalRect);
+            }
+
+            return base.ArrangeOverride(finalSize);
+        }
+
+        /// <summary>
+        ///    Gets or sets XAML content
+        /// </summary>
+        public Windows.UI.Xaml.UIElement Child
+        {
+            get
+            {
+                return Children.Count > 0 ? Children[0] : null;
+            }
+
+            set
+            {
+                Children.Clear();
+                Children.Add(value);
+
+                SetScalingFactor(_scalingFactor);
+            }
+        }
+
+        /// <summary>
+        ///    Sets the scaling factor of the panel
+        /// <param name="newScalingFactor">New scaling factor</param>
+        /// </summary>
+        public void SetScalingFactor(double newScalingFactor)
+        {
+            // Do not touch any user set render transform on the XAML element
+            // if scaling is not necessary and was not enabled before
+            if (newScalingFactor == 1.0f && _scalingFactor == 1.0f)
+            {
+                return;
+            }
+
+            _scalingFactor = newScalingFactor;
+
+            Windows.UI.Xaml.UIElement element = Child;
+
+            if (element == null)
+            {
+                return;
+            }
+
+            if (newScalingFactor == 1.0f)
+            {
+                element.RenderTransform = null;
+                return;
+            }
+
+            Windows.UI.Xaml.Media.ScaleTransform newScaleTransform = new Windows.UI.Xaml.Media.ScaleTransform();
+            newScaleTransform.ScaleX = newScalingFactor;
+            newScaleTransform.ScaleY = newScalingFactor;
+
+            element.RenderTransform = newScaleTransform;
+        }
+
+        /// <summary>
+        ///    The currently applied scaling factor
+        /// </summary>
+        private double _scalingFactor = 1.0f;
+    }
+}

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Interop/Win32/NativeDefines.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Interop/Win32/NativeDefines.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost.Interop.Win32
         public const int WM_KILLFOCUS = (int)WM.KILLFOCUS;
         public const int WM_KEYDOWN = (int)WM.KEYDOWN;
         public const int WM_KEYUP = (int)WM.KEYUP;
+        public const int WM_DPICHANGED_AFTERPARENT = (int)WM.DPICHANGED_AFTERPARENT;
 
         // Window Styles
         public const uint WS_EX_CONTROLPARENT = 0x00010000;

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Interop/Win32/SafeNativeMethods.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Interop/Win32/SafeNativeMethods.cs
@@ -37,5 +37,14 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost.Interop.Win32
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         [ResourceExposure(ResourceScope.None)]
         internal static extern IntPtr SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, int flags);
+
+        /// <summary>
+        /// Retrieves the dpi value of a window.
+        /// </summary>
+        /// <param name="hWnd">Handle to target window</param>
+        /// <returns>The dpi value or 0 for an invalid window.</returns>
+        [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
+        [ResourceExposure(ResourceScope.None)]
+        public static extern uint GetDpiForWindow(IntPtr hWnd);
     }
 }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <RootNamespace>Microsoft.Toolkit.Forms.UI.XamlHost</RootNamespace>
     <AssemblyName>Microsoft.Toolkit.Forms.UI.XamlHost</AssemblyName>
     <RunCodeAnalysis>true</RunCodeAnalysis>
@@ -45,7 +45,7 @@
     <Reference Include="System.Runtime.WindowsRuntime">
       <HintPath>$(WINDIR)\Microsoft.NET\Framework\v4.0.30319\System.Runtime.WindowsRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.WindowsRuntime.UI.Xaml" >
+    <Reference Include="System.Runtime.WindowsRuntime.UI.Xaml">
       <HintPath>$(WINDIR)\Microsoft.NET\Framework\v4.0.30319\System.Runtime.WindowsRuntime.UI.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RootNamespace>Microsoft.Toolkit.Forms.UI.XamlHost</RootNamespace>
     <AssemblyName>Microsoft.Toolkit.Forms.UI.XamlHost</AssemblyName>
     <RunCodeAnalysis>true</RunCodeAnalysis>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Microsoft.Toolkit.Forms.UI.XamlHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RootNamespace>Microsoft.Toolkit.Forms.UI.XamlHost</RootNamespace>
     <AssemblyName>Microsoft.Toolkit.Forms.UI.XamlHost</AssemblyName>
     <RunCodeAnalysis>true</RunCodeAnalysis>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHost.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHost.cs
@@ -62,27 +62,6 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether a render transform is added to the UWP control corresponding to the current dpi scaling factor
-        /// </summary>
-        /// <value>The dpi scaling mode.</value>
-        /// <remarks>A custom render transform added to the root UWP control will be overwritten.</remarks>
-        [ReadOnly(false)]
-        [Browsable(true)]
-        [Category("Layout")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        public bool DpiScalingRenderTransform
-        {
-            get => _dpiScalingRenderTransformEnabled;
-
-            set
-            {
-                _dpiScalingRenderTransformEnabled = value;
-                UpdateDpiScalingFactor();
-                PerformLayout();
-            }
-        }
-
-        /// <summary>
         /// Gets or sets XAML content for XamlContentHost
         /// </summary>
         /// <value>The <see cref="Windows.UI.Xaml.UIElement"/>.</value>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHost.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHost.cs
@@ -62,6 +62,27 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether a render transform is added to the UWP control corresponding to the current dpi scaling factor
+        /// </summary>
+        /// <value>The dpi scaling mode.</value>
+        /// <remarks>A custom render transform added to the root UWP control will be overwritten.</remarks>
+        [ReadOnly(false)]
+        [Browsable(true)]
+        [Category("Layout")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public bool DpiScalingRenderTransform
+        {
+            get => _dpiScalingRenderTransformEnabled;
+
+            set
+            {
+                _dpiScalingRenderTransformEnabled = value;
+                UpdateDpiScalingFactor();
+                PerformLayout();
+            }
+        }
+
+        /// <summary>
         /// Gets or sets XAML content for XamlContentHost
         /// </summary>
         /// <value>The <see cref="Windows.UI.Xaml.UIElement"/>.</value>
@@ -69,7 +90,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Windows.UI.Xaml.UIElement Child
         {
-            get => _xamlSource.Content;
+            get => (_xamlSource.Content as DpiScalingPanel).Child;
 
             set => ChildInternal = value;
         }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                 return Size;
             }
 
-            if (_xamlSource.Content != null)
+            if ((_xamlSource.Content as DpiScalingPanel).Child != null)
             {
                 double proposedWidth = proposedSize.Width;
                 double proposedHeight = proposedSize.Height;
@@ -45,12 +45,24 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             }
 
             var preferredSize = Size.Empty;
-            if (_xamlSource.Content != null)
+            if ((_xamlSource.Content as DpiScalingPanel).Child != null)
             {
                 preferredSize = new Size((int)_xamlSource.Content.DesiredSize.Width, (int)_xamlSource.Content.DesiredSize.Height);
             }
 
             return preferredSize;
+        }
+
+        /// <summary>
+        ///     Sets a scaling factor based on the current dpi value on the scaling panel
+        /// </summary>
+        protected void UpdateDpiScalingFactor()
+        {
+            DpiScalingPanel panel = _xamlSource.Content as DpiScalingPanel;
+
+            double newScalingFactor = _dpiScalingRenderTransformEnabled ? (this.DeviceDpi / 96.0f) : 1.0f;
+
+            panel.SetScalingFactor(newScalingFactor);
         }
 
         /// <summary>
@@ -119,7 +131,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
             if (AutoSize)
             {
-                if (_xamlSource.Content != null)
+                if ((_xamlSource.Content as DpiScalingPanel).Child != null)
                 {
                     // XamlContenHost Control.Size has changed. XAML must perform an Arrange pass.
                     // The XAML Arrange pass will expand XAML content with 'HorizontalStretch' and
@@ -130,6 +142,16 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                     PerformLayout();
                 }
             }
+        }
+
+        /// <summary>
+        ///     Event handler for <see cref="System.Windows.Forms.Control.DpiChangedAfterParent" />. Update scaling transform
+        ///     if necessary and re-run Windows Forms layout on this Control instance.
+        /// </summary>
+        private void OnWindowsXamlHostDpiChangedAfterParent(object sender, EventArgs e)
+        {
+            UpdateDpiScalingFactor();
+            PerformLayout();
         }
     }
 }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Drawing;
+using Microsoft.Toolkit.Forms.UI.XamlHost.Interop.Win32;
 
 namespace Microsoft.Toolkit.Forms.UI.XamlHost
 {
@@ -59,8 +60,17 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         protected void UpdateDpiScalingFactor()
         {
             DpiScalingPanel panel = _xamlSource.Content as DpiScalingPanel;
+            double dpi = 96.0f;
+            if (_xamlIslandWindowHandle != IntPtr.Zero)
+            {
+                uint windowDpi = SafeNativeMethods.GetDpiForWindow(_xamlIslandWindowHandle);
+                if (windowDpi > 0)
+                {
+                    dpi = windowDpi;
+                }
+            }
 
-            double newScalingFactor = _dpiScalingRenderTransformEnabled ? (this.DeviceDpi / 96.0f) : 1.0f;
+            double newScalingFactor = _dpiScalingRenderTransformEnabled ? (dpi / 96.0f) : 1.0f;
 
             panel.SetScalingFactor(newScalingFactor);
         }
@@ -142,16 +152,6 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                     PerformLayout();
                 }
             }
-        }
-
-        /// <summary>
-        ///     Event handler for <see cref="System.Windows.Forms.Control.DpiChangedAfterParent" />. Update scaling transform
-        ///     if necessary and re-run Windows Forms layout on this Control instance.
-        /// </summary>
-        private void OnWindowsXamlHostDpiChangedAfterParent(object sender, EventArgs e)
-        {
-            UpdateDpiScalingFactor();
-            PerformLayout();
         }
     }
 }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.WndProc.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.WndProc.cs
@@ -106,6 +106,15 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
                     break;
 
+                case NativeDefines.WM_DPICHANGED_AFTERPARENT:
+                    if (_xamlIslandWindowHandle != null)
+                    {
+                        UpdateDpiScalingFactor();
+                        PerformLayout();
+                    }
+
+                    break;
+
                 default:
                     base.WndProc(ref m);
                     break;

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        internal Windows.UI.Xaml.UIElement ChildInternal
+        protected Windows.UI.Xaml.UIElement ChildInternal
         {
             get => (_xamlSource.Content as DpiScalingPanel).Child;
 
@@ -150,6 +150,27 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             if (_xamlSource != null)
             {
                 (_xamlSource.Content as DpiScalingPanel).Child = newValue;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a render transform is added to the UWP control corresponding to the current dpi scaling factor
+        /// </summary>
+        /// <value>The dpi scaling mode.</value>
+        /// <remarks>A custom render transform added to the root UWP control will be overwritten.</remarks>
+        [ReadOnly(false)]
+        [Browsable(true)]
+        [Category("Layout")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public bool DpiScalingRenderTransform
+        {
+            get => _dpiScalingRenderTransformEnabled;
+
+            set
+            {
+                _dpiScalingRenderTransformEnabled = value;
+                UpdateDpiScalingFactor();
+                PerformLayout();
             }
         }
 

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -79,9 +79,6 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             // Respond to size changes on this Control
             SizeChanged += OnWindowXamlHostSizeChanged;
 
-            // Respond to dpi changes on this control
-            DpiChangedAfterParent += OnWindowsXamlHostDpiChangedAfterParent;
-
             // Windows.UI.Xaml.Application object is required for loading custom control metadata.  If a custom
             // Application object is not provided by the application, the host control will create one (XamlApplication).
             // Instantiation of the application object must occur before creating the DesktopWindowXamlSource instance.
@@ -105,7 +102,6 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
             // Add scaling panel as the root XAML element
             _xamlSource.Content = new DpiScalingPanel();
-            UpdateDpiScalingFactor();
         }
 
         /// <summary>
@@ -166,7 +162,6 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             if (disposing)
             {
                 SizeChanged -= OnWindowXamlHostSizeChanged;
-                DpiChangedAfterParent -= OnWindowsXamlHostDpiChangedAfterParent;
 
                 // Required by CA2213: _xamlSource?.Dispose() is insufficient.
                 if (_xamlSource != null)
@@ -199,6 +194,8 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                 {
                     throw new InvalidOperationException("WindowsXamlHostBase::OnHandleCreated: Failed to set WS_EX_CONTROLPARENT on control window.");
                 }
+
+                UpdateDpiScalingFactor();
             }
 
             base.OnHandleCreated(e);

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/Win32/WM.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/Win32/WM.cs
@@ -123,6 +123,8 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
         TABLET_FLICK = TABLET_DEFBASE + 11,
         TABLET_QUERYSYSTEMGESTURESTATUS = TABLET_DEFBASE + 12,
 
+        DPICHANGED_AFTERPARENT = 0x02E3,
+
         CUT = 0x0300,
         COPY = 0x0301,
         PASTE = 0x0302,


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

While experimenting with the windows forms xaml host control, I have tried to add at least some dpi scaling support. Applying a render transforms to the UWP content worked surprisingly well and I thought the code might also be useful for others. This pull request adds it directly to the XAML host control.

<!-- - Bugfix -->

<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?

No dpi scaling support in the XAML host controls

## What is the new behavior?

A render transform is added to the UWP XAML content according to the current dpi scaling value. Additionally, a custom panel implementation is used as the root XAML control to transform the values for the layout passes. A new property (DpiScalingRenderTransform) has been added to enable automatic scaling.

Known issues:

- This code uses win32 apis for getting the current dpi value because the windows forms apis are only supported in newer .net versions than the currently used .net 4.6.2
- Enabling the DpiScalingRenderTransform property will overwrite any user set render transforms on the provided root XAML element
- Scaling seems to work mostly fine, but some elements like tooltips do not scale correctly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
