### PR TITLE
Add null check for Content property before applying automation peer

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Opened?.Invoke(this, EventArgs.Empty);
             SetValue(AutomationProperties.NameProperty, StringExtensions.GetLocalized("WindowsCommunityToolkit_InAppNotification_NameProperty", "/Microsoft.Toolkit.Uwp.UI.Controls/Resources"));
             peer = FrameworkElementAutomationPeer.CreatePeerForElement(ContentTemplateRoot);
-            if (Content != null && Content.GetType() == typeof(string))
+            if (Content?.GetType() == typeof(string))
             {
                 AutomateTextNotification(Content.ToString());
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -7,7 +7,6 @@ using Microsoft.Toolkit.Uwp.Extensions;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
-using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
@@ -55,7 +54,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Opened?.Invoke(this, EventArgs.Empty);
             SetValue(AutomationProperties.NameProperty, StringExtensions.GetLocalized("WindowsCommunityToolkit_InAppNotification_NameProperty", "/Microsoft.Toolkit.Uwp.UI.Controls/Resources"));
             peer = FrameworkElementAutomationPeer.CreatePeerForElement(ContentTemplateRoot);
-            if (Content.GetType() == typeof(string))
+            if (Content != null && Content.GetType() == typeof(string))
             {
                 AutomateTextNotification(Content.ToString());
             }


### PR DESCRIPTION
Issue: #2805 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When creating a notification without setting the content (e.g. using a ContentTemplate), the app crashes.

## What is the new behavior?
The app no longer crashes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes