### PR TITLE
Null checks for Style Template on RemoteDevicePicker

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RemoteDevicePicker/RemoteDevicePicker.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RemoteDevicePicker/RemoteDevicePicker.cs
@@ -247,7 +247,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void LoadFilters()
         {
             var discoveryType = typeof(RemoteSystemDiscoveryType).GetEnumNames().OrderBy(a => a.ToString()).ToList();
-            _deviceDiscovery.ItemsSource = discoveryType;
+            if (_deviceDiscovery != null)
+            {
+                _deviceDiscovery.ItemsSource = discoveryType;
+            }
 
             if (_discoveryFilter != null)
             {
@@ -255,7 +258,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             var statusType = typeof(RemoteSystemStatusType).GetEnumNames().OrderBy(a => a.ToString()).ToList();
-            _deviceStatus.ItemsSource = statusType;
+            if (_deviceStatus != null)
+            {
+                _deviceStatus.ItemsSource = statusType;
+            }
 
             if (_statusFilter != null)
             {
@@ -263,7 +269,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             var authType = typeof(RemoteSystemAuthorizationKind).GetEnumNames().OrderBy(a => a.ToString()).ToList();
-            _authorizationType.ItemsSource = authType;
+            if (_authorizationType != null)
+            {
+                _authorizationType.ItemsSource = authType;
+            }
 
             if (_authorizationKindFilter != null)
             {
@@ -338,7 +347,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void UpdateList()
         {
             var bindingList = new ObservableCollection<RemoteSystem>();
-            if (RemoteSystems != null)
+            if (RemoteSystems != null && _listDeviceTypes != null && _listDevices != null)
             {
                 var bindinglist = _listDeviceTypes.SelectedValue.ToString().Equals("All")
                     ? RemoteSystems


### PR DESCRIPTION
Issue: #2126
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Check for null templated pieces in case removed from style.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
