### PR TITLE
Applied a change to invoke the Completed event after setting the resu…

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/AnimationSet.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/AnimationSet.cs
@@ -626,8 +626,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
             if (_animationTCS != null && !_animationTCS.Task.IsCompleted)
             {
-                Completed?.Invoke(this, new AnimationSetCompletedEventArgs() { Completed = _storyboardCompleted && _compositionCompleted });
                 _animationTCS.SetResult(State == AnimationSetState.Completed);
+                Completed?.Invoke(this, new AnimationSetCompletedEventArgs() { Completed = _storyboardCompleted && _compositionCompleted });
             }
         }
     }


### PR DESCRIPTION
 Applied a change to invoke the Completed event after setting the result for the TaskCompletionSource (to prevent a crash when disposing an AnimationSet on its Completed event)

Issue: #
[https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/2669](https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/2669)

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Explained in the following post:
[https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/2669](https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/2669)

## What is the new behavior?

In the Completed event, the result of the TaskCompletionSource is set right before the Completed event is invoked, this allows a developer to dispose of the AnimationSet in its Completed event (prevents a crash).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] Tested code with current [supported SDKs](../readme.md#supported)
- [ X] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ X] Sample in sample app has been added / updated (for bug fixes / features)
    - [X ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
