### PR TITLE
Take into account XAML islands dpi scaling in the winforms XAML host

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
@@ -25,30 +25,47 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                 return Size;
             }
 
-            if ((_xamlSource.Content as DpiScalingPanel).Child != null)
+            if (ChildInternal != null)
             {
                 double proposedWidth = proposedSize.Width;
                 double proposedHeight = proposedSize.Height;
 
                 // DockStyles will result in a constraint of 1 on the Docked axis. GetPreferredSize
                 // must convert this into an unconstrained value.
+                // Convert the proposed size form pixels to effective pixels if XAML island scales the content
                 if (proposedSize.Height == int.MaxValue || proposedSize.Height == 1)
                 {
                     proposedHeight = double.PositiveInfinity;
+                }
+                else if (_xamlIslandHandlesDpiScaling)
+                {
+                    proposedHeight /= _lastDpi / 96.0f;
                 }
 
                 if (proposedSize.Width == int.MaxValue || proposedSize.Width == 1)
                 {
                     proposedWidth = double.PositiveInfinity;
                 }
+                else if (_xamlIslandHandlesDpiScaling)
+                {
+                    proposedWidth /= _lastDpi / 96.0f;
+                }
 
                 _xamlSource.Content.Measure(new Windows.Foundation.Size(proposedWidth, proposedHeight));
             }
 
             var preferredSize = Size.Empty;
-            if ((_xamlSource.Content as DpiScalingPanel).Child != null)
+            if (ChildInternal != null)
             {
-                preferredSize = new Size((int)_xamlSource.Content.DesiredSize.Width, (int)_xamlSource.Content.DesiredSize.Height);
+                // Convert effective pixels to pixels if necessary
+                if (_xamlIslandHandlesDpiScaling)
+                {
+                    preferredSize = new Size((int)(_xamlSource.Content.DesiredSize.Width * _lastDpi / 96.0f), (int)(_xamlSource.Content.DesiredSize.Height * _lastDpi / 96.0f));
+                }
+                else
+                {
+                    preferredSize = new Size((int)_xamlSource.Content.DesiredSize.Width, (int)_xamlSource.Content.DesiredSize.Height);
+                }
             }
 
             return preferredSize;
@@ -70,7 +87,9 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                 }
             }
 
-            double newScalingFactor = _dpiScalingRenderTransformEnabled ? (dpi / 96.0f) : 1.0f;
+            _lastDpi = dpi;
+
+            double newScalingFactor = (_dpiScalingRenderTransformEnabled == true && _xamlIslandHandlesDpiScaling == false) ? (dpi / 96.0f) : 1.0f;
 
             panel.SetScalingFactor(newScalingFactor);
         }
