### PR TITLE
Make sure we see if a type is a platform type before trying to activa…

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.XamlHost/UWPTypeFactory.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.XamlHost/UWPTypeFactory.cs
@@ -35,16 +35,16 @@ namespace Microsoft.Toolkit.Win32.UI.XamlHost
 
             systemType = FindBuiltInType(xamlTypeName);
 
-            if (xamlType != null)
-            {
-                // Create custom UWP XAML type
-                return (Windows.UI.Xaml.FrameworkElement)xamlType.ActivateInstance();
-            }
-
             if (systemType != null)
             {
                 // Create built-in UWP XAML type
                 return (Windows.UI.Xaml.FrameworkElement)Activator.CreateInstance(systemType);
+            }
+
+            if (xamlType != null)
+            {
+                // Create custom UWP XAML type
+                return (Windows.UI.Xaml.FrameworkElement)xamlType.ActivateInstance();
             }
 
             throw new InvalidOperationException("Microsoft.Windows.Interop.UWPTypeFactory: Could not create type: " + xamlTypeName);


### PR DESCRIPTION
Make sure we see if a type is a platform type before trying to activate it through the app's metadata provider. App generated metadata code will throw not implemented exception for platform types. This PR changes the order in which we try to activate so that if it is a framework type we do not try to ask the app's metadata provider to activate it.

Issue: #2547

## PR Type
What kind of change does this PR introduce?
Bugfix
## What is the current behavior?
crash in markup compiler generated code when trying to load an app that has a custom type deriving from a framework type. 

## What is the new behavior?
No crash. The type in question is a framework type and will not fallback to calling into the app metadata provider to activate.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes
Tested with wpf app with a centennial package consuming a uwp xaml app generated code.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
No breaking changes. Just a bug fix.

## Other information
