### PR TITLE
Replace Task.FromResult by Task.CompletedTask

### DIFF
--- a/Microsoft.Toolkit.Uwp/Deferred/EventHandlerExtensions.cs
+++ b/Microsoft.Toolkit.Uwp/Deferred/EventHandlerExtensions.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,8 +14,6 @@ namespace Microsoft.Toolkit.Uwp.Deferred
     /// </summary>
     public static class EventHandlerExtensions
     {
-        private static readonly Task CompletedTask = Task.FromResult(0);
-
         /// <summary>
         /// Use to invoke an async <see cref="EventHandler{TEventArgs}"/> using <see cref="DeferredEventArgs"/>.
         /// </summary>
@@ -46,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.Deferred
         {
             if (eventHandler == null)
             {
-                return CompletedTask;
+                return Task.CompletedTask;
             }
 
             var tasks = eventHandler.GetInvocationList()
@@ -59,7 +55,7 @@ namespace Microsoft.Toolkit.Uwp.Deferred
 
                     var deferral = eventArgs.GetCurrentDeferralAndReset();
 
-                    return deferral?.WaitForCompletion(cancellationToken) ?? CompletedTask;
+                    return deferral?.WaitForCompletion(cancellationToken) ?? Task.CompletedTask;
                 })
                 .ToArray();
 

--- a/Microsoft.Toolkit.Uwp/Deferred/TypedEventHandlerExtensions.cs
+++ b/Microsoft.Toolkit.Uwp/Deferred/TypedEventHandlerExtensions.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Toolkit.Uwp.Deferred
     /// </summary>
     public static class TypedEventHandlerExtensions
     {
-        private static readonly Task CompletedTask = Task.FromResult(0);
-
         /// <summary>
         /// Use to invoke an async <see cref="TypedEventHandler{TSender, TResult}"/> using <see cref="DeferredEventArgs"/>.
         /// </summary>
@@ -47,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.Deferred
         {
             if (eventHandler == null)
             {
-                return CompletedTask;
+                return Task.CompletedTask;
             }
 
             var tasks = eventHandler.GetInvocationList()
@@ -60,7 +58,7 @@ namespace Microsoft.Toolkit.Uwp.Deferred
 
                     var deferral = eventArgs.GetCurrentDeferralAndReset();
 
-                    return deferral?.WaitForCompletion(cancellationToken) ?? CompletedTask;
+                    return deferral?.WaitForCompletion(cancellationToken) ?? Task.CompletedTask;
                 })
                 .ToArray();
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes) 

## What is the current behavior?
The community toolkit code is using `Task.FromResult(0)` to create completed task. This is not needed since we can directly use `Task.CompletedTask` and spare a few allocations.

## What is the new behavior?
The `Task.CompletedTask` instance will now be used for async methods returning a completed task.


## PR Checklist
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

