### PR TITLE
Remove RoundedImageEx from sample app

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
@@ -21,7 +21,7 @@
             <Setter Property="Width" Value="400" />
             <Setter Property="Height" Value="300" />
         </Style>
-        <Style x:Key="RoundStyle" TargetType="controls:RoundImageEx" BasedOn="{StaticResource BaseStyle}">
+        <Style x:Key="RoundStyle" TargetType="controls:ImageEx" BasedOn="{StaticResource BaseStyle}">
             <Setter Property="Width" Value="200" />
             <Setter Property="Height" Value="200" />
             <Setter Property="CornerRadius" Value="999" />
@@ -48,7 +48,7 @@
               
                 <TextBlock Text="Above ImageEx will have rounded corners on the Fall Creators Update." Margin="4" HorizontalAlignment="Center"/>
 
-                <controls:RoundImageEx x:Name="RoundImageExControl1"
+                <controls:ImageEx x:Name="RoundImageExControl1"
                                        IsCacheEnabled="@[Enable Cache]"
                                        Source="/Assets/Photos/Owl.jpg"
                                        PlaceholderSource="/Assets/Photos/ImageExPlaceholder.jpg"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
@@ -87,11 +87,9 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             ImageExBase newImage = null;
             if (round)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                newImage = new RoundImageEx
+                newImage = new ImageEx
                 {
                 };
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 if (resources?.ContainsKey("RoundStyle") == true)
                 {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MasterDetailsView/MasterDetailsView.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MasterDetailsView/MasterDetailsView.bind
@@ -30,7 +30,7 @@
             <controls:MasterDetailsView.DetailsTemplate>
                 <DataTemplate>
                     <RelativePanel Margin="24">
-                        <controls:RoundImageEx x:Name="FromEllipse"
+                        <controls:ImageEx x:Name="FromEllipse"
                                                Source="{Binding Thumbnail}"
                                                Width="50"
                                                Height="50"


### PR DESCRIPTION
Issue: #2557
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
- Sample app changes
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Samples uses deprecated RoundedImageEx

## What is the new behavior?
No longer uses the RoundedImageEx

## PR Checklist

Please check if your PR fulfills the following requirements:

toolkit/WindowsCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
