### PR TITLE
Condense Sample App Categories + Add Subcategories

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
@@ -83,6 +83,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
         public string Type { get; set; }
 
+        public string Subcategory { get; set; }
+
         public string About { get; set; }
 
         private string _codeUrl;

--- a/Microsoft.Toolkit.Uwp.SampleApp/Models/Samples.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Models/Samples.cs
@@ -37,10 +37,15 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             return (await GetCategoriesAsync()).SelectMany(c => c.Samples).FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         }
 
-        public static async Task<Sample[]> FindSamplesByName(string name)
+        public static async Task<Sample[]> FindSample(string name)
         {
             var query = name.ToLower();
-            return (await GetCategoriesAsync()).SelectMany(c => c.Samples).Where(s => s.Name.ToLower().Contains(query)).ToArray();
+            return (await GetCategoriesAsync())
+                .SelectMany(c => c.Samples)
+                .Where(s => s.Name.ToLower().Contains(query) ||
+                            s.Subcategory?.ToLower()?.Contains(query) == true ||
+                            s.About.ToLower().Contains(query))
+                .ToArray();
         }
 
         public static async Task<List<SampleCategory>> GetCategoriesAsync()

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
@@ -6,6 +6,7 @@
       {
         "Name": "TextToolbar",
         "Type": "TextToolbarPage",
+        "Subcategory": "Menus and Toolbars",
         "About": "A Toolbar for Editing Text attached to a RichEditBox. It can format RTF and Markdown, or use a Custom Formatter, and specify your own Formatter with Buttons and Actions.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar",
         "XamlCodeFile": "TextToolbar.bind",
@@ -16,6 +17,7 @@
       {
         "Name": "TabView",
         "Type": "TabViewPage",
+        "Subcategory": "Layout",
         "About": "A control for displaying multiple items in the same space and allows a user to easily switch between them.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/TabView",
         "XamlCodeFile": "TabViewXaml.bind",
@@ -25,6 +27,7 @@
       {
         "Name": "DataGrid",
         "Type": "DataGridPage",
+        "Subcategory": "Layout",
         "About": "Control that presents data in a customizable table of rows and columns.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid",
         "XamlCodeFile": "DataGridCode.bind",
@@ -34,6 +37,7 @@
       {
         "Name": "Carousel",
         "Type": "CarouselPage",
+        "Subcategory": "Layout",
         "About": "Presents items in a carousel control. It reacts to changes in the layout as well as the content so it can adapt to different form factors automatically.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/Carousel",
         "XamlCodeFile": "CarouselCode.bind",
@@ -43,6 +47,7 @@
       {
         "Name": "AdaptiveGridView",
         "Type": "AdaptiveGridViewPage",
+        "Subcategory": "Layout",
         "About": "Presents items in a evenly-spaced set of columns to fill the total available display space. It reacts to changes in the layout as well as the content so it can adapt to different form factors automatically.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView",
         "XamlCodeFile": "AdaptiveGridViewCode.bind",
@@ -52,6 +57,7 @@
       {
         "Name": "UniformGrid",
         "Type": "UniformGridPage",
+        "Subcategory": "Layout",
         "About": "Presents items in a evenly-spaced set of rows or columns to fill the total available display space. It reacts to changes in the layout as well as the content so it can adapt to different form factors automatically.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/UniformGrid",
         "XamlCodeFile": "UniformGridXaml.bind",
@@ -61,6 +67,7 @@
       {
         "Name": "RangeSelector",
         "Type": "RangeSelectorPage",
+        "Subcategory": "Input",
         "About": "The RangeSelector is a \"double slider\" control for range values.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector",
         "XamlCodeFile": "RangeSelectorCode.bind",
@@ -70,6 +77,7 @@
       {
         "Name": "ImageEx",
         "Type": "ImageExPage",
+        "Subcategory": "Media",
         "About": "Images are downloaded asynchronously showing a load indicator. Source images are then stored in the App local cache to preserve resources and load time.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx",
         "XamlCodeFile": "ImageExCode.bind",
@@ -79,6 +87,7 @@
       {
         "Name": "HeaderedTextBlock",
         "Type": "HeaderedTextBlockPage",
+        "Subcategory": "Layout",
         "About": "The HeaderedTextBlock control is designed to provide a header for read only text. This control is useful for displaying read only forms.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock",
         "XamlCodeFile": "HeaderedTextBlockCode.bind",
@@ -90,6 +99,7 @@
       {
         "Name": "MasterDetailsView",
         "Type": "MasterDetailsViewPage",
+        "Subcategory": "Layout",
         "About": "The MasterDetailsView control allows the user to implement the Master/Details design pattern.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView",
         "XamlCodeFile": "MasterDetailsView.bind",
@@ -100,6 +110,7 @@
       {
         "Name": "MarkdownTextBlock",
         "Type": "MarkdownTextBlockPage",
+        "Subcategory": "Input",
         "About": "An efficient and extensible control that can parse and render markdown.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock",
         "XamlCodeFile": "MarkdownTextBlock.bind",
@@ -110,6 +121,7 @@
       {
         "Name": "RadialGauge",
         "Type": "RadialGaugePage",
+        "Subcategory": "Status and Info",
         "About": "The radial gauge displays a value within a range, using a needle on a circular face.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge",
         "XamlCodeFile": "RadialGaugeCode.bind",
@@ -119,6 +131,7 @@
       {
         "Name": "RadialProgressBar",
         "Type": "RadialProgressBarPage",
+        "Subcategory": "Status and Info",
         "About": "The radial progress bar displays progress as a circle getting filled.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar",
         "XamlCodeFile": "RadialProgressBarCode.bind",
@@ -128,6 +141,7 @@
       {
         "Name": "RotatorTile",
         "Type": "RotatorTilePage",
+        "Subcategory": "Media",
         "About": "RotatorTile is an ItemsControl that rotates through a set of items one-by-one. It enables you to show multiple items of data in a live-tile like way.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/RotatorTile",
         "XamlCodeFile": "RotatorTileCode.bind",
@@ -137,6 +151,7 @@
       {
         "Name": "BladeView",
         "Type": "BladePage",
+        "Subcategory": "Layout",
         "About": "BladeView provides a horizontal collection of blades for master-detail scenarios. The control is based on the experience demonstrated by the Azure Portal.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/BladeView",
         "XamlCodeFile": "BladeCode.bind",
@@ -146,6 +161,7 @@
       {
         "Name": "ScrollHeader",
         "Type": "ScrollHeaderPage",
+        "Subcategory": "Layout",
         "About": "A UI control that works as a ListView or GridView header control with quick return, sticky and fade behavior.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/ScrollHeader",
         "XamlCodeFile": "ScrollHeaderCode.bind",
@@ -155,6 +171,7 @@
       {
         "Name": "GridSplitter",
         "Type": "GridSplitterPage",
+        "Subcategory": "Layout",
         "About": "GridSplitter represents the control that redistributes space between columns or rows of a Grid control.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter",
         "XamlCodeFile": "GridSplitter.bind",
@@ -164,6 +181,7 @@
       {
         "Name": "DropShadowPanel",
         "Type": "DropShadowPanelPage",
+        "Subcategory": "Media",
         "About": "DropShadowPanel contol allows the creation of a DropShadow for any Xaml FrameworkElement in markup.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel",
         "XamlCodeFile": "DropShadowPanelXaml.bind",
@@ -174,6 +192,7 @@
       {
         "Name": "Loading",
         "Type": "LoadingPage",
+        "Subcategory": "Status and Info",
         "About": "LoadingControl helps to show content with animation to the user while the app is doing some calculation.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/Loading",
         "XamlCodeFile": "LoadingCode.bind",
@@ -183,6 +202,7 @@
       {
         "Name": "Expander",
         "Type": "ExpanderPage",
+        "Subcategory": "Layout",
         "About": "Expander control allows user to show/hide content based on a boolean state.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/Expander",
         "XamlCodeFile": "ExpanderXaml.bind",
@@ -192,6 +212,7 @@
       {
         "Name": "TileControl",
         "Type": "TileControlPage",
+        "Subcategory": "Layout",
         "About": "A ContentControl that show an image repeated many times.The control can be synchronized with a Scrollviewer and animated easily",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/TileControl",
         "XamlCodeFile": "TileControl.bind",
@@ -201,6 +222,7 @@
       {
         "Name": "WrapPanel",
         "Type": "WrapPanelPage",
+        "Subcategory": "Layout",
         "About": "The WrapPanel Control positions child elements in sequential position from left to right, breaking content to the next line at the edge of the containing box.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel",
         "XamlCodeFile": "WrapPanel.bind",
@@ -210,6 +232,7 @@
       {
         "Name": "OrbitView",
         "Type": "OrbitViewPage",
+        "Subcategory": "Layout",
         "About": "The OrbitView Control positions items in a circle around a center element and supports orbits and anchors.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/OrbitView",
         "XamlCodeFile": "OrbitViewXaml.bind",
@@ -219,6 +242,7 @@
       {
         "Name": "Menu",
         "Type": "MenuPage",
+        "Subcategory": "Menus and Toolbars",
         "About": "This control will be removed in a future major release. Please use the MenuBar control from the WinUI Library instead.",
         "BadgeUpdateVersionRequired": "DEPRECATED",
         "DeprecatedWarning": "This control will be removed in a future major release. Please use the MenuBar control from the WinUI Library instead.",
@@ -230,6 +254,7 @@
       {
         "Name": "InAppNotification",
         "Type": "InAppNotificationPage",
+        "Subcategory": "Status and Info",
         "About": "The In App Notification control offers the ability to show local notifications in your application.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification",
         "XamlCodeFile": "InAppNotificationXaml.bind",
@@ -240,6 +265,7 @@
       {
         "Name": "DockPanel",
         "Type": "DockPanelPage",
+        "Subcategory": "Layout",
         "About": "Defines an area where you can arrange child elements either horizontally or vertically, relative to each other.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/DockPanel",
         "XamlCodeFile": "DockPanel.bind",
@@ -249,6 +275,7 @@
       {
         "Name": "HeaderedContentControl",
         "Type": "HeaderedContentControlPage",
+        "Subcategory": "Layout",
         "About": "Allows content to be displayed with a specified header.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl",
         "XamlCodeFile": "HeaderedContentControlXaml.bind",
@@ -258,6 +285,7 @@
       {
         "Name": "HeaderedItemsControl",
         "Type": "HeaderedItemsControlPage",
+        "Subcategory": "Layout",
         "About": "Allows items to be displayed with a specified header.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedItemsControl",
         "XamlCodeFile": "HeaderedItemsControlXaml.bind",
@@ -267,6 +295,7 @@
       {
         "Name": "StaggeredPanel",
         "Type": "StaggeredPanelPage",
+        "Subcategory": "Layout",
         "About": "The StaggeredPanel allows for layout of items in a column approach where an item will be added to whichever column has used the least amount of space.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel",
         "XamlCodeFile": "StaggeredPanel.bind",
@@ -276,6 +305,7 @@
       {
         "Name": "LayoutTransformControl",
         "Type": "LayoutTransformControlPage",
+        "Subcategory": "Layout",
         "About": "Control that implements support for transformations as if applied by LayoutTransform.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/LayoutTransformControl",
         "XamlCodeFile": "LayoutTransformControlXaml.bind",
@@ -285,6 +315,7 @@
       {
         "Name": "CameraPreview",
         "Type": "CameraPreviewPage",
+        "Subcategory": "Media",
         "About": "Allows to easily preview video from available camera frame source groups and also get realtime video frames/ software bitmaps from the selected source.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/CameraPreview",
         "XamlCodeFile": "CameraPreviewXaml.bind",
@@ -297,6 +328,7 @@
       {
         "Name": "InfiniteCanvas",
         "Type": "InfiniteCanvasPage",
+        "Subcategory": "Media",
         "About": "InfiniteCanvas is a canvas that supports Infinite Scrolling, Ink, Text, Format Text, Zoom in/out, Redo, Undo, Export canvas data, Import canvas data.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/InfiniteCanvas",
         "XamlCodeFile": "InfiniteCanvas.bind",
@@ -308,6 +340,7 @@
       {
         "Name": "RemoteDevicePicker",
         "Type": "RemoteDevicePickerControlPage",
+        "Subcategory": "Input",
         "About": "Remote Device Picker Control for Project Rome.",
         "CodeUrl": "https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/RemoteDevicePicker",
         "CodeFile": "RemoteDevicePickerCode.bind",
@@ -317,12 +350,94 @@
       {
         "Name": "ImageCropper",
         "Type": "ImageCropperPage",
+        "Subcategory": "Input",
         "About": "ImageCropper control allows user to crop image freely.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper",
         "XamlCodeFile": "ImageCropperXaml.bind",
         "CodeFile": "ImageCropperCode.bind",
         "Icon": "/SamplePages/ImageCropper/ImageCropper.png",
         "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/controls/ImageCropper.md"
+      },
+      {
+        "Name": "AadLogin",
+        "Type": "AadLoginPage",
+        "Subcategory": "Graph",
+        "About": "The AadLogin Control leverages existing .NET login libraries to support basic AAD sign-in processes for Microsoft Graph.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/AadLogin",
+        "CodeFile": "AadLoginCode.bind",
+        "XamlCodeFile": "AadLoginXaml.bind",
+        "Icon": "/SamplePages/AadLogin/AadLogin.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/AadLogin.md"
+      },
+      {
+        "Name": "ProfileCard",
+        "Type": "ProfileCardPage",
+        "Subcategory": "Graph",
+        "About": "The ProfileCard Control is a simple way to display a user in multiple different formats and mixes of name/image/e-mail.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/ProfileCard",
+        "XamlCodeFile": "ProfileCardXaml.bind",
+        "Icon": "/SamplePages/ProfileCard/ProfileCard.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/ProfileCard.md"
+      },
+      {
+        "Name": "PeoplePicker",
+        "Type": "PeoplePickerPage",
+        "Subcategory": "Graph",
+        "About": "The PeoplePicker Control is a simple control that allows for selection of one or more users from an organizational AD.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/PeoplePicker",
+        "XamlCodeFile": "PeoplePickerXaml.bind",
+        "Icon": "/SamplePages/PeoplePicker/PeoplePicker.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/PeoplePicker.md"
+      },
+      {
+        "Name": "SharePointFileList",
+        "Type": "SharePointFileListPage",
+        "Subcategory": "Graph",
+        "About": "The SharePointFileList Control displays a simple list of SharePoint Files.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/SharePointFileList",
+        "CodeFile": "SharePointFileListCode.bind",
+        "XamlCodeFile": "SharePointFileListXaml.bind",
+        "Icon": "/SamplePages/SharePointFileList/SharePointFileList.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/SharePointFileList.md"
+      },
+      {
+        "Name": "PowerBIEmbedded",
+        "Type": "PowerBIEmbeddedPage",
+        "Subcategory": "Graph",
+        "About": "The PowerBI embedded control is a simple wrapper to an IFRAME for a PowerBI embed.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/PowerBIEmbedded",
+        "Icon": "/SamplePages/PowerBIEmbedded/PowerBIEmbedded.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/PowerBIEmbedded.md"
+      },
+      {
+        "Name": "PlannerTaskList",
+        "Type": "PlannerTaskListPage",
+        "Subcategory": "Graph",
+        "About": "The PlannerTaskList Control displays a simple list of Planner tasks.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/PlannerTaskList",
+        "XamlCodeFile": "PlannerTaskListXaml.bind",
+        "Icon": "/SamplePages/PlannerTaskList/PlannerTaskList.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/PlannerTaskList.md"
+      },
+      {
+        "Name": "AlignmentGrid",
+        "Type": "AlignmentGridPage",
+        "Subcategory": "Developer",
+        "About": "AlignmentGrid is used to display a grid to help aligning controls.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.DeveloperTools/AlignmentGrid",
+        "XamlCodeFile": "AlignmentGridXaml.bind",
+        "Icon": "/SamplePages/AlignmentGrid/AlignmentGrid.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/developer-tools/AlignmentGrid.md"
+      },
+      {
+        "Name": "FocusTracker",
+        "Type": "FocusTrackerPage",
+        "Subcategory": "Developer",
+        "About": "FocusTracker can be used to display information about the current focused XAML element.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.DeveloperTools/FocusTracker",
+        "XamlCodeFile": "FocusTrackerXaml.bind",
+        "Icon": "/SamplePages/FocusTracker/FocusTracker.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/developer-tools/FocusTracker.md"
       }
     ]
   },
@@ -333,6 +448,7 @@
       {
         "Name": "Fade",
         "Type": "FadeBehaviorPage",
+        "Subcategory": "Behavior",
         "About": "Opacity of XAML elements using composition",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors",
         "CodeFile": "FadeBehaviorCode.bind",
@@ -343,6 +459,7 @@
       {
         "Name": "Scale",
         "Type": "ScaleBehaviorPage",
+        "Subcategory": "Behavior",
         "About": "Scale of XAML elements using composition",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors",
         "CodeFile": "ScaleBehaviorCode.bind",
@@ -353,6 +470,7 @@
       {
         "Name": "Offset",
         "Type": "OffsetBehaviorPage",
+        "Subcategory": "Behavior",
         "About": "Offset of XAML elements using composition",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors",
         "CodeFile": "OffsetBehaviorCode.bind",
@@ -363,6 +481,7 @@
       {
         "Name": "Rotate",
         "Type": "RotateBehaviorPage",
+        "Subcategory": "Behavior",
         "About": "Rotation on XAML elements using composition",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors",
         "CodeFile": "RotateBehaviorCode.bind",
@@ -373,6 +492,7 @@
       {
         "Name": "Blur",
         "Type": "BlurBehaviorPage",
+        "Subcategory": "Behavior",
         "About": "Blur XAML elements using composition",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors",
         "CodeFile": "BlurBehaviorCode.bind",
@@ -384,6 +504,7 @@
       {
         "Name": "Saturation",
         "Type": "SaturationBehaviorPage",
+        "Subcategory": "Behavior",
         "About": "Saturate XAML elements using composition",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors",
         "CodeFile": "SaturationBehaviorCode.bind",
@@ -395,6 +516,7 @@
       {
         "Name": "Light",
         "Type": "LightBehaviorPage",
+        "Subcategory": "Behavior",
         "About": "The Light effect will be removed in a future major release",
         "BadgeUpdateVersionRequired": "DEPRECATED",
         "DeprecatedWarning": "The Light effect will be removed in a future major release",
@@ -407,6 +529,7 @@
       {
         "Name": "FadeHeader",
         "Type": "FadeHeaderBehaviorPage",
+        "Subcategory": "Effect",
         "About": "Fade ListView and GridView Headers",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors",
         "CodeFile": "FadeHeaderBehaviorCode.bind",
@@ -417,6 +540,7 @@
       {
         "Name": "ReorderGridAnimation",
         "Type": "ReorderGridPage",
+        "Subcategory": "Effect",
         "About": "Animates items of a grid when the size changes",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations",
         "XamlCodeFile": "ReorderGrid.bind",
@@ -427,6 +551,7 @@
       {
         "Name": "Implicit Animations",
         "Type": "ImplicitAnimationsPage",
+        "Subcategory": "Effect",
         "About": "Attached properties to enable Implicit animations (including Show and Hide animations) through XAML",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations",
         "Icon": "/SamplePages/Implicit Animations/ImplicitAnimations.png",
@@ -437,6 +562,7 @@
       {
         "Name": "Connected Animations",
         "Type": "ConnectedAnimationsPage",
+        "Subcategory": "Effect",
         "About": "Attached properties to enable Connected animations through XAML",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations",
         "XamlCodeFile": "ConnectedAnimationsCode.bind",
@@ -498,67 +624,6 @@
         "Icon": "/Assets/Helpers.png",
         "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/controls/wpf-winforms/MapControl.md",
         "CodeUrl": "https://github.com/windows-toolkit/Microsoft.Toolkit.Win32"
-      }
-    ]
-  },
-  {
-    "Name": "Graph Controls",
-    "Icon": "Icons/Foundation.png",
-    "Samples": [
-      {
-        "Name": "AadLogin",
-        "Type": "AadLoginPage",
-        "About": "The AadLogin Control leverages existing .NET login libraries to support basic AAD sign-in processes for Microsoft Graph.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/AadLogin",
-        "CodeFile": "AadLoginCode.bind",
-        "XamlCodeFile": "AadLoginXaml.bind",
-        "Icon": "/SamplePages/AadLogin/AadLogin.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/AadLogin.md"
-      },
-      {
-        "Name": "ProfileCard",
-        "Type": "ProfileCardPage",
-        "About": "The ProfileCard Control is a simple way to display a user in multiple different formats and mixes of name/image/e-mail.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/ProfileCard",
-        "XamlCodeFile": "ProfileCardXaml.bind",
-        "Icon": "/SamplePages/ProfileCard/ProfileCard.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/ProfileCard.md"
-      },
-      {
-        "Name": "PeoplePicker",
-        "Type": "PeoplePickerPage",
-        "About": "The PeoplePicker Control is a simple control that allows for selection of one or more users from an organizational AD.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/PeoplePicker",
-        "XamlCodeFile": "PeoplePickerXaml.bind",
-        "Icon": "/SamplePages/PeoplePicker/PeoplePicker.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/PeoplePicker.md"
-      },
-      {
-        "Name": "SharePointFileList",
-        "Type": "SharePointFileListPage",
-        "About": "The SharePointFileList Control displays a simple list of SharePoint Files.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/SharePointFileList",
-        "CodeFile": "SharePointFileListCode.bind",
-        "XamlCodeFile": "SharePointFileListXaml.bind",
-        "Icon": "/SamplePages/SharePointFileList/SharePointFileList.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/SharePointFileList.md"
-      },
-      {
-        "Name": "PowerBIEmbedded",
-        "Type": "PowerBIEmbeddedPage",
-        "About": "The PowerBI embedded control is a simple wrapper to an IFRAME for a PowerBI embed.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/PowerBIEmbedded",
-        "Icon": "/SamplePages/PowerBIEmbedded/PowerBIEmbedded.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/PowerBIEmbedded.md"
-      },
-      {
-        "Name": "PlannerTaskList",
-        "Type": "PlannerTaskListPage",
-        "About": "The PlannerTaskList Control displays a simple list of Planner tasks.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Graph/PlannerTaskList",
-        "XamlCodeFile": "PlannerTaskListXaml.bind",
-        "Icon": "/SamplePages/PlannerTaskList/PlannerTaskList.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/graph/PlannerTaskList.md"
       }
     ]
   },
@@ -632,48 +697,13 @@
     ]
   },
   {
-    "Name": "Notifications",
-    "Icon": "Icons/Notifications.png",
-    "Samples": [
-      {
-        "Name": "LiveTile",
-        "Type": "LiveTilePage",
-        "About": "This shows how to update a Live Tile with a rich Adaptive notification.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Notifications",
-        "CodeFile": "LiveTileCode.bind",
-        "JavaScriptCodeFile": "LiveTileCodeJavaScript.bind",
-        "Icon": "/SamplePages/LiveTile/LiveTile.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/notifications/NotificationsOverview.md"
-      },
-      {
-        "Name": "Toast",
-        "Type": "ToastPage",
-        "About": "This shows how to send a Toast notification.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Notifications",
-        "CodeFile": "ToastCode.bind",
-        "JavaScriptCodeFile": "ToastCodeJavaScript.bind",
-        "Icon": "/SamplePages/Toast/Toast.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/notifications/NotificationsOverview.md"
-      },
-      {
-        "Name": "WeatherLiveTileAndToast",
-        "Type": "WeatherLiveTileAndToastPage",
-        "About": "This shows how to send a Weather Live Tile and Toast notification, displaying the forecast.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Notifications",
-        "CodeFile": "WeatherLiveTileAndToastCode.bind",
-        "JavaScriptCodeFile": "WeatherLiveTileAndToastCodeJavaScript.bind",
-        "Icon": "/SamplePages/WeatherLiveTileAndToast/WeatherLiveTileAndToast.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/notifications/NotificationsOverview.md"
-      }
-    ]
-  },
-  {
     "Name": "Helpers",
     "Icon": "Icons/Helpers.png",
     "Samples": [
       {
         "Name": "ImageCache",
         "Type": "ImageCachePage",
+        "Subcategory": "Data",
         "About": "The ImageCache allows persistence of images with an option to use in-memory storage.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs",
         "CodeFile": "ImageCacheCode.bind",
@@ -684,6 +714,7 @@
       {
         "Name": "Object Storage",
         "Type": "ObjectStoragePage",
+        "Subcategory": "Systems",
         "About": "The Object Storage helper allows you to easily read and save objects in your application, both locally or on every device (roaming).",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage",
         "CodeFile": "ObjectStorageCode.bind",
@@ -693,6 +724,7 @@
       {
         "Name": "Incremental Loading Collection",
         "Type": "IncrementalLoadingCollectionPage",
+        "Subcategory": "Data",
         "About": "Allows to create collections that can be loaded incrementally, as user requests more items in the view. This type of collections can be bound to controls like GridView and ListView.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp/IncrementalLoadingCollection",
         "CodeFile": "IncrementalLoadingCollectionCode.bind",
@@ -702,6 +734,7 @@
       {
         "Name": "BackgroundTaskHelper",
         "Type": "BackgroundTaskHelperPage",
+        "Subcategory": "Systems",
         "About": "Allows easy registration and maintenance of background task",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp/Helpers/BackgroundTaskHelper.cs",
         "CodeFile": "BackgroundTaskHelperCode.bind",
@@ -711,6 +744,7 @@
       {
         "Name": "NetworkHelper",
         "Type": "NetworkHelperPage",
+        "Subcategory": "Systems",
         "About": "The NetworkHelper class is used to determine whether the app has Internet, and if it is on a metered Internet connection",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Connectivity/Network",
         "CodeFile": "NetworkHelperCode.bind",
@@ -720,6 +754,7 @@
       {
         "Name": "BluetoothLEHelper",
         "Type": "BluetoothLEHelperPage",
+        "Subcategory": "Systems",
         "About": "The Bluetooth LE helper class is used to connect and interact with bluetooth LE devices.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Connectivity/BluetoothLEHelper",
         "CodeFile": "BluetoothLEHelperCode.bind",
@@ -730,6 +765,7 @@
       {
         "Name": "SystemInformation",
         "Type": "SystemInformationPage",
+        "Subcategory": "Systems",
         "About": "The SystemInformation class provides easy access to some of system/app/device information",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs",
         "CodeFile": "SystemInformationCode.bind",
@@ -739,6 +775,7 @@
       {
         "Name": "PrintHelper",
         "Type": "PrintHelperPage",
+        "Subcategory": "Systems",
         "About": "Allows to easily print XAML controls",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp/Helpers/PrintHelper",
         "CodeFile": "PrintHelperCode.bind",
@@ -749,6 +786,7 @@
       {
         "Name": "DispatcherHelper",
         "Type": "DispatcherHelperPage",
+        "Subcategory": "Developer",
         "About": "Allows easy interaction with Windows Runtime core message dispatcher for multi-threaded scenario (I.E: Run code on UI thread). ",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs",
         "CodeFile": "DispatcherHelperCode.bind",
@@ -758,6 +796,7 @@
       {
         "Name": "AdvancedCollectionView",
         "Type": "AdvancedCollectionViewPage",
+        "Subcategory": "Data",
         "About": "Allows you to easily sort and filter your collections before displaying them.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView",
         "CodeFile": "AdvancedCollectionView.bind",
@@ -767,6 +806,7 @@
       {
         "Name": "CameraHelper",
         "Type": "CameraHelperPage",
+        "Subcategory": "Systems",
         "About": "Allows to easily get camera frame sources available for media capture to preview video and get real time video frames/software bitmaps.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp/Helpers/CameraHelper/CameraHelper.cs",
         "CodeFile": "CameraHelperCode.bind",
@@ -777,6 +817,7 @@
       {
         "Name": "ThemeListener",
         "Type": "ThemeListenerPage",
+        "Subcategory": "Developer",
         "About": "The ThemeListener allows you to keep track of changes to the System Theme.",
         "Icon": "/Assets/Helpers.png",
         "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/helpers/ThemeListener.md"
@@ -784,11 +825,69 @@
       {
         "Name": "RemoteDeviceHelper",
         "Type": "RemoteDeviceHelperPage",
+        "Subcategory": "Systems",
         "About": "Allows you to easily enumerate remote devices ( Project Rome ).",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp/Helpers/RemoteDeviceHelper/RemoteDeviceHelper.cs",
         "CodeFile": "RemoteDeviceHelperCode.bind",
         "Icon": "/SamplePages/RemoteDeviceHelper/RemoteDeviceHelper.png",
         "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/helpers/RemoteDeviceHelper.md"
+      },
+      {
+        "Name": "Markdown Parser",
+        "Type": "MarkdownParserPage",
+        "Subcategory": "Parser",
+        "About": "The Markdown Parser allows you to parse a Markdown String into a Markdown Document, and then Render it with a Markdown Renderer.",
+        "Icon": "/Assets/Helpers.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/parsers/MarkdownParser.md"
+      },
+      {
+        "Name": "RSS Parser",
+        "Type": "RssParserPage",
+        "Subcategory": "Parser",
+        "About": "The RSS Parser allows you to parse an RSS content String into RSS Schema.",
+        "Icon": "/Assets/Helpers.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/parsers/RssParser.md"
+      },
+      {
+        "Name": "LiveTile",
+        "Type": "LiveTilePage",
+        "Subcategory": "Notifications",
+        "About": "This shows how to update a Live Tile with a rich Adaptive notification.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Notifications",
+        "CodeFile": "LiveTileCode.bind",
+        "JavaScriptCodeFile": "LiveTileCodeJavaScript.bind",
+        "Icon": "/SamplePages/LiveTile/LiveTile.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/notifications/NotificationsOverview.md"
+      },
+      {
+        "Name": "Toast",
+        "Type": "ToastPage",
+        "Subcategory": "Notifications",
+        "About": "This shows how to send a Toast notification.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Notifications",
+        "CodeFile": "ToastCode.bind",
+        "JavaScriptCodeFile": "ToastCodeJavaScript.bind",
+        "Icon": "/SamplePages/Toast/Toast.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/notifications/NotificationsOverview.md"
+      },
+      {
+        "Name": "WeatherLiveTileAndToast",
+        "Type": "WeatherLiveTileAndToastPage",
+        "Subcategory": "Notifications",
+        "About": "This shows how to send a Weather Live Tile and Toast notification, displaying the forecast.",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.Notifications",
+        "CodeFile": "WeatherLiveTileAndToastCode.bind",
+        "JavaScriptCodeFile": "WeatherLiveTileAndToastCodeJavaScript.bind",
+        "Icon": "/SamplePages/WeatherLiveTileAndToast/WeatherLiveTileAndToast.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/notifications/NotificationsOverview.md"
+      },
+      {
+        "Name": "PlatformSpecificAnalyzer",
+        "Subcategory": "Developer",
+        "About": "Platform Specific Analyzer is a Roslyn analyzer that analyzes and suggests code fixes to ensure that any version / platform specific API are guarded by correct runtime checks",
+        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer",
+        "Icon": "/Assets/Helpers.png",
+        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/platform-specific/PlatformSpecificAnalyzer.md"
       }
     ]
   },
@@ -977,57 +1076,6 @@
         "Icon": "/SamplePages/OnDevice/OnDevice.png",
         "XamlCodeFile": "OnDeviceXaml.bind",
         "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/extensions/OnDeviceMarkup.md"
-      }
-    ]
-  },
-  {
-    "Name": "Parsers",
-    "Icon": "Icons/Helpers.png",
-    "Samples": [
-      {
-        "Name": "Markdown Parser",
-        "Type": "MarkdownParserPage",
-        "About": "The Markdown Parser allows you to parse a Markdown String into a Markdown Document, and then Render it with a Markdown Renderer.",
-        "Icon": "/Assets/Helpers.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/parsers/MarkdownParser.md"
-      },
-      {
-        "Name": "RSS Parser",
-        "Type": "RssParserPage",
-        "About": "The RSS Parser allows you to parse an RSS content String into RSS Schema.",
-        "Icon": "/Assets/Helpers.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/parsers/RssParser.md"
-      }
-    ]
-  },
-  {
-    "Name": "Developer tools",
-    "Icon": "Icons/DeveloperTools.png",
-    "Samples": [
-      {
-        "Name": "AlignmentGrid",
-        "Type": "AlignmentGridPage",
-        "About": "AlignmentGrid is used to display a grid to help aligning controls.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.DeveloperTools/AlignmentGrid",
-        "XamlCodeFile": "AlignmentGridXaml.bind",
-        "Icon": "/SamplePages/AlignmentGrid/AlignmentGrid.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/developer-tools/AlignmentGrid.md"
-      },
-      {
-        "Name": "FocusTracker",
-        "Type": "FocusTrackerPage",
-        "About": "FocusTracker can be used to display information about the current focused XAML element.",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.DeveloperTools/FocusTracker",
-        "XamlCodeFile": "FocusTrackerXaml.bind",
-        "Icon": "/SamplePages/FocusTracker/FocusTracker.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/developer-tools/FocusTracker.md"
-      },
-      {
-        "Name": "PlatformSpecificAnalyzer",
-        "About": "Platform Specific Analyzer is a Roslyn analyzer that analyzes and suggests code fixes to ensure that any version / platform specific API are guarded by correct runtime checks",
-        "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer",
-        "Icon": "/Assets/Helpers.png",
-        "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/platform-specific/PlatformSpecificAnalyzer.md"
       }
     ]
   },

--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.SamplePicker.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.SamplePicker.cs
@@ -14,6 +14,7 @@ using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media.Animation;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp
@@ -22,6 +23,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
     {
         private Sample _currentSample;
         private SampleCategory _selectedCategory;
+
+        public CollectionViewSource SampleView { get; } = new CollectionViewSource();
 
         private Sample CurrentSample
         {
@@ -62,7 +65,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             var noop = SetNavViewSelection();
         }
 
-        private async void ShowSamplePicker(Sample[] samples = null)
+        private async void ShowSamplePicker(Sample[] samples = null, bool group = false)
         {
             if (samples == null && _currentSample != null)
             {
@@ -91,7 +94,20 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 return;
             }
 
-            SamplePickerGridView.ItemsSource = samples;
+            var groups = samples.GroupBy(sample => sample.Subcategory);
+
+            if (group && groups.Count() > 1)
+            {
+                SampleView.IsSourceGrouped = true;
+                SampleView.Source = groups.OrderBy(g => g.Key);
+            }
+            else
+            {
+                SampleView.IsSourceGrouped = false;
+                SampleView.Source = samples;
+            }
+
+            SamplePickerGridView.ItemsSource = SampleView.View;
 
             if (_currentSample != null && samples.Contains(_currentSample))
             {
@@ -118,7 +134,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 else
                 {
                     _selectedCategory = category;
-                    ShowSamplePicker(category.Samples);
+                    ShowSamplePicker(category.Samples, true);
                 }
             }
             else if (args.IsSettingsInvoked)

--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.Search.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.Search.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 return;
             }
 
-            var samples = (await Samples.FindSamplesByName(SearchBox.Text)).OrderBy(s => s.Name).ToArray();
+            var samples = (await Samples.FindSample(SearchBox.Text)).OrderBy(s => s.Name).ToArray();
             if (samples.Count() > 0)
             {
                 ShowSamplePicker(samples);

--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml
@@ -98,6 +98,15 @@
                                   ItemClick="SamplePickerGridView_ItemClick"
                                   ChoosingItemContainer="SamplePickerGridView_ChoosingItemContainer"
                                   Transitions="{x:Null}">
+                            <GridView.GroupStyle>
+                                <GroupStyle>
+                                    <GroupStyle.HeaderTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Key}"/>
+                                        </DataTemplate>
+                                    </GroupStyle.HeaderTemplate>
+                                </GroupStyle>
+                            </GridView.GroupStyle>
                             <animations:Implicit.ShowAnimations>
                                 <animations:OpacityAnimation From="0" To="1" Duration="0:0:0.3" Delay="0:0:0.2" SetInitialValueBeforeDelay="True"></animations:OpacityAnimation>
                             </animations:Implicit.ShowAnimations>


### PR DESCRIPTION
Issue: #2688 

## PR Type
What kind of change does this PR introduce?
- Sample app changes 

## What is the current behavior?
1. Sample app has many categories (12):
![image](https://user-images.githubusercontent.com/24302614/49090622-ee87a400-f212-11e8-85fb-34af6068ec5b.png)

2. Controls category is pretty large (and gets bigger with condensing step done as part of this review):
![image](https://user-images.githubusercontent.com/24302614/52551054-bf9fb980-2d8f-11e9-8df5-fc795a76b28f.png)

3. Search only worked by name:
![image](https://user-images.githubusercontent.com/24302614/52551116-0097ce00-2d90-11e9-83c1-2372e935e982.png)

## What is the new behavior?
1. Condense categories to 8:
![image](https://user-images.githubusercontent.com/24302614/52551007-7f403b80-2d8f-11e9-843a-88468cf58b1f.png)

2. Add Subcategories to certain categories to allow for more ordered grouping to aid in searching:
![image](https://user-images.githubusercontent.com/24302614/52551084-e4942c80-2d8f-11e9-9d98-03e9be78a77d.png)

3. Search looks at name, description and subcategory:
![image](https://user-images.githubusercontent.com/24302614/52551159-1c02d900-2d90-11e9-847d-d1e89015dfa7.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
Adds a new property to the `Sample` object and modifies `samples.json` to add it and condense some categories.  Adds a `CollectionViewSource` and grouping step in the method which retrieves the samples when the menu is opened.  Modifies search to look at more fields.

Named most of Control categories off of XAML Control Gallery categories.  Happy for input on other categories added to Animations and Helpers categories.