### PR TITLE
Add Guard and Timer to supplement EnumerationCompleted event which is missing on RS3

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/RemoteDeviceHelper/RemoteDeviceHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/RemoteDeviceHelper/RemoteDeviceHelper.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Windows.Foundation.Metadata;
 using Windows.System.RemoteSystems;
+using Windows.System.Threading;
 
 namespace Microsoft.Toolkit.Uwp.Helpers
 {
@@ -87,7 +89,19 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 _remoteSystemWatcher.RemoteSystemAdded += RemoteSystemWatcher_RemoteSystemAdded;
                 _remoteSystemWatcher.RemoteSystemRemoved += RemoteSystemWatcher_RemoteSystemRemoved;
                 _remoteSystemWatcher.RemoteSystemUpdated += RemoteSystemWatcher_RemoteSystemUpdated;
-                _remoteSystemWatcher.EnumerationCompleted += RemoteSystemWatcher_EnumerationCompleted;
+                if (ApiInformation.IsEventPresent("Windows.System.RemoteSystems.RemoteSystemWatcher", "EnumerationCompleted"))
+                {
+                    _remoteSystemWatcher.EnumerationCompleted += RemoteSystemWatcher_EnumerationCompleted;
+                }
+                else
+                {
+                    ThreadPoolTimer.CreateTimer(
+                        (e) =>
+                        {
+                            RemoteSystemWatcher_EnumerationCompleted(_remoteSystemWatcher, null);
+                        }, TimeSpan.FromSeconds(2));
+                }
+
                 _remoteSystemWatcher.Start();
             }
         }


### PR DESCRIPTION
Related to PR #2126

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix

## What is the current behavior?
IRemoteSystemWatcher2 interface doesn't exist on RS3 so we can't use EnumerationCompleted event there.

## What is the new behavior?
Create a timer to stop the watcher after a couple of seconds when that event is missing.

We can remove this guard in 6.0 when we up the min version.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
