### PR TITLE
🚧 Added deconstructor to ObservableGattCharacteristics

### DIFF
--- a/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableGattCharacteristics.cs
+++ b/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableGattCharacteristics.cs
@@ -126,15 +126,19 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
             ReadValueAsync();
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
-            characteristic.ValueChanged += Characteristic_ValueChanged;
+            Characteristic.ValueChanged += Characteristic_ValueChanged;
         }
 
         /// <summary>
+        /// Finalizes an instance of the <see cref="ObservableGattCharacteristics"/> class.
         /// Destruct this object by unsetting notification/indication.
         /// </summary>
         ~ObservableGattCharacteristics()
         {
-            characteristic.ValueChanged -= Characteristic_ValueChanged;
+            if (Characteristic != null)
+            {
+                Characteristic.ValueChanged -= Characteristic_ValueChanged;
+            }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableGattCharacteristics.cs
+++ b/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper/ObservableGattCharacteristics.cs
@@ -130,6 +130,14 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
         }
 
         /// <summary>
+        /// Destruct this object by unsetting notification/indication.
+        /// </summary>
+        ~ObservableGattCharacteristics()
+        {
+            characteristic.ValueChanged -= Characteristic_ValueChanged;
+        }
+
+        /// <summary>
         /// Gets or sets the characteristic this class wraps
         /// </summary>
         public GattCharacteristic Characteristic


### PR DESCRIPTION
Destruct this object by unsetting notification/indication.

Issue: #2696

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
The `ValueChanged` event handler is added to the private `Characteristic_ValueChanged` function in the `ObservableGattCharacteristics` constructor. This handler is never removed, causing memory leaks.

## What is the new behavior?
The `ValueChanged` event handler is removed in the deconstructor.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes