### PR TITLE
Fix RangeSelector crash when the tooltip is removed from the template.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -586,7 +586,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private static void UpdateToolTipText(RangeSelector rangeSelector, TextBlock toolTip, double newValue)
         {
-            toolTip.Text = string.Format("{0:0.##}", newValue);
+            if (toolTip != null)
+            {
+                toolTip.Text = string.Format("{0:0.##}", newValue);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Issue: #2888
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
RangeSelector will crash when the tooltip is removed from the template.

## What is the new behavior?
Fixed this bug.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
