### PR TITLE
Markdown parses fix for ArgumentOutOfRangeException when parsing urls

### DIFF
--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/HyperlinkInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/HyperlinkInline.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Toolkit.Parsers.Markdown.Inlines
 
             // The URL must have at least one character after the http:// and at least one dot.
             int pos = tripPos + 3;
+            if (pos > maxEnd)
+            {
+                return null;
+            }
+
             int dotIndex = markdown.IndexOf('.', pos, maxEnd - pos);
             if (dotIndex == -1 || dotIndex == pos)
             {


### PR DESCRIPTION
Issue: #2749
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See #2749 

## What is the new behavior?
No exceptions when parsing a link

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes

