### PR TITLE
Fix Mouse Cursor Extensions not changing cursor back

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Mouse/Mouse.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Mouse/Mouse.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         {
             // when exiting change the cursor to the target Mouse.Cursor value of the new element
             CoreCursor cursor;
-            if (e.OriginalSource is FrameworkElement newElement)
+            if (sender != e.OriginalSource && e.OriginalSource is FrameworkElement newElement)
             {
                 cursor = _cursors[GetCursor(newElement)];
             }


### PR DESCRIPTION
Related Issue: #2017 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Sometimes when using Mouse Extensions the cursor doesn't change back properly.

## What is the new behavior?
Now cursor should be properly restored.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


## Other information
Pointer Exit is sometimes called originating from the element itself, which in turn causes it to set the pointer to the changed cursor instead of back to something else.  This checks that the source is not the item we've attached the property to.

Unfortunately, the original issue filed with GridSplitter is entirely different as there's a lot more logic there.  We should refactor GridSplitter for 6.0 to use Mouse Extensions instead, I have some of this done already as part of another more general 'ContentSplitter' control I've written.