### PR TITLE
Dispatcher helper optimizations

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
     public static class DispatcherHelper
     {
         /// <summary>
-        /// Executes the given function on a given view's UI thread. The default view is the main view.
+        /// Executes the given function on the main view's UI thread.
         /// </summary>
         /// <param name="function">Synchronous function to be executed on UI thread.</param>
         /// <param name="priority">Dispatcher execution priority, default is normal.</param>
@@ -27,7 +27,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Executes the given function on a given view's UI thread. The default view is the main view.
+        /// Executes the given function on the main view's UI thread and returns its result.
         /// </summary>
         /// <typeparam name="T">Returned data type of the function.</typeparam>
         /// <param name="function">Synchronous function to be executed on UI thread.</param>
@@ -40,7 +40,8 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Executes the given function asynchronously on UI thread of the main view.
+        /// Executes the given <see cref="Task"/>-returning function on the main view's UI thread and returns either that <see cref="Task"/>
+        /// or a proxy <see cref="Task"/> that completes when the one produced by the given function completes.
         /// </summary>
         /// <param name="function">Asynchronous function to be executed asynchronously on UI thread.</param>
         /// <param name="priority">Dispatcher execution priority, default is normal.</param>
@@ -51,7 +52,8 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Executes the given function asynchronously on UI thread of the main view.
+        /// Executes the given <see cref="Task{TResult}"/>-returning function on the main view's UI thread and returns either that <see cref="Task{TResult}"/>
+        /// or a proxy <see cref="Task{TResult}"/> that completes when the one produced by the given function completes.
         /// </summary>
         /// <typeparam name="T">Returned data type of the function.</typeparam>
         /// <param name="function">Asynchronous function to be executed asynchronously on UI thread.</param>

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -15,23 +15,25 @@ namespace Microsoft.Toolkit.Uwp.Helpers
     public static class DispatcherHelper
     {
         /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// Executes the given function on a given view's UI thread. The default view is the main view.
         /// </summary>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task/></returns>
+        /// <param name="function">Synchronous function to be executed on UI thread.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task ExecuteOnUIThreadAsync(Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// Executes the given function on a given view's UI thread. The default view is the main view.
         /// </summary>
-        /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="function">Synchronous function to be executed on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task </returns>
+        /// <typeparam name="T">Returned data type of the function.</typeparam>
+        /// <param name="function">Synchronous function to be executed on UI thread.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task{T}"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task<T> ExecuteOnUIThreadAsync<T>(Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
@@ -40,9 +42,9 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <summary>
         /// Executes the given function asynchronously on UI thread of the main view.
         /// </summary>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task"/> for the operation.</returns>
         public static Task ExecuteOnUIThreadAsync(Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
@@ -51,22 +53,23 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <summary>
         /// Executes the given function asynchronously on UI thread of the main view.
         /// </summary>
-        /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        /// <typeparam name="T">Returned data type of the function.</typeparam>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task{T}"/> for the operation.</returns>
         public static Task<T> ExecuteOnUIThreadAsync<T>(Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// Executes the given function on a given view's UI thread.
         /// </summary>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/> to be executed on.</param>
+        /// <param name="function">Synchronous function to be executed on UI thread.</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task/></returns>
+        /// <returns>An awaitable <see cref="Task"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task ExecuteOnUIThreadAsync(this CoreApplicationView viewToExecuteOn, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn is null)
@@ -78,13 +81,14 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// Executes the given function on a given view's UI thread.
         /// </summary>
-        /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Synchronous function with return type <typeparamref name="T"/> to be executed on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        /// <typeparam name="T">Returned data type of the function.</typeparam>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/> to be executed on.</param>
+        /// <param name="function">Synchronous function with return type <typeparamref name="T"/> to be executed on UI thread.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task{T}"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task<T> ExecuteOnUIThreadAsync<T>(this CoreApplicationView viewToExecuteOn, Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn is null)
@@ -96,12 +100,13 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// Executes the given function on a given view's UI thread.
         /// </summary>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/> to be executed on.</param>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task ExecuteOnUIThreadAsync(this CoreApplicationView viewToExecuteOn, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn is null)
@@ -113,13 +118,14 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// Executes the given function on a given view's UI thread.
         /// </summary>
-        /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        /// <typeparam name="T">Returned data type of the function.</typeparam>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on.</param>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task<T> ExecuteOnUIThreadAsync<T>(this CoreApplicationView viewToExecuteOn, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn is null)
@@ -131,12 +137,13 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
+        /// Extension method for <see cref="CoreDispatcher"/>. Offering an actual awaitable <see cref="Task"/> with optional result that will be executed on the given dispatcher.
         /// </summary>
-        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
+        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/>.</param>
+        /// <param name="function"> Function to be executed on the given dispatcher.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (function is null)
@@ -181,13 +188,14 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
+        /// Extension method for <see cref="CoreDispatcher"/>. Offering an actual awaitable <see cref="Task{T}"/> with optional result that will be executed on the given dispatcher.
         /// </summary>
-        /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
+        /// <typeparam name="T">Returned data type of the function.</typeparam>
+        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/>.</param>
+        /// <param name="function"> Function to be executed on the given dispatcher.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task{T}"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (function is null)
@@ -226,12 +234,13 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
+        /// Extension method for <see cref="CoreDispatcher"/>. Offering an actual awaitable <see cref="Task"/> with optional result that will be executed on the given dispatcher.
         /// </summary>
-        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
+        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/>.</param>
+        /// <param name="function">Asynchrounous function to be executed on the given dispatcher.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (function is null)
@@ -287,13 +296,14 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
-        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
+        /// Extension method for <see cref="CoreDispatcher"/>. Offering an actual awaitable <see cref="Task{T}"/> with optional result that will be executed on the given dispatcher.
         /// </summary>
-        /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        /// <typeparam name="T">Returned data type of the function.</typeparam>
+        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/>.</param>
+        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher.</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal.</param>
+        /// <returns>An awaitable <see cref="Task{T}"/> for the operation.</returns>
+        /// <remarks>If the current thread has UI access, <paramref name="function"/> will be invoked directly.</remarks>
         public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (function is null)

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -15,50 +15,26 @@ namespace Microsoft.Toolkit.Uwp.Helpers
     public static class DispatcherHelper
     {
         /// <summary>
-        /// Executes the given function asynchronously on UI thread of the main view.
+        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
         /// </summary>
-        /// <typeparam name="T">Returned data type of the function</typeparam>
         /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        /// <returns>Awaitable Task/></returns>
+        public static Task ExecuteOnUIThreadAsync(Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            return ExecuteOnUIThreadAsync<T>(CoreApplication.MainView, function, priority);
+            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
         /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
         /// </summary>
         /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
+        /// <param name="function">Synchronous function to be executed on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(this CoreApplicationView viewToExecuteOn, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        /// <returns>Awaitable Task </returns>
+        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            if (viewToExecuteOn == null)
-            {
-                throw new ArgumentNullException(nameof(viewToExecuteOn));
-            }
-
-            return viewToExecuteOn.Dispatcher.AwaitableRunAsync<T>(function, priority);
-        }
-
-        /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
-        /// </summary>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
-        public static Task ExecuteOnUIThreadAsync(this CoreApplicationView viewToExecuteOn, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
-        {
-            if (viewToExecuteOn == null)
-            {
-                throw new ArgumentNullException(nameof(viewToExecuteOn));
-            }
-
-            return viewToExecuteOn.Dispatcher.AwaitableRunAsync(function, priority);
+            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
@@ -68,6 +44,18 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
         /// <returns>Awaitable Task</returns>
         public static Task ExecuteOnUIThreadAsync(Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
+        }
+
+        /// <summary>
+        /// Executes the given function asynchronously on UI thread of the main view.
+        /// </summary>
+        /// <typeparam name="T">Returned data type of the function</typeparam>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal</param>
+        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
@@ -92,17 +80,6 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <summary>
         /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
         /// </summary>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task/></returns>
-        public static Task ExecuteOnUIThreadAsync(Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
-        {
-            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
-        }
-
-        /// <summary>
-        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
-        /// </summary>
         /// <typeparam name="T">Returned data type of the function</typeparam>
         /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
         /// <param name="function">Synchronous function with return type <typeparamref name="T"/> to be executed on UI thread</param>
@@ -115,19 +92,81 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 throw new ArgumentNullException(nameof(viewToExecuteOn));
             }
 
-            return viewToExecuteOn.Dispatcher.AwaitableRunAsync<T>(function, priority);
+            return viewToExecuteOn.Dispatcher.AwaitableRunAsync(function, priority);
+        }
+
+        /// <summary>
+        /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// </summary>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal</param>
+        /// <returns>Awaitable Task</returns>
+        public static Task ExecuteOnUIThreadAsync(this CoreApplicationView viewToExecuteOn, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            if (viewToExecuteOn == null)
+            {
+                throw new ArgumentNullException(nameof(viewToExecuteOn));
+            }
+
+            return viewToExecuteOn.Dispatcher.AwaitableRunAsync(function, priority);
         }
 
         /// <summary>
         /// Executes the given function asynchronously on given view's UI thread. Default view is the main view.
         /// </summary>
         /// <typeparam name="T">Returned data type of the function</typeparam>
-        /// <param name="function">Synchronous function to be executed on UI thread</param>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task </returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        public static Task<T> ExecuteOnUIThreadAsync<T>(this CoreApplicationView viewToExecuteOn, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
+            if (viewToExecuteOn == null)
+            {
+                throw new ArgumentNullException(nameof(viewToExecuteOn));
+            }
+
+            return viewToExecuteOn.Dispatcher.AwaitableRunAsync(function, priority);
+        }
+
+        /// <summary>
+        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
+        /// </summary>
+        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
+        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal</param>
+        /// <returns>Awaitable Task</returns>
+        public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            if (function == null)
+            {
+                throw new ArgumentNullException(nameof(function));
+            }
+
+            if (dispatcher.HasThreadAccess)
+            {
+                function();
+
+                return Task.CompletedTask;
+            }
+
+            var taskCompletionSource = new TaskCompletionSource<object>();
+
+            _ = dispatcher.RunAsync(priority, () =>
+            {
+                try
+                {
+                    function();
+                    taskCompletionSource.SetResult(null);
+                }
+                catch (Exception e)
+                {
+                    taskCompletionSource.SetException(e);
+                }
+            });
+
+            return taskCompletionSource.Task;
         }
 
         /// <summary>
@@ -135,34 +174,30 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// </summary>
         /// <typeparam name="T">Returned data type of the function</typeparam>
         /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
+        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        /// <returns>Awaitable Task</returns>
+        public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (function == null)
             {
                 throw new ArgumentNullException(nameof(function));
             }
 
+            if (dispatcher.HasThreadAccess)
+            {
+                var result = function();
+
+                return Task.FromResult(result);
+            }
+
             var taskCompletionSource = new TaskCompletionSource<T>();
 
-            _ = dispatcher.RunAsync(priority, async () =>
+            _ = dispatcher.RunAsync(priority, () =>
             {
                 try
                 {
-                    var awaitableResult = function();
-
-                    if (awaitableResult != null)
-                    {
-                        var result = await awaitableResult.ConfigureAwait(false);
-
-                        taskCompletionSource.SetResult(result);
-                    }
-                    else
-                    {
-                        taskCompletionSource.SetException(new InvalidOperationException("The Task returned by function cannot be null."));
-                    }
+                    taskCompletionSource.SetResult(function());
                 }
                 catch (Exception e)
                 {
@@ -220,69 +255,34 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// </summary>
         /// <typeparam name="T">Returned data type of the function</typeparam>
         /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
+        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
-        public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (function == null)
             {
                 throw new ArgumentNullException(nameof(function));
-            }
-
-            if (dispatcher.HasThreadAccess)
-            {
-                var result = function();
-
-                return Task.FromResult(result);
             }
 
             var taskCompletionSource = new TaskCompletionSource<T>();
 
-            _ = dispatcher.RunAsync(priority, () =>
+            _ = dispatcher.RunAsync(priority, async () =>
             {
                 try
                 {
-                    taskCompletionSource.SetResult(function());
-                }
-                catch (Exception e)
-                {
-                    taskCompletionSource.SetException(e);
-                }
-            });
+                    var awaitableResult = function();
 
-            return taskCompletionSource.Task;
-        }
+                    if (awaitableResult != null)
+                    {
+                        var result = await awaitableResult.ConfigureAwait(false);
 
-        /// <summary>
-        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
-        /// </summary>
-        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
-        public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
-        {
-            if (function == null)
-            {
-                throw new ArgumentNullException(nameof(function));
-            }
-
-            if (dispatcher.HasThreadAccess)
-            {
-                function();
-
-                return Task.CompletedTask;
-            }
-
-            var taskCompletionSource = new TaskCompletionSource<object>();
-
-            _ = dispatcher.RunAsync(priority, () =>
-            {
-                try
-                {
-                    function();
-                    taskCompletionSource.SetResult(null);
+                        taskCompletionSource.SetResult(result);
+                    }
+                    else
+                    {
+                        taskCompletionSource.SetException(new InvalidOperationException("The Task returned by function cannot be null."));
+                    }
                 }
                 catch (Exception e)
                 {

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -146,6 +146,11 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
             if (dispatcher.HasThreadAccess)
             {
+                /* There is no need to manually handle the exceptions in this case.
+                 * Since we're not scheduling a callback, exceptions thrown by the
+                 * function in this path will correctly end up in the stack trace
+                 * when the returned task is awaited anyway.
+                 * This also saves a heap allocation, as the returned task is reused. */
                 function();
 
                 return Task.CompletedTask;
@@ -158,6 +163,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 try
                 {
                     function();
+
                     taskCompletionSource.SetResult(null);
                 }
                 catch (Exception e)
@@ -186,6 +192,10 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
             if (dispatcher.HasThreadAccess)
             {
+                /* Just like with a simple action, we don't need to manually
+                 * handle failures here. As we're not in a dispatched callback,
+                 * exceptions thrown at this point will just show up correctly
+                 * in the stack trace when the returned task is awaited. */
                 var result = function();
 
                 return Task.FromResult(result);

--- a/UnitTests/Helpers/Test_DispatcherHelper.cs
+++ b/UnitTests/Helpers/Test_DispatcherHelper.cs
@@ -1,0 +1,221 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Microsoft.Toolkit.Uwp.Helpers;
+
+namespace UnitTests.Helpers
+{
+    [TestClass]
+    public class Test_DispatcherHelper
+    {
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Test_DispatcherHelper_Action_Null()
+        {
+            DispatcherHelper.ExecuteOnUIThreadAsync(default(Action));
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_Action_Ok_UIThread()
+        {
+            DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                var textBlock = new TextBlock { Text = nameof(Test_DispatcherHelper_Action_Ok_NonUIThread) };
+
+                Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_Action_Ok_NonUIThread));
+            }).Wait();
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public async Task Test_DispatcherHelper_Action_Ok_NonUIThread()
+        {
+            await DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                var textBlock = new TextBlock { Text = nameof(Test_DispatcherHelper_Action_Ok_NonUIThread) };
+
+                Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_Action_Ok_NonUIThread));
+            });
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_Action_Exception()
+        {
+            var task = DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                throw new ArgumentException(nameof(this.Test_DispatcherHelper_Action_Exception));
+            });
+
+            Assert.IsNotNull(task);
+            Assert.AreEqual(task.Status, TaskStatus.Faulted);
+            Assert.IsNotNull(task.Exception);
+            Assert.IsInstanceOfType(task.Exception.InnerExceptions.FirstOrDefault(), typeof(ArgumentException));
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Test_DispatcherHelper_FuncOfT_Null()
+        {
+            DispatcherHelper.ExecuteOnUIThreadAsync(default(Func<int>));
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_FuncOfT_Ok_UIThread()
+        {
+            var textBlock = DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                return new TextBlock { Text = nameof(Test_DispatcherHelper_FuncOfT_Ok_NonUIThread) };
+            }).Result;
+
+            Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_FuncOfT_Ok_NonUIThread));
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public async Task Test_DispatcherHelper_FuncOfT_Ok_NonUIThread()
+        {
+            var textBlock = await DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                return new TextBlock { Text = nameof(Test_DispatcherHelper_FuncOfT_Ok_NonUIThread) };
+            });
+
+            await DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_FuncOfT_Ok_NonUIThread));
+            });
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_FuncOfT_Exception()
+        {
+            var task = DispatcherHelper.ExecuteOnUIThreadAsync(new Func<int>(() =>
+            {
+                throw new ArgumentException(nameof(this.Test_DispatcherHelper_FuncOfT_Exception));
+            }));
+
+            Assert.IsNotNull(task);
+            Assert.AreEqual(task.Status, TaskStatus.Faulted);
+            Assert.IsNotNull(task.Exception);
+            Assert.IsInstanceOfType(task.Exception.InnerExceptions.FirstOrDefault(), typeof(ArgumentException));
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        [SuppressMessage("Style", "IDE0034", Justification = "Explicit overload for clarity")]
+        public void Test_DispatcherHelper_FuncOfTask_Null()
+        {
+            DispatcherHelper.ExecuteOnUIThreadAsync(default(Func<Task>));
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_FuncOfTask_Ok_UIThread()
+        {
+            DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                var textBlock = new TextBlock { Text = nameof(Test_DispatcherHelper_FuncOfTask_Ok_NonUIThread) };
+
+                Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_FuncOfTask_Ok_NonUIThread));
+
+                return Task.CompletedTask;
+            }).Wait();
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public async Task Test_DispatcherHelper_FuncOfTask_Ok_NonUIThread()
+        {
+            await DispatcherHelper.ExecuteOnUIThreadAsync(async () =>
+            {
+                await Task.Yield();
+
+                var textBlock = new TextBlock { Text = nameof(Test_DispatcherHelper_FuncOfTask_Ok_NonUIThread) };
+
+                Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_FuncOfTask_Ok_NonUIThread));
+            });
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_FuncOfTask_Exception()
+        {
+            var task = DispatcherHelper.ExecuteOnUIThreadAsync(new Func<Task>(() =>
+            {
+                throw new ArgumentException(nameof(this.Test_DispatcherHelper_FuncOfTask_Exception));
+            }));
+
+            Assert.IsNotNull(task);
+            Assert.AreEqual(task.Status, TaskStatus.Faulted);
+            Assert.IsNotNull(task.Exception);
+            Assert.IsInstanceOfType(task.Exception.InnerExceptions.FirstOrDefault(), typeof(ArgumentException));
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Test_DispatcherHelper_FuncOfTaskOfT_Null()
+        {
+            DispatcherHelper.ExecuteOnUIThreadAsync(default(Func<Task<int>>));
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_FuncOfTaskOfT_Ok_UIThread()
+        {
+            DispatcherHelper.ExecuteOnUIThreadAsync(() =>
+            {
+                var textBlock = new TextBlock { Text = nameof(Test_DispatcherHelper_FuncOfTaskOfT_Ok_NonUIThread) };
+
+                Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_FuncOfTaskOfT_Ok_NonUIThread));
+
+                return Task.FromResult(1);
+            }).Wait();
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public async Task Test_DispatcherHelper_FuncOfTaskOfT_Ok_NonUIThread()
+        {
+            await DispatcherHelper.ExecuteOnUIThreadAsync(async () =>
+            {
+                await Task.Yield();
+
+                var textBlock = new TextBlock { Text = nameof(Test_DispatcherHelper_FuncOfTaskOfT_Ok_NonUIThread) };
+
+                Assert.AreEqual(textBlock.Text, nameof(Test_DispatcherHelper_FuncOfTaskOfT_Ok_NonUIThread));
+
+                return textBlock;
+            });
+        }
+
+        [TestCategory("Helpers")]
+        [UITestMethod]
+        public void Test_DispatcherHelper_FuncOfTaskOfT_Exception()
+        {
+            var task = DispatcherHelper.ExecuteOnUIThreadAsync(new Func<Task<int>>(() =>
+            {
+                throw new ArgumentException(nameof(this.Test_DispatcherHelper_FuncOfTaskOfT_Exception));
+            }));
+
+            Assert.IsNotNull(task);
+            Assert.AreEqual(task.Status, TaskStatus.Faulted);
+            Assert.IsNotNull(task.Exception);
+            Assert.IsInstanceOfType(task.Exception.InnerExceptions.FirstOrDefault(), typeof(ArgumentException));
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Extensions\Test_ArrayExtensions.cs" />
     <Compile Include="Extensions\Test_NullableBoolMarkupExtension.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Helpers\Test_DispatcherHelper.cs" />
     <Compile Include="Helpers\Test_AdvancedCollectionView.cs" />
     <Compile Include="Helpers\Test_BackgroundTaskHelper.cs" />
     <Compile Include="Helpers\Test_ColorHelper.cs" />


### PR DESCRIPTION
This PR is part of the group being tracked in #3108.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Optimization
<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, APIs in the `DispatcherHelper` class will always result in a callback dispatch on the target `CoreDispatcher` instance, and a `Task` or `Task<T>` allocation, even when the caller is already running on that same `CoreDispatcher` instance, therefore not needing the dispatching at all.

## What is the new behavior?
There are just 2 changes being introduced by this PR:

- When scheduling an `Action` or `Func<T>` on the UI thread, if the target `CoreDispatcher` already has thread access, the delegates will be invoked directly, skipping the dispatcher scheduling entirely.
- When running an `Action` on the same UI thread, `Task.CompletedTask` is used, to avoid the unnecessary allocation of a new `Task` instance every time.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->