### PR TITLE
Add `IsMasked` property to DropShadowPanel

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DropShadowPanel/DropShadowPanelXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DropShadowPanel/DropShadowPanelXaml.bind
@@ -33,7 +33,8 @@
                                   OffsetY="@[OffsetY:DoubleSlider:2.0:0.0-100.0]"
                                   Color="@[Color:Brush:Black]"
                                   VerticalAlignment="Center"
-                                  HorizontalAlignment="Center">
+                                  HorizontalAlignment="Center"
+                                  IsMasked="@[Is Masked:Bool:true]">
           <TextBlock TextWrapping="Wrap">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. In eget sem luctus, gravida diam cursus, rutrum ipsum.
             Pellentesque semper magna nec sapien ornare tincidunt. Sed pellentesque, turpis quis laoreet pellentesque, urna sapien efficitur nulla,
@@ -53,7 +54,8 @@
                                     OffsetX="@[OffsetX]"
                                     OffsetY="@[OffsetY]"
                                     Color="@[Color]"
-                                    Margin="20">
+                                    Margin="20"
+                                    IsMasked="@[Is Masked]">
             <Polygon Points="50,0 0,50 50,50"
                 Stroke="BlueViolet" StrokeThickness="2" Fill="Blue" />
           </controls:DropShadowPanel>
@@ -63,7 +65,8 @@
                                     OffsetX="@[OffsetX]"
                                     OffsetY="@[OffsetY]"
                                     Color="@[Color]"
-                                    Margin="20">
+                                    Margin="20"
+                                    IsMasked="@[Is Masked]">
             <Rectangle Width="100" Height="50"
                 Stroke="Green" StrokeThickness="5" />
           </controls:DropShadowPanel>
@@ -73,13 +76,14 @@
                                     OffsetX="@[OffsetX]"
                                     OffsetY="@[OffsetY]"
                                     Color="@[Color]"
-                                    Margin="20">
+                                    Margin="20"
+                                    IsMasked="@[Is Masked]">
             <Polyline Points="0,0 50,50 50,0 0,50"
                 Stroke="Black" StrokeThickness="2" />
           </controls:DropShadowPanel>
         </StackPanel>
 
-        <TextBlock Style="{StaticResource TitleText}" >Images</TextBlock>
+        <TextBlock Style="{StaticResource TitleText}">Images</TextBlock>
         <Border Style="{StaticResource DividingBorder}" />
 
         <StackPanel Orientation="Horizontal">
@@ -89,7 +93,8 @@
                                     OffsetY="@[OffsetY]"
                                     Color="@[Color]"
                                     VerticalAlignment="Center"
-                                    HorizontalAlignment="Center">
+                                    HorizontalAlignment="Center"
+                                    IsMasked="@[Is Masked]">
             <Image Width="200" Source="/SamplePages/DropShadowPanel/Unicorn.png" Stretch="Uniform" />
           </controls:DropShadowPanel>
           <controls:DropShadowPanel BlurRadius="@[BlurRadius]"
@@ -98,7 +103,8 @@
                                     OffsetY="@[OffsetY]"
                                     Color="@[Color]"
                                     VerticalAlignment="Center"
-                                    HorizontalAlignment="Center">
+                                    HorizontalAlignment="Center"
+                                    IsMasked="@[Is Masked]">
             <Image Width="200" Source="/SamplePages/DropShadowPanel/Trex.png" Stretch="Uniform" />
           </controls:DropShadowPanel>
         </StackPanel>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.Properties.cs
@@ -53,6 +53,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             DependencyProperty.Register(nameof(ShadowOpacity), typeof(double), typeof(DropShadowPanel), new PropertyMetadata(1.0, OnShadowOpacityChanged));
 
         /// <summary>
+        /// Identifies the <see cref="IsMasked"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsMaskedProperty =
+            DependencyProperty.Register(nameof(IsMasked), typeof(bool), typeof(DropShadowPanel), new PropertyMetadata(true, OnIsMaskedChanged));
+
+        /// <summary>
         /// Gets a value indicating whether the platform supports drop shadows.
         /// </summary>
         /// <remarks>
@@ -182,57 +188,71 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the panel uses an alpha mask to create a more precise shadow vs. a quicker rectangle shape.
+        /// </summary>
+        /// <remarks>
+        /// Turn this off to lose fidelity and gain performance of the panel.
+        /// </remarks>
+        public bool IsMasked
+        {
+            get { return (bool)GetValue(IsMaskedProperty); }
+            set { SetValue(IsMaskedProperty, value); }
+        }
+
         private static void OnBlurRadiusChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (IsSupported)
+            if (IsSupported && d is DropShadowPanel panel)
             {
-                var panel = d as DropShadowPanel;
-                panel?.OnBlurRadiusChanged((double)e.NewValue);
+                panel.OnBlurRadiusChanged((double)e.NewValue);
             }
         }
 
         private static void OnColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (IsSupported)
+            if (IsSupported && d is DropShadowPanel panel)
             {
-                var panel = d as DropShadowPanel;
-                panel?.OnColorChanged((Color)e.NewValue);
+                panel.OnColorChanged((Color)e.NewValue);
             }
         }
 
         private static void OnOffsetXChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (IsSupported)
+            if (IsSupported && d is DropShadowPanel panel)
             {
-                var panel = d as DropShadowPanel;
-                panel?.OnOffsetXChanged((double)e.NewValue);
+                panel.OnOffsetXChanged((double)e.NewValue);
             }
         }
 
         private static void OnOffsetYChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (IsSupported)
+            if (IsSupported && d is DropShadowPanel panel)
             {
-                var panel = d as DropShadowPanel;
-                panel?.OnOffsetYChanged((double)e.NewValue);
+                panel.OnOffsetYChanged((double)e.NewValue);
             }
         }
 
         private static void OnOffsetZChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (IsSupported)
+            if (IsSupported && d is DropShadowPanel panel)
             {
-                var panel = d as DropShadowPanel;
-                panel?.OnOffsetZChanged((double)e.NewValue);
+                panel.OnOffsetZChanged((double)e.NewValue);
             }
         }
 
         private static void OnShadowOpacityChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (IsSupported)
+            if (IsSupported && d is DropShadowPanel panel)
             {
-                var panel = d as DropShadowPanel;
-                panel?.OnShadowOpacityChanged((double)e.NewValue);
+                panel.OnShadowOpacityChanged((double)e.NewValue);
+            }
+        }
+
+        private static void OnIsMaskedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (IsSupported && d is DropShadowPanel panel)
+            {
+                panel.UpdateShadowMask();
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            if (Content != null)
+            if (Content != null && IsMasked)
             {
                 CompositionBrush mask = null;
 


### PR DESCRIPTION
Allows opting-in to non-alpha masks and more performant shadows for rectangular geometries.

Issue: #2862

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?
When using rectangular geometries with DropShadowPanel the performance can be pretty bad with hundreds of elements, as by default we always use an alpha mask:

![image](https://user-images.githubusercontent.com/24302614/54325562-2ea34480-45c0-11e9-9f21-056ed8de48b9.png)

## What is the new behavior?
Allow turning off Alpha Masking (see new `IsMasked` option in sample) to use more performant rectangular shadows in composition layer.  Default is still `true` for backwards compatibility and more reasonable assumed behavior for infrequent uses.

![image](https://user-images.githubusercontent.com/24302614/54325460-868d7b80-45bf-11e9-89b0-2f7fdbd41107.png)

Default is still `True` so non-breaking change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
