### PR TITLE
Add narrator feature for GridSplitter control

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.xaml
@@ -23,6 +23,7 @@
         <Setter Property="MinHeight" Value="16"></Setter>
         <Setter Property="Background" Value="{ThemeResource SystemControlHighlightChromeHighBrush}"></Setter>
         <Setter Property="GripperForeground" Value="{ThemeResource SystemControlForegroundAltHighBrush}" />
+        <Setter Property="AutomationProperties.Name" Value="GridSplitter" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:GridSplitter">


### PR DESCRIPTION
Issue: #2276 

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix 

## What is the current behavior?

The GridSplitter control doesn't support narrator feature.

## What is the new behavior?

Now, this control supports narrator. It reads the GridSplitter bar as "GridSplitter" and its GripperDisplay as its displayed text. However, it doesn't recognize the Segoe MDL2 icons (I'm open to any kind of suggestion to improve this).

![image](https://user-images.githubusercontent.com/3893598/51635266-279f7480-1f35-11e9-87d6-4d8461e3fc3b.png)

![image](https://user-images.githubusercontent.com/3893598/51635697-33d80180-1f36-11e9-8605-20441e43331c.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