@@ -141,13 +160,19 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
             if (AutoSize)
             {
-                if ((_xamlSource.Content as DpiScalingPanel).Child != null)
+                if (ChildInternal != null)
                 {
                     // XamlContenHost Control.Size has changed. XAML must perform an Arrange pass.
                     // The XAML Arrange pass will expand XAML content with 'HorizontalStretch' and
                     // 'VerticalStretch' properties to the bounds of the XamlContentHost Control.
                     var rect = new Windows.Foundation.Rect(0, 0, Width, Height);
-                    _xamlSource.Content.Measure(new Windows.Foundation.Size(Width, Height));
+                    if (_xamlIslandHandlesDpiScaling)
+                    {
+                        rect.Width /= _lastDpi / 96.0f;
+                        rect.Height /= _lastDpi / 96.0f;
+                    }
+
+                    _xamlSource.Content.Measure(new Windows.Foundation.Size(rect.Width, rect.Height));
                     _xamlSource.Content.Arrange(rect);
                     PerformLayout();
                 }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.Layout.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
                 // DockStyles will result in a constraint of 1 on the Docked axis. GetPreferredSize
                 // must convert this into an unconstrained value.
-                // Convert the proposed size form pixels to effective pixels if XAML island scales the content
+                // Convert the proposed size from pixels to effective pixels if the XAML island scales the content
                 if (proposedSize.Height == int.MaxValue || proposedSize.Height == 1)
                 {
                     proposedHeight = double.PositiveInfinity;

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -207,6 +207,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             if (disposing)
             {
                 SizeChanged -= OnWindowXamlHostSizeChanged;
+                ChildInternal?.ClearWrapper();
 
                 // Required by CA2213: _xamlSource?.Dispose() is insufficient.
                 if (_xamlSource != null)
@@ -216,7 +217,6 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                 }
 
                 _windowsXamlManager?.Dispose();
-                ChildInternal?.ClearWrapper();
             }
 
             base.Dispose(disposing);

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -7,7 +7,9 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Security.Permissions;
 using System.Windows.Forms;
+using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
+using Windows.Foundation.Metadata;
 
 namespace Microsoft.Toolkit.Forms.UI.XamlHost
 {
@@ -52,6 +54,16 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         ///    UWP XAML island window handle associated with this Control instance
         /// </summary>
         private IntPtr _xamlIslandWindowHandle = IntPtr.Zero;
+
+        /// <summary>
+        ///    Set if the UWP XAML island handles scaling of the content
+        /// </summary>
+        private bool _xamlIslandHandlesDpiScaling = false;
+
+        /// <summary>
+        ///    The last dpi value retrieved from the system
+        /// </summary>
+        private double _lastDpi = 96.0f;
 
         /// <summary>
         ///     Fired when XAML content has been updated
@@ -104,6 +116,9 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
             // Hook up method for DesktopWindowXamlSource Focus handling
             _xamlSource.TakeFocusRequested += this.OnTakeFocusRequested;
+
+            // Check if the XAML island scales the content according to the current dpi value
+            _xamlIslandHandlesDpiScaling = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8);
 
             // Add scaling panel as the root XAML element
             _xamlSource.Content = new DpiScalingPanel();
@@ -179,6 +194,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
         /// <summary>
         /// Gets or sets a value indicating whether a render transform is added to the UWP control corresponding to the current dpi scaling factor
+        /// if scaling is not supported natively by the XAML island
         /// </summary>
         /// <value>The dpi scaling mode.</value>
         /// <remarks>A custom render transform added to the root UWP control will be overwritten.</remarks>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Forms.App/app.manifest
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Forms.App/app.manifest
@@ -52,12 +52,10 @@
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <!-- The combination of below two tags have the following effect :
+      1) Per-Monitor for >= Windows 10 Anniversary Update
+      2) System < Windows 10 Anniversary Update -->
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
-    </windowsSettings>
-  </application>
-
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
   </application>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Forms.App/app.manifest
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Forms.App/app.manifest
@@ -56,6 +56,11 @@
     </windowsSettings>
   </application>
 
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
 

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Wpf.App/app.manifest
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Wpf.App/app.manifest
@@ -54,8 +54,8 @@
       <!-- The combination of below two tags have the following effect :
       1) Per-Monitor for >= Windows 10 Anniversary Update
       2) System < Windows 10 Anniversary Update -->
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
   </application>
 


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?

Starting in one of the recent windows insider builds, the XAML island content is now automatically dpi scaled. Therefore, enabling the dpiScalingRenderTransformEnabled property of the windows forms XAML host (to enable scaling with Windows 1809) would result in double scaling.

## What is the new behavior?

If running on a Windows 19H1 insider build, the additional scaling will not be applied. Some code has been added to transform the layout from pixels (winforms) to effective pixels (UWP) in this case to size elements with AutoSize=true correctly. The WPF and winforms sample app are also now declared to be per monitor V2 dpi aware. This enables dynamic rescaling for both apps. However, in the winforms app this only applies to the UWP content.

One additional change avoids a crash when the winforms XAML host control is disposed (e.g. when the app is closed)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [X] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
