### PR TITLE
Fix RadialGauge default template value formatting

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RadialGauge/RadialGaugeCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RadialGauge/RadialGaugeCode.bind
@@ -26,6 +26,7 @@
                   MinAngle="@[MinAngle:Slider:210:0-360]"
                   MaxAngle="@[MaxAngle:Slider:150:0-360]"
                   Unit="units"
+                  ValueStringFormat="@[ValueStringFormat:String:N0]"
                   NeedleWidth="@[NeedleWidth:Slider:4:1-10]"
                   NeedleLength="@[NeedleLength:Slider:100:20-100]" 
                   TickLength="@[TickLength:Slider:10:0-30]"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the ValueStringFormat dependency property.
         /// </summary>
         public static readonly DependencyProperty ValueStringFormatProperty =
-            DependencyProperty.Register(nameof(ValueStringFormat), typeof(string), typeof(RadialGauge), new PropertyMetadata("N0"));
+            DependencyProperty.Register(nameof(ValueStringFormat), typeof(string), typeof(RadialGauge), new PropertyMetadata("N0", (s, e) => OnValueChanged(s)));
 
         /// <summary>
         /// Identifies the TickSpacing dependency property.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.xaml
@@ -108,7 +108,6 @@
                                            FontSize="20"
                                            FontWeight="SemiBold"
                                            Foreground="{TemplateBinding Foreground}"
-                                           Text="{TemplateBinding Value}"
                                            TextAlignment="Center" />
                                 <TextBlock Margin="0"
                                            FontSize="16"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Changing the `RadialGauge.ValueStringFormat` does not have an effect on the displayed value.

## What is the new behavior?
This update fixes the `RadialGauge` value text formatting that was overridden by a template binding on the `Value` property.

Here's the appropriate text update location:

https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/ef6527227539362125a0617d9b9821b2c009e11e/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs#L537
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
