### PR TITLE
Fix adding additional buttons to the winforms inktoolbar control

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbar.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbar.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected InkToolbar(string name)
             : base(name)
         {
-            if (!DesignMode)
+            if (UwpControl != null)
             {
                 ControlAdded += InkToolbar_ControlAdded;
                 ControlRemoved += InkToolbar_ControlRemoved;
@@ -277,11 +277,8 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
             base.Dispose(disposing);
             if (disposing)
             {
-                if (!DesignMode)
-                {
-                    ControlAdded -= InkToolbar_ControlAdded;
-                    ControlRemoved -= InkToolbar_ControlRemoved;
-                }
+                ControlAdded -= InkToolbar_ControlAdded;
+                ControlRemoved -= InkToolbar_ControlRemoved;
             }
         }
     }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbar.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbar.cs
@@ -37,13 +37,29 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected InkToolbar(string name)
             : base(name)
         {
+            if (!DesignMode)
+            {
+                ControlAdded += InkToolbar_ControlAdded;
+                ControlRemoved += InkToolbar_ControlRemoved;
+                UwpControl.Visibility = Windows.UI.Xaml.Visibility.Collapsed; // supports a workaround for a bug:  InkToolbar won't initialize if it's not initially collapsed.
+                UwpControl.Loaded += OnUwpControlLoaded;
+            }
         }
 
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            ControlAdded += InkToolbar_ControlAdded;
-            ControlRemoved += InkToolbar_ControlRemoved;
+        }
+
+        /// <summary>
+        /// supports a workaround for a bug:  InkToolbar won't initialize if it's not initially collapsed, so we update visibility on it's loaded event.
+        /// </summary>
+        /// <param name="sender">event sender</param>
+        /// <param name="e">event parameters</param>
+        private void OnUwpControlLoaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            UwpControl.Visibility = Windows.UI.Xaml.Visibility.Visible;
+            UwpControl.Loaded -= OnUwpControlLoaded;
         }
 
         private void InkToolbar_ControlRemoved(object sender, System.Windows.Forms.ControlEventArgs e)
