### PR TITLE
Make eye tracking RequestCalibrationAsync friendlier

### DIFF
--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazePointer.cpp
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazePointer.cpp
@@ -765,7 +765,9 @@ void GazePointer::Click()
 /// </summary>
 IAsyncOperation<bool>^ GazePointer::RequestCalibrationAsync()
 {
-    return _devices->GetAt(0)->RequestCalibrationAsync();
+    return _devices->Size == 1 ?
+        _devices->GetAt(0)->RequestCalibrationAsync() :
+        concurrency::create_async([] { return false; });
 }
 
 


### PR DESCRIPTION
Changed implementation of RequestCalibrationAsync to return false when it cannot be done because there is no device or is ambiguous because there is more than one device.