### PR TITLE
Fix compatibility of InAppNotification with build 17134

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
@@ -2,8 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
-    xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)">
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml" />
@@ -31,11 +31,11 @@
         <Setter Property="Template" Value="{StaticResource MSEdgeNotificationTemplate}" />
     </Style>
 
-    <contract5NotPresent:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+    <contract7NotPresent:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
-    </contract5NotPresent:Style>
+    </contract7NotPresent:Style>
 
-    <contract5Present:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+    <contract7Present:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
         <Setter Property="Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />
-    </contract5Present:Style>
+    </contract7Present:Style>
 </ResourceDictionary>


### PR DESCRIPTION


Issue: #2823 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 


## What is the current behavior?
If run on version 1803 build 17134 the InAppNotification threw a XamlParseException caused by the IXamlType2 being not found at runtime by the conditional on the XAML code of the control. 

## What is the new behavior?
Now it runs in all supported versions. 
Changed the UniversalApiContract in the XAML conditional to 7 where the IXamlType2 was already added. 

<img width="1236" alt="Annotation 2019-03-13 162104" src="https://user-images.githubusercontent.com/4763385/54308141-1f1a0080-45ac-11e9-9aad-1464f3c53759.png">


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

## Other information

 I Refactored the namespaces to indicate the version of the UniversalApiContract version used.