### PR TITLE
Make StaggeredPanel sensitive to HorizontalContentAlignment of children

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             SetHeaderVisibility();
+            SetOrientation();
         }
 
         /// <summary>
@@ -100,12 +101,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnOrientationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var control = (HeaderedContentControl)d;
-
-            var orientation = control.Orientation == Orientation.Vertical
-                ? nameof(Orientation.Vertical)
-                : nameof(Orientation.Horizontal);
-
-            VisualStateManager.GoToState(control, orientation, true);
+            control.SetOrientation();
         }
 
         private static void OnHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -123,6 +119,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     ? Visibility.Visible
                     : Visibility.Collapsed;
             }
+        }
+        
+        private void SetOrientation()
+        {
+            var orientation = this.Orientation == Orientation.Vertical
+                ? nameof(Orientation.Vertical)
+                : nameof(Orientation.Horizontal);
+            VisualStateManager.GoToState(this, orientation, true);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             SetHeaderVisibility();
-            SetOrientation();
         }
 
         /// <summary>
@@ -101,7 +100,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnOrientationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var control = (HeaderedContentControl)d;
-            control.SetOrientation();
+
+            var orientation = control.Orientation == Orientation.Vertical
+                ? nameof(Orientation.Vertical)
+                : nameof(Orientation.Horizontal);
+
+            VisualStateManager.GoToState(control, orientation, true);
         }
 
         private static void OnHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -119,14 +123,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     ? Visibility.Visible
                     : Visibility.Collapsed;
             }
-        }
-        
-        private void SetOrientation()
-        {
-            var orientation = this.Orientation == Orientation.Vertical
-                ? nameof(Orientation.Vertical)
-                : nameof(Orientation.Horizontal);
-            VisualStateManager.GoToState(this, orientation, true);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 var child = Children[i];
                 var elementSize = child.DesiredSize;
+
                 HorizontalAlignment childHorizontalAlignment = HorizontalAlignment.Left;
                 if (child is ContentControl contentControl)
                 {
@@ -137,7 +138,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     elementHeight = elementHeight * differencePercentage;
                     elementWidth = _columnWidth;
                 }
-                
+
                 double finalHorizontalOffset = horizontalOffset + (_columnWidth * columnIndex);
                 if (childHorizontalAlignment == HorizontalAlignment.Right)
                 {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
@@ -124,32 +124,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 var child = Children[i];
                 var elementSize = child.DesiredSize;
 
-                HorizontalAlignment childHorizontalAlignment = HorizontalAlignment.Left;
-                if (child is ContentControl contentControl)
-                {
-                    childHorizontalAlignment = contentControl.HorizontalContentAlignment;
-                }
-
-                double elementWidth = childHorizontalAlignment == HorizontalAlignment.Stretch ? _columnWidth : elementSize.Width;
                 double elementHeight = elementSize.Height;
-                if (elementWidth > _columnWidth)
-                {
-                    double differencePercentage = _columnWidth / elementWidth;
-                    elementHeight = elementHeight * differencePercentage;
-                    elementWidth = _columnWidth;
-                }
 
-                double finalHorizontalOffset = horizontalOffset + (_columnWidth * columnIndex);
-                if (childHorizontalAlignment == HorizontalAlignment.Right)
-                {
-                    finalHorizontalOffset += _columnWidth - elementSize.Width;
-                }
-                else if (childHorizontalAlignment == HorizontalAlignment.Center)
-                {
-                    finalHorizontalOffset += (_columnWidth - elementSize.Width) / 2;
-                }
-
-                Rect bounds = new Rect(finalHorizontalOffset, columnHeights[columnIndex] + verticalOffset, elementWidth, elementHeight);
+                Rect bounds = new Rect(horizontalOffset + (_columnWidth * columnIndex), columnHeights[columnIndex] + verticalOffset, _columnWidth, elementHeight);
                 child.Arrange(bounds);
 
                 columnHeights[columnIndex] += elementSize.Height;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
@@ -123,8 +123,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 var child = Children[i];
                 var elementSize = child.DesiredSize;
+                
+                HorizontalAlignment childHorizontalAlignment = HorizontalAlignment.Left;
+                if(child is ContentControl contentControl)
+                {
+                    childHorizontalAlignment = contentControl.HorizontalContentAlignment;
+                }
 
-                double elementWidth = elementSize.Width;
+                double elementWidth = childHorizontalAlignment == HorizontalAlignment.Stretch ? _columnWidth : elementSize.Width;
                 double elementHeight = elementSize.Height;
                 if (elementWidth > _columnWidth)
                 {
@@ -132,8 +138,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     elementHeight = elementHeight * differencePercentage;
                     elementWidth = _columnWidth;
                 }
+                
+                double finalHorizontalOffset = horizontalOffset + (_columnWidth * columnIndex);
+                if(childHorizontalAlignment == HorizontalAlignment.Right)
+                {
+                    finalHorizontalOffset += _columnWidth - elementSize.Width;
+                }
+                else if(childHorizontalAlignment == HorizontalAlignment.Center)
+                {
+                    finalHorizontalOffset += (_columnWidth - elementSize.Width) / 2;
+                }
 
-                Rect bounds = new Rect(horizontalOffset + (_columnWidth * columnIndex), columnHeights[columnIndex] + verticalOffset, elementWidth, elementHeight);
+                Rect bounds = new Rect(finalHorizontalOffset, columnHeights[columnIndex] + verticalOffset, elementWidth, elementHeight);
                 child.Arrange(bounds);
 
                 columnHeights[columnIndex] += elementSize.Height;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/StaggeredPanel/StaggeredPanel.cs
@@ -123,9 +123,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 var child = Children[i];
                 var elementSize = child.DesiredSize;
-                
                 HorizontalAlignment childHorizontalAlignment = HorizontalAlignment.Left;
-                if(child is ContentControl contentControl)
+                if (child is ContentControl contentControl)
                 {
                     childHorizontalAlignment = contentControl.HorizontalContentAlignment;
                 }
@@ -140,11 +139,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
                 
                 double finalHorizontalOffset = horizontalOffset + (_columnWidth * columnIndex);
-                if(childHorizontalAlignment == HorizontalAlignment.Right)
+                if (childHorizontalAlignment == HorizontalAlignment.Right)
                 {
                     finalHorizontalOffset += _columnWidth - elementSize.Width;
                 }
-                else if(childHorizontalAlignment == HorizontalAlignment.Center)
+                else if (childHorizontalAlignment == HorizontalAlignment.Center)
                 {
                     finalHorizontalOffset += (_columnWidth - elementSize.Width) / 2;
                 }


### PR DESCRIPTION
Issue: #
#2825

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See #2825

## What is the new behavior?
The alignment of the children of StaggeredPanel will changed based on the HorizontalContentAlignment property set in the child.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
