### PR TITLE
🚧 Added deconstructor to ObservableBluetoothLEDevice

### DIFF
--- a/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableBluetoothLEDevice.cs
+++ b/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableBluetoothLEDevice.cs
@@ -147,7 +147,15 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
 
             LoadGlyph();
 
-            this.PropertyChanged += ObservableBluetoothLEDevice_PropertyChanged;
+            PropertyChanged += ObservableBluetoothLEDevice_PropertyChanged;
+        }
+
+        /// <summary>
+        /// Destruct this object by unregistering from property changed callbacks.
+        /// </summary>
+        ~ObservableBluetoothLEDevice()
+        {
+            PropertyChanged -= ObservableBluetoothLEDevice_PropertyChanged;
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableBluetoothLEDevice.cs
+++ b/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableBluetoothLEDevice.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
         }
 
         /// <summary>
+        /// Finalizes an instance of the <see cref="ObservableBluetoothLEDevice"/> class.
         /// Destruct this object by unregistering from property changed callbacks.
         /// </summary>
         ~ObservableBluetoothLEDevice()


### PR DESCRIPTION
Destruct this object by unregistering from property changed callbacks.

Issue: #2696

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
The `PropertyChanged` event handler is added to the private `ObservableBluetoothLEDevice_PropertyChanged` function in the `ObservableBluetoothLEDevice` constructor. This handler is never removed, causing memory leaks.

## What is the new behavior?
The `PropertyChanged` event handler is removed in the deconstructor.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes