### PR TITLE
[SetListDataItemForNextConnectedAnimation] Deprecated misspelled method and added correct spelling

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/Connected.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/Connected.cs
@@ -371,7 +371,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// </summary>
         /// <param name="frame">The Frame handling the navigation</param>
         /// <param name="item">The data item from a list control to be animated during next frame navigation</param>
+        [Obsolete("Method is replaced by SetListDataItemForNextConnectedAnimation")]
         public static void SetListDataItemForNextConnectedAnnimation(this Frame frame, object item)
+        {
+            GetConnectedAnimationHelper(frame)?.SetParameterForNextFrameNavigation(item);
+        }
+
+        /// <summary>
+        /// Sets the object that will be used during next Frame navigation for
+        /// Connected Animation involving a list control (item must be an element of
+        /// ListViewBase.ItemsSource collection).
+        /// Useful if the parameter used during page navigation is different from the
+        /// data item in the list control. Also useful during back navigation if the
+        /// item navigating back to is different from the item that was navigated from.
+        /// </summary>
+        /// <param name="frame">The Frame handling the navigation</param>
+        /// <param name="item">The data item from a list control to be animated during next frame navigation</param>
+        public static void SetListDataItemForNextConnectedAnimation(this Frame frame, object item)
         {
             GetConnectedAnimationHelper(frame)?.SetParameterForNextFrameNavigation(item);
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes) 
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The SetListDataItemForNextConnectedAnimation is misspelled

## What is the new behavior?
The method is spelled correctly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes
