### PR TITLE
Fix for DataGrid Issue #3010 - NullReferenceException in DataGrid.ComputeDisplayedColumns

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumns.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumns.cs
@@ -1209,6 +1209,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         {
                             cx += _negHorizontalOffset;
                             _horizontalOffset -= _negHorizontalOffset;
+                            if (_horizontalOffset < DATAGRID_roundingDelta)
+                            {
+                                // Snap to zero to avoid trying to partially scroll in first scrolled off column below
+                                _horizontalOffset = 0;
+                            }
+
                             _negHorizontalOffset = 0;
                         }
                         else
@@ -1217,6 +1223,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                             _negHorizontalOffset -= displayWidth - cx;
                             cx = displayWidth;
                         }
+
+                        // Make sure the HorizontalAdjustment is not greater than the new HorizontalOffset
+                        // since it would cause an assertion failure in DataGridCellsPresenter.ShouldDisplayCell
+                        // called by DataGridCellsPresenter.MeasureOverride.
+                        this.HorizontalAdjustment = Math.Min(this.HorizontalAdjustment, _horizontalOffset);
                     }
 
                     // second try to scroll entire columns


### PR DESCRIPTION
Issue: #3010  -  Resize DataGrid cause NullReferenceException

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Assertion failure in DataGrid.ComputeDisplayedColumns
  Debug.Assert(dataGridColumn != null, "Expected non-null dataGridColumn.");
followed by NullReferenceException while trying to use that null dataGridColumn.

## What is the new behavior?
NullReferenceException avoided and app continues to run as expected.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
