### PR TITLE
Fix Narrator accessibility issues from InAppNotification control

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -4,12 +4,15 @@
 
 using System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
     /// <summary>
     /// In App Notification defines a control to show local notification in the app.
     /// </summary>
+
     public partial class InAppNotification
     {
         /// <summary>
@@ -47,7 +50,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             _animationTimer.Stop();
             Opened?.Invoke(this, EventArgs.Empty);
+            if (Content.GetType() == typeof(string))
+            {
+                AutomateTextNotification(Content.ToString());
+            }
+
             _animationTimer.Tick -= OpenAnimationTimer_Tick;
+        }
+
+        private void AutomateTextNotification(string message)
+        {
+            AutomationPeer peer = FrameworkElementAutomationPeer.CreatePeerForElement(ContentTemplateRoot);
+            if (peer != null)
+            {
+                peer.SetFocus();
+                peer.RaiseNotificationEvent(
+                    AutomationNotificationKind.Other,
+                    AutomationNotificationProcessing.ImportantMostRecent,
+                    "New notification " + message,
+                    Guid.NewGuid().ToString());
+            }
         }
 
         private void DismissAnimationTimer_Tick(object sender, object e)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Media;
 
@@ -50,6 +51,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             _animationTimer.Stop();
             Opened?.Invoke(this, EventArgs.Empty);
+            SetValue(AutomationProperties.NameProperty, "Notification");
             if (Content.GetType() == typeof(string))
             {
                 AutomateTextNotification(Content.ToString());


### PR DESCRIPTION
Issue: #2276 

## PR Type
What kind of change does this PR introduce?
 - Bugfix

## What is the current behavior?
The InAppNotification isn't recognized by the narrator once its triggered.

## What is the new behavior?

Now, the InAppNotification is recognized by the narrator once its triggered. This modification only works when the _show_ method receives text.

![image](https://user-images.githubusercontent.com/3893598/52012130-8c6c4900-24b8-11e9-8587-0279efb06323.png)

[![](http://img.youtube.com/vi/Rv4QQfdozVM/0.jpg)](http://www.youtube.com/watch?v=Rv4QQfdozVM "WCT inAppNotification Narrator")

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

