### PR TITLE
Removed unnecessary Setter in NavigationView toolkit UWP Style

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Styles/Generic.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Styles/Generic.xaml
@@ -1014,7 +1014,6 @@
                                 <VisualState x:Name="TitleBarVisible" />
                                 <VisualState x:Name="TitleBarCollapsed">
                                     <VisualState.Setters>
-                                        <Setter Target="PaneButtonGrid.Margin" Value="0,32,0,0" />
                                         <Setter Target="PaneContentGrid.Margin" Value="0,32,0,0" />
                                     </VisualState.Setters>
                                 </VisualState>


### PR DESCRIPTION
### Removed unnecessary Setter in NavigationView toolkit UWP Style

Removed PaneButtonGrid.Margin in the VisualState Setters for the default UWP NavigationView Style.
PaneButtonGrid does not exist in the NavigationView template and in the code behind of the control.

![image](https://user-images.githubusercontent.com/16295702/49675878-693b9500-fa45-11e8-91e1-31ddc759310f.png)

![image](https://user-images.githubusercontent.com/16295702/49675884-6e004900-fa45-11e8-9387-dc30b14b204a.png)

Related to this previous PR in WinUI : 
https://github.com/Microsoft/microsoft-ui-xaml/pull/46

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
PaneButtonGrid does not exist in the NavigationView template and in the code behind of the control, but it's used in one of the VisualState Setter.

## What is the new behavior?
Removed unnecessary Setter in NavigationView toolkit UWP Style.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes
