### PR TITLE
Replaced Invoke-WebRequest with WebClient in SDK Installation script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,9 @@ steps:
 - script: nbgv cloud
   displayName: Set Version
 
+- powershell: .\build\Install-WindowsSdkISO.ps1 17763
+  displayName: Insider SDK
+
 - powershell: .\build\build.ps1 -target=Package
   displayName: Build 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,6 @@ steps:
 
 - script: nbgv cloud
   displayName: Set Version
-      
-- powershell: .\build\Install-WindowsSdkISO.ps1 17763
-  displayName: Insider SDK
 
 - powershell: .\build\build.ps1 -target=Package
   displayName: Build 

--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -24,7 +24,7 @@ function Download-File
     $downloadDest = Join-Path $outDir $downloadName
     $downloadDestTemp = Join-Path $outDir "$downloadName.tmp"
 
-    Write-Host -NoNewline "Downloading $downloadName ..."
+    Write-Host -NoNewline "Downloading $downloadName..."
 
     try
     {
@@ -56,7 +56,7 @@ function Download-File
     }
 
     Move-Item -Force $downloadDestTemp $downloadDest
-    Write-Host "Updated $downloadName"
+    Write-Host "Done"
 
     return $downloadDest
 }

--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -20,59 +20,18 @@ function Download-File
            [string] $downloadUrl,
            [string] $downloadName)
 
-    # The ISO file can be large (800 MB), we want to use smart caching if we can to avoid long delays
-    # Note that some sources explicitly disable caching, so this may not be possible
-    $etagFile = Join-path $outDir "$downloadName.ETag"
     $downloadPath = Join-Path $outDir "$downloadName.download"
     $downloadDest = Join-Path $outDir $downloadName
     $downloadDestTemp = Join-Path $outDir "$downloadName.tmp"
-    $headers = @{}
 
-    Write-Host -NoNewline "Ensuring that $downloadName is up to date..."
-
-    # if the destination folder doesn't exist, delete the ETAG file if it exists
-    if (!(Test-Path -PathType Container $downloadDest) -and (Test-Path -PathType Container $etagFile))
-    {
-        Remove-Item -Force $etagFile
-    }
-
-    if (Test-Path $etagFile)
-    {
-        $headers.Add("If-None-Match", [System.IO.File]::ReadAllText($etagFile))
-    }
+    Write-Host -NoNewline "Downloading $downloadName ..."
 
     try
     {
-        # Dramatically speeds up download performance
-        $ProgressPreference = 'SilentlyContinue'
-        $response = Invoke-WebRequest -Headers $headers -Uri $downloadUrl -PassThru -OutFile $downloadPath -UseBasicParsing
+        $webclient = new-object System.Net.WebClient
+        $webclient.DownloadFile($downloadUrl, $downloadPath)
     }
     catch [System.Net.WebException]
-    {
-        $response = $_.Exception.Response
-    }
-
-    if ($response.StatusCode -eq 200)
-    {
-        Unblock-File $downloadPath
-        [System.IO.File]::WriteAllText($etagFile, $response.Headers["ETag"])
-
-        $downloadDestTemp = $downloadPath;
-
-        # Delete and rename to final dest
-        if (Test-Path -PathType Container $downloadDest)
-        {
-            [System.IO.Directory]::Delete($downloadDest, $true)
-        }
-
-        Move-Item -Force $downloadDestTemp $downloadDest
-        Write-Host "Updated $downloadName"
-    }
-    elseif ($response.StatusCode -eq 304)
-    {
-        Write-Host "Done"
-    }
-    else
     {
         Write-Host
         Write-Warning "Failed to fetch updated file from $downloadUrl"
@@ -85,6 +44,19 @@ function Download-File
             Write-Warning "$downloadName may be out of date"
         }
     }
+
+    Unblock-File $downloadPath
+
+    $downloadDestTemp = $downloadPath;
+
+    # Delete and rename to final dest
+    if (Test-Path -PathType Container $downloadDest)
+    {
+        [System.IO.Directory]::Delete($downloadDest, $true)
+    }
+
+    Move-Item -Force $downloadDestTemp $downloadDest
+    Write-Host "Updated $downloadName"
 
     return $downloadDest
 }


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Builds often get a OutOfMemoryException due to Invoke-WebRequest trying to download the SDK ISO (800+mb) in memory before saving to disk

## What is the new behavior?
Replaced Invoke-WebRequest with WebClient to avoid the issue

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
This new implementation does not handle smart caching because WebClient does not expose the headers of the request (easily). Caching is not strictly necessary as the script always runs on a clean vm which will always need to the sdk downloaded and installed