### PR TITLE
FileCache throws NullReferenceException

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/FileCache.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/FileCache.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         protected override Task<StorageFile> InitializeTypeAsync(Stream stream, List<KeyValuePair<string, object>> initializerKeyValues = null)
         {
             // nothing to do in this instance;
-            return null;
+            return Task.FromResult<StorageFile>(null);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>awaitable task</returns>
         protected override Task<StorageFile> InitializeTypeAsync(StorageFile baseFile, List<KeyValuePair<string, object>> initializerKeyValues = null)
         {
-            return Task.Run(() => baseFile);
+            return Task.FromResult(baseFile);
         }
     }
 }


### PR DESCRIPTION
FileCache.InitializeTypeAsync(Stream...) should not return null. It should return `Task.FromResult<StorageFile>(null)`. Otherwise, CacheBase attempts to dereference the Task to call ConfigureAwait(false) which results in a NullReferenceException.

Fixes #3104

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
If the Uri has not already been cached, calling the following throws a NullReferenceException
```
StorageFile file = await FileCache.Instance.GetFromCacheAsync(new Uri("https://www.bing.com"));
```


## What is the new behavior?
No NullReferenceException is thrown.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
I also updated the what the InitializeTypeAsync(StorageFile...) return to be consistent with the other InitializeTypeAsync(Stream...) return. In the end, Task.FromResult is the more appropriate thing to return when your asynchronous method does not await.