### PR TITLE
Fix behavior on queue behind and stack in front modes

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void DismissTimer_Tick(object sender, object e)
         {
-            Dismiss(InAppNotificationDismissKind.Timeout);
             _dismissTimer.Stop();
+            Dismiss(InAppNotificationDismissKind.Timeout);
         }
 
         private void OpenAnimationTimer_Tick(object sender, object e)


### PR DESCRIPTION
Issue: #2442 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

InAppNotification does not replace the content from the current notification options to the next one in either `StackInFront` or `QueueBehind` mode.

## What is the new behavior?

Well, now it works.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Contains **NO** breaking changes

## Information

It was due to the fact that the `dismissTimer` that need to be used was always stopped after the first replacement of content but we need it to continue to tick until the final dismiss.