### PR TITLE
Fix issue #2667 TabView on RS3 Resource Missing

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/TabView/TabView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TabView/TabView.xaml
@@ -570,7 +570,7 @@
         <Setter Property="MinWidth" Value="{ThemeResource TabViewItemHeaderMinWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource TabViewItemHeaderMinHeight}" />
         <Setter Property="MaxWidth" Value="{ThemeResource TabViewItemHeaderMaxWidth}" />
-        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="FocusVisualMargin" Value="0" />
         <Setter Property="IsClosable" Value="False" />
         <Setter Property="Template" Value="{StaticResource TabViewItemHeaderTemplate}" />
@@ -682,7 +682,7 @@
         <Setter Property="BorderThickness" Value="1,0,0,0" />
         <Setter Property="BorderBrush" Value="{ThemeResource TabViewItemHeaderRevealBorderBrush}" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ScrollViewer">


### PR DESCRIPTION
Issue: #2667

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Apps using TabView crash on RS3

## What is the new behavior?
Removes resource that wasn't used until RS4.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
(https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Contains **NO** breaking changes
