### PR TITLE
Expander fix for tab navigation, tab focus, and high contrast

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -14,8 +14,8 @@
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
-        <Setter Property="BorderThickness" Value="{ThemeResource ToggleButtonBorderThemeThickness}" />
-        <Setter Property="Padding" Value="0" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="2,0,0,0" />
         <Setter Property="Height" Value="40" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -7,6 +7,7 @@
                     mc:Ignorable="d">
 
     <converters:EmptyObjectToObjectConverter x:Key="NullToVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible" />
+    <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
 
     <Style x:Key="HeaderToggleButtonStyle"
            TargetType="ToggleButton">
@@ -322,6 +323,26 @@
                                 <ColumnDefinition x:Name="ColumnTwo"
                                                   Width="*" />
                             </Grid.ColumnDefinitions>
+                            <controls:LayoutTransformControl x:Name="PART_LayoutTransformer"
+                                                             Grid.Row="0"
+                                                             Grid.RowSpan="1"
+                                                             Grid.Column="0"
+                                                             Grid.ColumnSpan="2"
+                                                             RenderTransformOrigin="0.5,0.5">
+                                <controls:LayoutTransformControl.Transform>
+                                    <RotateTransform x:Name="RotateLayoutTransform" Angle="0" />
+                                </controls:LayoutTransformControl.Transform>
+                                <ToggleButton x:Name="PART_ExpanderToggleButton"
+                                              MinWidth="40"
+                                              MinHeight="40"
+                                              AutomationProperties.Name="Expand"
+                                              Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              Foreground="{TemplateBinding Foreground}"
+                                              IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              Style="{TemplateBinding HeaderStyle}"
+                                              TabIndex="0" />
+                            </controls:LayoutTransformControl>
                             <Grid x:Name="PART_ContentOverlay"
                                   Grid.Row="1"
                                   Grid.RowSpan="1"
@@ -334,6 +355,8 @@
                                   <ContentControl Content="{TemplateBinding ContentOverlay}"
                                                   HorizontalContentAlignment="Stretch"
                                                   VerticalContentAlignment="Stretch"
+                                                  IsTabStop="False"
+                                                  IsEnabled="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolNegationConverter}}"
                                                   HorizontalAlignment="Stretch"
                                                   VerticalAlignment="Stretch">
                                     <ContentControl.RenderTransform>
@@ -361,26 +384,6 @@
                                     <ScaleTransform />
                                 </Grid.RenderTransform>
                             </Grid>
-                            <controls:LayoutTransformControl x:Name="PART_LayoutTransformer"
-                                                             Grid.Row="0"
-                                                             Grid.RowSpan="1"
-                                                             Grid.Column="0"
-                                                             Grid.ColumnSpan="2"
-                                                             RenderTransformOrigin="0.5,0.5">
-                                <controls:LayoutTransformControl.Transform>
-                                    <RotateTransform x:Name="RotateLayoutTransform" Angle="0" />
-                                </controls:LayoutTransformControl.Transform>
-                                <ToggleButton x:Name="PART_ExpanderToggleButton"
-                                              MinWidth="40"
-                                              MinHeight="40"
-                                              AutomationProperties.Name="Expand"
-                                              Content="{TemplateBinding Header}"
-                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                              Foreground="{TemplateBinding Foreground}"
-                                              IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                              Style="{TemplateBinding HeaderStyle}"
-                                              TabIndex="0" />
-                            </controls:LayoutTransformControl>
                         </Grid>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="DisplayModeAndDirectionStates">


### PR DESCRIPTION
Issue: #2276
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
* Tab order is broken (content focuses before header)
* User is able to focus inside overlay when it's not visible
* A border is visible in high contrast when it's not supposed to

## What is the new behavior?
* Tab order works as expected
* User is no longer able to focus inside the overlay when it's not visible
* No border in high contrast mode

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
