### PR TITLE
Corrected TextBoxRegex IsValid Set() to update the correct DependencyProperty

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/TextBoxRegEx/TextBoxRegex.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/TextBoxRegEx/TextBoxRegex.Properties.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         /// <param name="value">A value indicating if the Text is valid according to the Regex property.</param>
         public static void SetIsValid(TextBox textBox, bool value)
         {
-            textBox.SetValue(ValidationModeProperty, value);
+            textBox.SetValue(IsValidProperty, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Issue: #2840
https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/2840

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
TextBoxRegex 'IsValid' property cannot be bound, as it's 'Set' method attempts to set the wrong DependencyProperty.


## What is the new behavior?
TextBoxRegex 'IsValid' property's 'Set' method targets the correct property.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [N/A] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [N/A] Sample in sample app has been added / updated (for bug fixes / features)
    - [N/A] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [N/A] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [N/A] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


## Other information
None