### PR TITLE
AdaptiveGridView - When a textbox is selected the previous element lose the focus

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private Orientation _savedOrientation;
         private bool _needToRestoreScrollStates;
         private bool _needContainerMarginForLayout;
+        private int prevIndex;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveGridView"/> class.
@@ -42,9 +43,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Items.VectorChanged += ItemsOnVectorChanged;
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+            LostFocus += this.AdaptiveGridView_LostFocus;
 
             // Prevent issues with higher DPIs and underlying panel. #1803
             UseLayoutRounding = false;
+        }
+
+        private void AdaptiveGridView_LostFocus(object sender, RoutedEventArgs e)
+        {
+            int newIndex = (sender as AdaptiveGridView).SelectedIndex;
+
+            if (prevIndex == newIndex)
+            {
+                (sender as AdaptiveGridView).SelectedIndex = -1;
+            }
+
+            prevIndex = newIndex;
         }
 
         /// <summary>


### PR DESCRIPTION
Issue: #2276 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Having ItemClick disabled and selection mode as single, when an item is focused and a textbox on another item is clicked, the selected item won't change.

## What is the new behavior?
Now when an item is selected and a textbox from another element is selected, the previous item loses the focus indicator.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
