### PR TITLE
Adding StretchChild property to WrapPanel control

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/StretchChild.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/StretchChild.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// Options for how to calculate the layout of <see cref="Windows.UI.Xaml.Controls.WrapGrid"/> items.
+    /// </summary>
+    public enum StretchChild
+    {
+        /// <summary>
+        /// Don't apply any additional stretching logic
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Make the first child stretch to push any other items to the end
+        /// </summary>
+        First,
+
+        /// <summary>
+        /// Make the last child stretch to fill the available space
+        /// </summary>
+        Last
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/StretchChild.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/StretchChild.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         None,
 
         /// <summary>
-        /// Make the first child stretch to push any other items to the end
-        /// </summary>
-        First,
-
-        /// <summary>
         /// Make the last child stretch to fill the available space
         /// </summary>
         Last

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/StretchChild.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/StretchChild.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.Toolkit.Uwp.UI.Controls
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
     /// <summary>
     /// Options for how to calculate the layout of <see cref="Windows.UI.Xaml.Controls.WrapGrid"/> items.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="StretchLastChild"/> dependency property.
         /// </summary>
+        /// <returns>The identifier for the <see cref="StretchLastChild"/> dependency property.</returns>
         public static readonly DependencyProperty StretchLastChildProperty =
             DependencyProperty.Register(
                 nameof(StretchLastChild),

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Identifies the StretchLastChild dependency property.
+        /// Identifies the <see cref="StretchLastChild"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty StretchLastChildProperty =
             DependencyProperty.Register(

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 nameof(StretchChild),
                 typeof(StretchChild),
                 typeof(WrapPanel),
-                new PropertyMetadata(false, LayoutPropertyChanged));
+                new PropertyMetadata(StretchChild.None, LayoutPropertyChanged));
 
         private static void LayoutPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
@@ -100,22 +100,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 new PropertyMetadata(default(Thickness), LayoutPropertyChanged));
 
         /// <summary>
-        /// Gets or sets a value indicating whether the last child should fill the remaining space, or not.
+        /// Gets or sets a value indicating how to arrange child items
         /// </summary>
-        public bool StretchLastChild
+        public StretchChild StretchChild
         {
-            get { return (bool)GetValue(StretchLastChildProperty); }
-            set { SetValue(StretchLastChildProperty, value); }
+            get { return (StretchChild)GetValue(StretchChildProperty); }
+            set { SetValue(StretchChildProperty, value); }
         }
 
         /// <summary>
-        /// Identifies the <see cref="StretchLastChild"/> dependency property.
+        /// Identifies the <see cref="StretchChild"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="StretchLastChild"/> dependency property.</returns>
-        public static readonly DependencyProperty StretchLastChildProperty =
+        /// <returns>The identifier for the <see cref="StretchChild"/> dependency property.</returns>
+        public static readonly DependencyProperty StretchChildProperty =
             DependencyProperty.Register(
-                nameof(StretchLastChild),
-                typeof(bool),
+                nameof(StretchChild),
+                typeof(StretchChild),
                 typeof(WrapPanel),
                 new PropertyMetadata(false, LayoutPropertyChanged));
 
@@ -251,7 +251,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     arrange(Children[i]);
                 }
 
-                arrange(Children[lastIndex], StretchLastChild);
+                arrange(Children[lastIndex], StretchChild == StretchChild.Last);
             }
 
             return finalSize;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
@@ -245,23 +245,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     currentV = Math.Max(desiredMeasure.V, currentV);
                 }
 
-                if (StretchLastChild)
+                var lastIndex = Children.Count - 1;
+                for (var i = 0; i < lastIndex; i++)
                 {
-                    var lastIndex = Children.Count - 1;
-                    for (var i = 0; i < lastIndex; i++)
-                    {
-                        arrange(Children[i]);
-                    }
+                    arrange(Children[i]);
+                }
 
-                    arrange(Children[lastIndex], true);
-                }
-                else
-                {
-                    foreach (var child in Children)
-                    {
-                        arrange(child);
-                    }
-                }
+                arrange(Children[lastIndex], StretchLastChild);
             }
 
             return finalSize;


### PR DESCRIPTION
Issue: #
https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/195

## PR Type
What kind of change does this PR introduce?

Adding an extra property and matching enum: StretchChild. This is needed to support the design of the upcoming TokenizingTextBox control.

Set StretchChild to StretchChild.Last to cause the last child of the wrap panel to fill any remaining space.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes