### PR TITLE
Allow to set CroppedRegion in ImageCropper

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.Properties.cs
@@ -26,9 +26,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public double MinSelectedLength { get; set; } = 40;
 
         /// <summary>
-        /// Gets the current cropped region.
+        /// Gets or sets the current cropped region.
         /// </summary>
-        public Rect CroppedRegion => _currentCroppedRect;
+        public Rect CroppedRegion
+        {
+            get
+            {
+                return _currentCroppedRect;
+            }
+
+            set
+            {
+                _currentCroppedRect = value;
+                UpdateImageLayout(true);
+            }
+        }
 
         private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.Properties.cs
@@ -26,19 +26,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public double MinSelectedLength { get; set; } = 40;
 
         /// <summary>
-        /// Gets or sets the current cropped region.
+        /// Gets the current cropped region.
         /// </summary>
         public Rect CroppedRegion
         {
             get
             {
                 return _currentCroppedRect;
-            }
-
-            set
-            {
-                _currentCroppedRect = value;
-                UpdateImageLayout(true);
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.Properties.cs
@@ -28,13 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Gets the current cropped region.
         /// </summary>
-        public Rect CroppedRegion
-        {
-            get
-            {
-                return _currentCroppedRect;
-            }
-        }
+        public Rect CroppedRegion => _currentCroppedRect;
 
         private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.cs
@@ -426,8 +426,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return false;
             }
 
-            // Reject regions larger than the original picture
-            if (rect.Width > _restrictedCropRect.Width || rect.Height > _restrictedCropRect.Height)
+            // Reject regions that are not contained in the original picture
+            if (rect.Left < _restrictedCropRect.Left || rect.Top < _restrictedCropRect.Top || rect.Right > _restrictedCropRect.Right || rect.Bottom > _restrictedCropRect.Bottom)
             {
                 return false;
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.cs
@@ -412,5 +412,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             InitImageLayout(true);
         }
+
+
+        /// <summary>
+        /// Tries to set a new value for the cropped region, returns true if it succeeded, false if the region is invalid
+        /// </summary>
+        /// <param name="rect">The new cropped region.</param>
+        /// <returns>bool</returns>
+        public bool TrySetCroppedRegion(Rect rect)
+        {
+            // Reject regions smaller than the minimum size
+            if (rect.Width < MinCropSize.Width || rect.Height < MinCropSize.Height)
+            {
+                return false;
+            }
+
+            // Reject regions larger than the original picture
+            if (rect.Width > _restrictedCropRect.Width || rect.Height > _restrictedCropRect.Height)
+            {
+                return false;
+            }
+
+            // If an aspect ratio is set, reject regions that don't respect it
+            // If cropping a circle, reject regions where the aspect ratio is not 1
+            if (KeepAspectRatio && UsedAspectRatio != rect.Width / rect.Height)
+            {
+                return false;
+            }
+
+            _currentCroppedRect = rect;
+            UpdateImageLayout(true);
+            return true;
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageCropper/ImageCropper.cs
@@ -413,7 +413,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             InitImageLayout(true);
         }
 
-
         /// <summary>
         /// Tries to set a new value for the cropped region, returns true if it succeeded, false if the region is invalid
         /// </summary>


### PR DESCRIPTION
Issue: #2845 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?

The ImageCropper control doesn't allow to set the CroppedRegion

## What is the new behavior?

The ImageCropper allows to set the CroppedRegion, so the app can  specify a default crop region.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [X] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/190
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
