### PR TITLE
Fix HeaderedContentControl throws ArgumentException

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
@@ -119,7 +119,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (GetTemplateChild(PartHeaderPresenter) is FrameworkElement headerPresenter)
             {
-                headerPresenter.Visibility = Header != null
+                var isEmptyString = false;
+                if (Header is string headerText)
+                {
+                    isEmptyString = string.IsNullOrEmpty(headerText);
+                }
+
+                headerPresenter.Visibility = (Header != null && isEmptyString == false)
                     ? Visibility.Visible
                     : Visibility.Collapsed;
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
@@ -119,15 +119,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (GetTemplateChild(PartHeaderPresenter) is FrameworkElement headerPresenter)
             {
-                var isEmptyString = false;
                 if (Header is string headerText)
                 {
-                    isEmptyString = string.IsNullOrEmpty(headerText);
+                    headerPresenter.Visibility = string.IsNullOrEmpty(headerText)
+                        ? Visibility.Collapsed
+                        : Visibility.Visible;
                 }
-
-                headerPresenter.Visibility = (Header != null && isEmptyString == false)
-                    ? Visibility.Visible
-                    : Visibility.Collapsed;
+                else
+                {
+                    headerPresenter.Visibility = Header != null
+                        ? Visibility.Visible
+                        : Visibility.Collapsed;
+                }
             }
         }
     }


### PR DESCRIPTION
Issue: #2822
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Hide HeaderPresenter when Header is null.

## What is the new behavior?
Hide headerPresenter when Header is null or an empty string.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
