### PR TITLE
fix: add unit tests to fix StringFormatConverter

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Converters/StringFormatConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Converters/StringFormatConverter.cs
@@ -32,7 +32,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Converters
                 return value;
             }
 
-            return string.Format((string)parameter, value);
+            try
+            {
+                return string.Format((string)parameter, value);
+            }
+            catch
+            {
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/UnitTests/Converters/Test_StringFormatConverter.cs
+++ b/UnitTests/Converters/Test_StringFormatConverter.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Toolkit.Uwp.UI.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UnitTests.Converters
+{
+    [TestClass]
+    public class Test_StringFormatConverter
+    {
+        private static readonly object NullString = null;
+        private static readonly object NotEmptyString = "Hello, world";
+        private static readonly DateTime Date = DateTime.Now;
+
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void WhenValueIsNull_ThenReturnNull()
+        {
+            var converter = new StringFormatConverter();
+            var result = converter.Convert(NullString, typeof(string), NullString, "en-us");
+            Assert.IsNull(result);
+        }
+
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void WhenValueExistsAndParameterIsNull_ThenReturnValue()
+        {
+            var converter = new StringFormatConverter();
+            var result = converter.Convert(NotEmptyString, typeof(string), NullString, "en-us");
+            Assert.AreEqual(NotEmptyString, result);
+        }
+
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void WhenParameterIsTimeFormat_ThenReturnValueOfTimeFormat()
+        {
+            var converter = new StringFormatConverter();
+            var result = converter.Convert(Date, typeof(string), "{0:HH:mm}", "en-us");
+            Assert.AreEqual(Date.ToString("HH:mm"), result);
+        }
+
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void WhenParameterIsInvalidFormat_ThenReturnValue()
+        {
+            var converter = new StringFormatConverter();
+            var result = converter.Convert(Date, typeof(string), "{1:}", "en-us");
+            Assert.AreEqual(Date, result);
+        }
+
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void WhenParameterIsNotAString_ThenReturnValue()
+        {
+            var converter = new StringFormatConverter();
+            var result = converter.Convert(NotEmptyString, typeof(string), 172, "en-us");
+            Assert.AreEqual(NotEmptyString, result);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Converters\Test_BoolToObjectConverter.cs" />
     <Compile Include="Converters\Test_EmptyCollectionToObjectConverter.cs" />
     <Compile Include="Converters\Test_EmptyStringToObjectConverter.cs" />
+    <Compile Include="Converters\Test_StringFormatConverter.cs" />
     <Compile Include="Extensions\Helpers\ObjectWithNullableBoolProperty.cs" />
     <Compile Include="Extensions\Test_ArrayExtensions.cs" />
     <Compile Include="Extensions\Test_NullableBoolMarkupExtension.cs" />


### PR DESCRIPTION
Issue: #2744 

## PR Type

Bugfix

## What is the current behavior?

An exception is thrown when parameter of `StringFormatConverter` is invalid

## What is the new behavior?

Return the value by catching exception

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
(https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