@@ -143,6 +159,35 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the control dynamically sizes to its content
+        /// </summary>
+        [ReadOnly(false)]
+        [Browsable(true)]
+        [Category("Layout")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public override bool AutoSize
+        {
+            get => base.AutoSize;
+
+            set => base.AutoSize = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the automatic size mode.
+        /// </summary>
+        /// <value>The automatic size mode.</value>
+        [ReadOnly(false)]
+        [Browsable(true)]
+        [Category("Layout")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public System.Windows.Forms.AutoSizeMode AutoSizeMode
+        {
+            get => GetAutoSizeMode();
+
+            set => SetAutoSizeMode(value);
+        }
+
+        /// <summary>
         /// Gets <see cref="Windows.UI.Xaml.Controls.InkToolbar.InkDrawingAttributes"/>
         /// </summary>
         public InkDrawingAttributes InkDrawingAttributes
@@ -232,8 +277,11 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
             base.Dispose(disposing);
             if (disposing)
             {
-                ControlAdded -= InkToolbar_ControlAdded;
-                ControlRemoved -= InkToolbar_ControlRemoved;
+                if (!DesignMode)
+                {
+                    ControlAdded -= InkToolbar_ControlAdded;
+                    ControlRemoved -= InkToolbar_ControlRemoved;
+                }
             }
         }
     }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarCustomPenButton.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarCustomPenButton.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Microsoft.Toolkit.Forms.UI.XamlHost;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
 using Microsoft.Toolkit.Win32.UI.Interop;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -18,7 +19,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
     [Designer(typeof(InkToolbarToolButtonDesigner))]
     public class InkToolbarCustomPenButton : WindowsXamlHostBase
     {
-        internal Windows.UI.Xaml.Controls.InkToolbarCustomPenButton UwpControl { get; set; }
+        internal Windows.UI.Xaml.Controls.InkToolbarCustomPenButton UwpControl => ChildInternal as Windows.UI.Xaml.Controls.InkToolbarCustomPenButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InkToolbarCustomPenButton"/> class, a
@@ -37,7 +38,12 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            UwpControl = GetUwpInternalObject() as Windows.UI.Xaml.Controls.InkToolbarCustomPenButton;
+        }
+
+        /// <inheritdoc />
+        protected override void SetContent(UIElement newValue)
+        {
+            // intentionally empty
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarCustomToolButton.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarCustomToolButton.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel;
 using Microsoft.Toolkit.Forms.UI.XamlHost;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -34,6 +35,12 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
+        }
+
+        /// <inheritdoc />
+        protected override void SetContent(UIElement newValue)
+        {
+            // intentionally empty
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarMenuButton.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarMenuButton.cs
@@ -5,6 +5,7 @@
 using System;
 using System.ComponentModel;
 using Microsoft.Toolkit.Forms.UI.XamlHost;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -14,7 +15,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
     [Designer(typeof(InkToolbarToolButtonDesigner))]
     public class InkToolbarMenuButton : WindowsXamlHostBase
     {
-        internal Windows.UI.Xaml.Controls.InkToolbarMenuButton UwpControl { get; set; }
+        internal Windows.UI.Xaml.Controls.InkToolbarMenuButton UwpControl => ChildInternal as Windows.UI.Xaml.Controls.InkToolbarMenuButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InkToolbarMenuButton"/> class, a
@@ -33,10 +34,15 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            UwpControl = GetUwpInternalObject() as Windows.UI.Xaml.Controls.InkToolbarMenuButton;
             UwpControl.Checked += UwpControl_Checked;
             UwpControl.Indeterminate += UwpControl_Indeterminate;
             UwpControl.Unchecked += UwpControl_Unchecked;
+        }
+
+        /// <inheritdoc />
+        protected override void SetContent(UIElement newValue)
+        {
+            // intentionally empty
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarPenButton.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarPenButton.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Toolkit.Forms.UI.XamlHost;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
     /// </summary>[Designer(typeof(InkToolbarToolButtonDesigner))]
     public class InkToolbarPenButton : WindowsXamlHostBase
     {
-        internal Windows.UI.Xaml.Controls.InkToolbarPenButton UwpControl { get; set; }
+        internal Windows.UI.Xaml.Controls.InkToolbarPenButton UwpControl => ChildInternal as Windows.UI.Xaml.Controls.InkToolbarPenButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InkToolbarPenButton"/> class, a
@@ -34,7 +35,12 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            UwpControl = GetUwpInternalObject() as Windows.UI.Xaml.Controls.InkToolbarPenButton;
+        }
+
+        /// <inheritdoc />
+        protected override void SetContent(UIElement newValue)
+        {
+            // intentionally empty
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarStencilButton.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarStencilButton.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel;
 using Microsoft.Toolkit.Forms.UI.XamlHost;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
     [Designer(typeof(InkToolbarToolButtonDesigner))]
     public class InkToolbarStencilButton : WindowsXamlHostBase
     {
-        internal Windows.UI.Xaml.Controls.InkToolbarStencilButton UwpControl { get; set; }
+        internal Windows.UI.Xaml.Controls.InkToolbarStencilButton UwpControl => ChildInternal as Windows.UI.Xaml.Controls.InkToolbarStencilButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InkToolbarStencilButton"/> class, a
@@ -34,7 +35,12 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            UwpControl = GetUwpInternalObject() as Windows.UI.Xaml.Controls.InkToolbarStencilButton;
+        }
+
+        /// <inheritdoc />
+        protected override void SetContent(UIElement newValue)
+        {
+            // intentionally empty
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarToggleButton.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarToggleButton.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel;
 using Microsoft.Toolkit.Forms.UI.XamlHost;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
     [Designer(typeof(InkToolbarToolButtonDesigner))]
     public class InkToolbarToggleButton : WindowsXamlHostBase
     {
-        internal Windows.UI.Xaml.Controls.InkToolbarToggleButton UwpControl { get; set; }
+        internal Windows.UI.Xaml.Controls.InkToolbarToggleButton UwpControl => ChildInternal as Windows.UI.Xaml.Controls.InkToolbarToggleButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InkToolbarToggleButton"/> class, a
@@ -34,10 +35,15 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            UwpControl = GetUwpInternalObject() as Windows.UI.Xaml.Controls.InkToolbarToggleButton;
             UwpControl.Checked += UwpControl_Checked;
             UwpControl.Indeterminate += UwpControl_Indeterminate;
             UwpControl.Unchecked += UwpControl_Unchecked;
+        }
+
+        /// <inheritdoc />
+        protected override void SetContent(UIElement newValue)
+        {
+            // intentionally empty
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarToolButton.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.Controls/InkToolbar/InkToolbarToolButton.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel;
 using Microsoft.Toolkit.Forms.UI.XamlHost;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.Controls
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
     [Designer(typeof(InkToolbarToolButtonDesigner))]
     public class InkToolbarToolButton : WindowsXamlHostBase
     {
-        internal Windows.UI.Xaml.Controls.InkToolbarToolButton UwpControl { get; set; }
+        internal Windows.UI.Xaml.Controls.InkToolbarToolButton UwpControl => ChildInternal as Windows.UI.Xaml.Controls.InkToolbarToolButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InkToolbarToolButton"/> class, a
@@ -34,7 +35,12 @@ namespace Microsoft.Toolkit.Forms.UI.Controls
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            UwpControl = GetUwpInternalObject() as Windows.UI.Xaml.Controls.InkToolbarToolButton;
+        }
+
+        /// <inheritdoc />
+        protected override void SetContent(UIElement newValue)
+        {
+            // intentionally empty
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHost.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHost.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Windows.UI.Xaml.UIElement Child
         {
-            get => (_xamlSource.Content as DpiScalingPanel).Child;
+            get => ChildInternal;
 
             set => ChildInternal = value;
         }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -189,6 +189,10 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
 
                     ChildChanged?.Invoke(this, new EventArgs());
                 }
+                else
+                {
+                    _childInternal = value;
+                }
             }
         }
 
@@ -221,8 +225,11 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
             set
             {
                 _dpiScalingRenderTransformEnabled = value;
-                UpdateDpiScalingFactor();
-                PerformLayout();
+                if (!DesignMode)
+                {
+                    UpdateDpiScalingFactor();
+                    PerformLayout();
+                }
             }
         }
 

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
 using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Forms.UI.XamlHost
 {
@@ -44,6 +45,11 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         /// creating any DesktopWindowXamlSource instances if custom UWP XAML types are required.
         /// </summary>
         private readonly Windows.UI.Xaml.Application _application;
+
+        /// <summary>
+        /// Private field that backs ChildInternal property.
+        /// </summary>
+        private UIElement _childInternal;
 
         /// <summary>
         ///    Last preferredSize returned by UWP XAML during WinForms layout pass
@@ -150,19 +156,27 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         protected Windows.UI.Xaml.UIElement ChildInternal
         {
-            get => (_xamlSource.Content as DpiScalingPanel).Child;
+            get => _childInternal;
 
             set
             {
                 if (!DesignMode)
                 {
+                    if (value == ChildInternal)
+                    {
+                        return;
+                    }
+
                     var newFrameworkElement = value as Windows.UI.Xaml.FrameworkElement;
-                    var oldFrameworkElement = (_xamlSource.Content as DpiScalingPanel).Child as Windows.UI.Xaml.FrameworkElement;
+                    var oldFrameworkElement = ChildInternal as Windows.UI.Xaml.FrameworkElement;
 
                     if (oldFrameworkElement != null)
                     {
                         oldFrameworkElement.SizeChanged -= OnChildSizeChanged;
                     }
+
+                    _childInternal = value;
+                    SetContent(value);
 
                     if (newFrameworkElement != null)
                     {
@@ -170,8 +184,6 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                         // setting to determine if WindowsXamlHost needs to re-run layout.
                         newFrameworkElement.SizeChanged += OnChildSizeChanged;
                     }
-
-                    (_xamlSource.Content as DpiScalingPanel).Child = value;
 
                     PerformLayout();
 

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Forms.App/Form1.Designer.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Sample.Forms.App/Form1.Designer.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Toolkit.Win32.Samples.WinForms.App
             // inkToolbar1
             // 
             this.inkToolbar1.ActiveTool = this.inkToolbarCustomToolButton1;
+            this.inkToolbar1.AutoSize = true;
             this.inkToolbar1.ButtonFlyoutPlacement = Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.InkToolbarButtonFlyoutPlacement.Bottom;
             this.inkToolbar1.Controls.Add(this.inkToolbarCustomToolButton1);
             this.inkToolbar1.Dock = System.Windows.Forms.DockStyle.Top;


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As can be seen in the winforms sample app, custom buttons are not added correctly to the ink toolbar.

## What is the new behavior?

Some code changes to align with the WPF code to add the button XAML element directly to the inktoolbar XAML Control.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
