### PR TITLE
BladeView - Set blade status programmatically

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/BladeItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/BladeItem.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
@@ -66,6 +67,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 Width = _normalModeWidth;
                 VisualStateManager.GoToState(this, "Expanded", true);
+                AutomationProperties.SetName(this, "Expanded");
             }
         }
 
@@ -77,6 +79,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 Width = double.NaN;
                 VisualStateManager.GoToState(this, "Collapsed", true);
+                AutomationProperties.SetName(this, "Collapsed");
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/BladeView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/BladeView.xaml
@@ -23,6 +23,7 @@
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
         <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="AutomationProperties.Name" Value="{Binding BladeStatus}" />
         <Setter Property="ItemContainerTransitions">
             <Setter.Value>
                 <TransitionCollection>


### PR DESCRIPTION
Issue: #2276 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When the blade is collapsed or expanded there isn't a notification about the status.

## What is the new behavior?
When the blade is collapsed or expanded, the property _AutomationProperties.Name_ is set with the status (expanded or collapsed) and the Narrator can read this to notify it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
