### PR TITLE
Add fallback color to acrylic brushes on sample app

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Styles/ThemeInjector.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Styles/ThemeInjector.cs
@@ -30,13 +30,15 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.Styles
                     {
                         TintColor = Helpers.ColorHelper.ToColor("#FF333333"),
                         TintOpacity = 0.8,
-                        BackgroundSource = AcrylicBackgroundSource.Backdrop
+                        BackgroundSource = AcrylicBackgroundSource.Backdrop,
+                        FallbackColor = Helpers.ColorHelper.ToColor("#FF333333")
                     },
                     LightAcrylic = new AcrylicBrush
                     {
                         TintColor = Colors.White,
                         TintOpacity = 0.8,
                         BackgroundSource = AcrylicBackgroundSource.Backdrop,
+                        FallbackColor = Colors.White
                     }
                 });
 
@@ -47,13 +49,15 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.Styles
                     {
                         TintColor = Helpers.ColorHelper.ToColor("#FF111111"),
                         TintOpacity = 0.7,
-                        BackgroundSource = AcrylicBackgroundSource.Backdrop
+                        BackgroundSource = AcrylicBackgroundSource.Backdrop,
+                        FallbackColor = Helpers.ColorHelper.ToColor("#FF111111")
                     },
                     LightAcrylic = new AcrylicBrush
                     {
                         TintColor = Helpers.ColorHelper.ToColor("#FFDDDDDD"),
                         TintOpacity = 0.6,
                         BackgroundSource = AcrylicBackgroundSource.Backdrop,
+                        FallbackColor = Helpers.ColorHelper.ToColor("#FFDDDDDD")
                     }
                 });
             }


### PR DESCRIPTION
Issue: #2626 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the system supports acrylic brushes, but transparency effects are disabled (or a high contrast theme is being used), the background of the Sample app's About page sidebar looks completely transparent.

## What is the new behavior?
If the system supports acrylic brushes, but transparency effects are disabled (or a high contrast theme is being used), the brushes fallback to the color that was used for the acrylic brush.

Transparency enabled:
![image](https://user-images.githubusercontent.com/14252330/47794053-6dfe8200-dcfe-11e8-9666-4eb7e946df0f.png)

Transparency disabled:
![image](https://user-images.githubusercontent.com/14252330/47794081-7b1b7100-dcfe-11e8-8c80-72c1986b6a39.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
