### PR TITLE
Hide Header for HeaderedContentControl when Header is null

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// </summary>
     public class HeaderedContentControl : ContentControl
     {
+        private const string PartHeaderPresenter = "HeaderPresenter";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderedContentControl"/> class.
         /// </summary>
@@ -78,6 +80,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             set { SetValue(HeaderTemplateProperty, value); }
         }
 
+        /// <inheritdoc/>
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            SetHeaderVisibility();
+        }
+
         /// <summary>
         /// Called when the <see cref="Header"/> property changes.
         /// </summary>
@@ -101,7 +111,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var control = (HeaderedContentControl)d;
+            control.SetHeaderVisibility();
             control.OnHeaderChanged(e.OldValue, e.NewValue);
+        }
+
+        private void SetHeaderVisibility()
+        {
+            if (GetTemplateChild(PartHeaderPresenter) is FrameworkElement headerPresenter)
+            {
+                headerPresenter.Visibility = Header != null
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.xaml
@@ -17,8 +17,15 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <ContentPresenter x:Name="HeaderPresenter" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" Grid.ColumnSpan="2"/>
-                        <ContentPresenter x:Name="ContentPresenter" Grid.Row="1" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Grid.ColumnSpan="2"/>
+                        <ContentPresenter x:Name="HeaderPresenter" 
+                                          Content="{TemplateBinding Header}" 
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}" 
+                                          Grid.ColumnSpan="2"/>
+                        <ContentPresenter x:Name="ContentPresenter" 
+                                          Grid.ColumnSpan="2"
+                                          Grid.Row="1" 
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="OrientationStates">
                                 <VisualState x:Name="Vertical" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.xaml
@@ -18,6 +18,7 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <ContentPresenter x:Name="HeaderPresenter" 
+                                          x:DeferLoadStrategy="Lazy"
                                           Content="{TemplateBinding Header}" 
                                           ContentTemplate="{TemplateBinding HeaderTemplate}" 
                                           Grid.ColumnSpan="2"/>


### PR DESCRIPTION
Issue: #2661
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Header shows the Content property if the Header is null and the Content is text

## What is the new behavior?
The Header is not visible if the Header property is null

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
