### PR TITLE
Fix HeaderedContentControl orientation bug.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedContentControl/HeaderedContentControl.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             SetHeaderVisibility();
+            SetOrientation();
         }
 
         /// <summary>
@@ -100,12 +101,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnOrientationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var control = (HeaderedContentControl)d;
-
-            var orientation = control.Orientation == Orientation.Vertical
-                ? nameof(Orientation.Vertical)
-                : nameof(Orientation.Horizontal);
-
-            VisualStateManager.GoToState(control, orientation, true);
+            control.SetOrientation();
         }
 
         private static void OnHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -132,6 +128,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         : Visibility.Collapsed;
                 }
             }
+        }
+
+        private void SetOrientation()
+        {
+            var orientation = this.Orientation == Orientation.Vertical
+                ? nameof(Orientation.Vertical)
+                : nameof(Orientation.Horizontal);
+
+            VisualStateManager.GoToState(this, orientation, true);
         }
     }
 }


### PR DESCRIPTION
Issue: #2865
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
HeaderedContentControl does not respond to orientation set before applying control template (for example, in XAML markup).

## What is the new behavior?
The control now correctly reflects the orientation set before applying template.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
