### PR TITLE
Add support for FlowDirection in the MarkdownTextBlock

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     renderer.ImageMaxHeight = ImageMaxHeight;
                     renderer.ImageMaxWidth = ImageMaxWidth;
                     renderer.WrapCodeBlock = WrapCodeBlock;
+                    renderer.FlowDirection = FlowDirection;
 
                     _rootElement.Child = renderer.Render();
                 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class MarkdownTextBlock : Control, ILinkRegister, IImageResolver, ICodeBlockResolver
     {
         private long _fontSizePropertyToken;
+        private long _flowDirectionPropertyToken;
         private long _backgroundPropertyToken;
         private long _borderBrushPropertyToken;
         private long _borderThicknessPropertyToken;
@@ -49,6 +50,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             // Register for property callbacks that are owned by our parent class.
             _fontSizePropertyToken = RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
+            _flowDirectionPropertyToken = RegisterPropertyChangedCallback(FlowDirectionProperty, OnPropertyChanged);
             _backgroundPropertyToken = RegisterPropertyChangedCallback(BackgroundProperty, OnPropertyChanged);
             _borderBrushPropertyToken = RegisterPropertyChangedCallback(BorderBrushProperty, OnPropertyChanged);
             _borderThicknessPropertyToken = RegisterPropertyChangedCallback(BorderThicknessProperty, OnPropertyChanged);
@@ -74,6 +76,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             // Register for property callbacks that are owned by our parent class.
             UnregisterPropertyChangedCallback(FontSizeProperty, _fontSizePropertyToken);
+            UnregisterPropertyChangedCallback(FlowDirectionProperty, _flowDirectionPropertyToken);
             UnregisterPropertyChangedCallback(BackgroundProperty, _backgroundPropertyToken);
             UnregisterPropertyChangedCallback(BorderBrushProperty, _borderBrushPropertyToken);
             UnregisterPropertyChangedCallback(BorderThicknessProperty, _borderThicknessPropertyToken);

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Blocks.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Blocks.cs
@@ -374,7 +374,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
             {
                 FontFamily = CodeFontFamily ?? FontFamily,
                 Foreground = brush,
-                LineHeight = FontSize * 1.4
+                LineHeight = FontSize * 1.4,
+                FlowDirection = FlowDirection
             };
 
             textBlock.PointerWheelChanged += Preventative_PointerWheelChanged;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Properties.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
         public Brush BorderBrush { get; set; }
 
         /// <summary>
+        /// Gets or sets the <see cref="FlowDirection"/> of the markdown.
+        /// </summary>
+        public FlowDirection FlowDirection { get; set; }
+
+        /// <summary>
         /// Gets or sets the font used to display text in the control.
         /// </summary>
         public FontFamily FontFamily { get; set; }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
                 FontWeight = FontWeight,
                 Foreground = localContext.Foreground,
                 IsTextSelectionEnabled = IsTextSelectionEnabled,
-                TextWrapping = TextWrapping
+                TextWrapping = TextWrapping,
+                FlowDirection = FlowDirection
             };
             localContext.BlockUIElementCollection?.Add(result);
 
@@ -108,7 +109,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
                 FontWeight = FontWeight,
                 Foreground = context.Foreground,
                 IsTextSelectionEnabled = IsTextSelectionEnabled,
-                TextWrapping = TextWrapping
+                TextWrapping = TextWrapping,
+                FlowDirection = FlowDirection
             };
             return result;
         }


### PR DESCRIPTION
Issue: #2642
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The MarkdownTextBlock does not support the `FlowDirection` property.

## What is the new behavior?
Added support for FlowDirection in the MarkdownTextBlock. Setting the FlowDirection of the MarkdownTextBlock will set the FlowDirection of the underling TextBlocks used

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes
