### PR TITLE
MasterDetailsView Windows 10X and Two-pane view support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,6 +42,7 @@ Windows 10 Build Number:
 - [ ] April 2018 Update (17134)
 - [ ] October 2018 Update (17763)
 - [ ] May 2019 Update (18362)
+- [ ] November 2019 Update (18363)
 - [ ] Insider Build (build number: )
 
 App min and target version:
@@ -49,6 +50,7 @@ App min and target version:
 - [ ] April 2018 Update (17134)
 - [ ] October 2018 Update (17763)
 - [ ] May 2019 Update (18362)
+- [ ] November 2019 Update (18363)
 - [ ] Insider Build (xxxxx)
 
 Device form factor:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
     <IsUwpProject Condition="'$(IsDesignProject)' != 'true'">$(MSBuildProjectName.Contains('Uwp'))</IsUwpProject>
     <IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
-    <DefaultTargetPlatformVersion>17763</DefaultTargetPlatformVersion>
+    <DefaultTargetPlatformVersion>18362</DefaultTargetPlatformVersion>
     <DefaultTargetPlatformMinVersion>16299</DefaultTargetPlatformMinVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)bin\nupkg</PackageOutputPath>
   </PropertyGroup>

--- a/GazeInputTest/GazeInputTest.csproj
+++ b/GazeInputTest/GazeInputTest.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>GazeInputTest</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/Microsoft.Toolkit.UWP.Input.GazeInteraction.vcxproj
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/Microsoft.Toolkit.UWP.Input.GazeInteraction.vcxproj
@@ -42,7 +42,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ProjectName>Microsoft.Toolkit.Uwp.Input.GazeInteraction</ProjectName>

--- a/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
+++ b/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
@@ -48,7 +48,7 @@
     <NugetTargetMoniker Condition="'$(DesignTimeBuild)' == 'true'">native</NugetTargetMoniker>
     <NugetTargetMoniker Condition="'$(DesignTimeBuild)' != 'true'">UAP,Version=v10.0</NugetTargetMoniker>
     <PackageTargetFallback>uap10.0</PackageTargetFallback>
-    <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == '' ">10.0.10240.0</TargetPlatformMinVersion>
     <DefineConstants Condition="'$(DisableImplicitFrameworkDefines)' != 'true'">$(DefineConstants);NETFX_CORE;WINDOWS_UWP;WINRT</DefineConstants>
     <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">false</CopyLocalLockFileAssemblies>

--- a/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
@@ -125,7 +125,7 @@
       <Version>6.1.0-build.6</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.2.190917002</Version>
+      <Version>2.3.200213001</Version>
     </PackageReference>
     <PackageReference Include="Monaco.Editor">
       <Version>0.7.0-alpha</Version>

--- a/Microsoft.Toolkit.Uwp.Samples.BackgroundTasks/Microsoft.Toolkit.Uwp.Samples.BackgroundTasks.csproj
+++ b/Microsoft.Toolkit.Uwp.Samples.BackgroundTasks/Microsoft.Toolkit.Uwp.Samples.BackgroundTasks.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Microsoft.Toolkit.Uwp.Samples.BackgroundTasks</AssemblyName>
     <DefaultLanguage>fr-FR</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.Design/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.Design.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.Design/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid.Design.csproj
@@ -57,7 +57,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Windows.winmd</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
@@ -73,12 +73,12 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Runtime.WindowsRuntime.UI.Xaml" />
     <Reference Include="Windows.Foundation.FoundationContract">
-      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
+      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
       <Aliases>WindowsRuntime</Aliases>
       <Private>False</Private>
     </Reference>
     <Reference Include="Windows.Foundation.UniversalApiContract">
-      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
+      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
       <Aliases>WindowsRuntime</Aliases>
       <Private>False</Private>
     </Reference>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Design/Microsoft.Toolkit.Uwp.UI.Controls.Design.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Design/Microsoft.Toolkit.Uwp.UI.Controls.Design.csproj
@@ -58,7 +58,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Windows.winmd</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
@@ -74,12 +74,12 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Runtime.WindowsRuntime.UI.Xaml" />
     <Reference Include="Windows.Foundation.FoundationContract">
-      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
+      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
       <Aliases>WindowsRuntime</Aliases>
       <Private>False</Private>
     </Reference>
     <Reference Include="Windows.Foundation.UniversalApiContract">
-      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
+      <HintPath>$(ProgramFiles)\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
       <Aliases>WindowsRuntime</Aliases>
       <Private>False</Private>
     </Reference>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/BackButtonBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/BackButtonBehavior.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         /// <remarks>
         /// If the back button controlled by <see cref="Windows.UI.Core.SystemNavigationManager"/> is already visible, the <see cref="MasterDetailsView"/> will hook into that button.
-        /// If the new NavigationView provided by the Windows UI nuget package is used, the <see cref="MasterDetailsView"/> will enable and show that button.
+        /// If the new NavigationView provided by the Windows UI NuGet package is used, the <see cref="MasterDetailsView"/> will enable and show that button.
         /// Otherwise the inline button is used.
         /// </remarks>
         Automatic,

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.BackButton.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.BackButton.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if ((args.NavigationMode == NavigationMode.Back) && (ViewState == MasterDetailsViewState.Details))
             {
-                SelectedItem = null;
+                ClearSelectedItem();
                 args.Cancel = true;
             }
         }
@@ -151,7 +151,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 // let the OnFrameNavigating method handle it if
                 if (frame == null || !frame.CanGoBack)
                 {
-                    SelectedItem = null;
+                    ClearSelectedItem();
                 }
 
                 args.Handled = true;
@@ -160,7 +160,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnInlineBackButtonClicked(object sender, RoutedEventArgs e)
         {
-            SelectedItem = null;
+            ClearSelectedItem();
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.BackButton.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.BackButton.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <seealso cref="Windows.UI.Xaml.Controls.ItemsControl" />
     public partial class MasterDetailsView
     {
-        private AppViewBackButtonVisibility? previousSystemBackButtonVisibility;
-        private bool previousNavigationViewBackEnabled;
+        private AppViewBackButtonVisibility? _previousSystemBackButtonVisibility;
+        private bool _previousNavigationViewBackEnabled;
 
         // Int used because the underlying type is an enum, but we don't have access to the enum
-        private int previousNavigationViewBackVisibilty;
-        private Button inlineBackButton;
-        private object navigationView;
-        private Frame frame;
+        private int _previousNavigationViewBackVisibilty;
+        private Button _inlineBackButton;
+        private object _navigationView;
+        private Frame _frame;
 
         /// <summary>
         /// Sets the back button visibility based on the current visual state and selected item
@@ -40,9 +40,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (ViewState == MasterDetailsViewState.Details)
             {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (inlineBackButton != null))
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
                 {
-                    inlineBackButton.Visibility = Visibility.Visible;
+                    _inlineBackButton.Visibility = Visibility.Visible;
                 }
                 else if (BackButtonBehavior == BackButtonBehavior.Automatic)
                 {
@@ -51,13 +51,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     if (navigationManager.AppViewBackButtonVisibility == AppViewBackButtonVisibility.Visible)
                     {
                         // Setting this indicates that the system back button is being used
-                        previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+                        _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
                     }
-                    else if ((inlineBackButton != null) && ((navigationView == null) || (frame == null)))
+                    else if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
                     {
                         // We can only use the new NavigationView if we also have a Frame
                         // If there is no frame we have to use the inline button
-                        inlineBackButton.Visibility = Visibility.Visible;
+                        _inlineBackButton.Visibility = Visibility.Visible;
                     }
                     else
                     {
@@ -67,61 +67,61 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 else if (BackButtonBehavior != BackButtonBehavior.Manual)
                 {
                     SystemNavigationManager navigationManager = SystemNavigationManager.GetForCurrentView();
-                    previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+                    _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
 
                     navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
                 }
             }
             else if (previousState == MasterDetailsViewState.Details)
             {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (inlineBackButton != null))
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
                 {
-                    inlineBackButton.Visibility = Visibility.Collapsed;
+                    _inlineBackButton.Visibility = Visibility.Collapsed;
                 }
                 else if (BackButtonBehavior == BackButtonBehavior.Automatic)
                 {
-                    if (!previousSystemBackButtonVisibility.HasValue)
+                    if (!_previousSystemBackButtonVisibility.HasValue)
                     {
-                        if ((inlineBackButton != null) && ((navigationView == null) || (frame == null)))
+                        if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
                         {
-                            inlineBackButton.Visibility = Visibility.Collapsed;
+                            _inlineBackButton.Visibility = Visibility.Collapsed;
                         }
                         else
                         {
-                            SetNavigationViewBackButtonState(previousNavigationViewBackVisibilty, previousNavigationViewBackEnabled);
+                            SetNavigationViewBackButtonState(_previousNavigationViewBackVisibilty, _previousNavigationViewBackEnabled);
                         }
                     }
                 }
 
-                if (previousSystemBackButtonVisibility.HasValue)
+                if (_previousSystemBackButtonVisibility.HasValue)
                 {
                     // Make sure we show the back button if the stack can navigate back
-                    SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = previousSystemBackButtonVisibility.Value;
-                    previousSystemBackButtonVisibility = null;
+                    SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = _previousSystemBackButtonVisibility.Value;
+                    _previousSystemBackButtonVisibility = null;
                 }
             }
         }
 
         private void SetNavigationViewBackButtonState(int visible, bool enabled)
         {
-            if (navigationView == null)
+            if (_navigationView == null)
             {
                 return;
             }
 
-            System.Type navType = navigationView.GetType();
+            System.Type navType = _navigationView.GetType();
             PropertyInfo visibleProperty = navType.GetProperty("IsBackButtonVisible");
             if (visibleProperty != null)
             {
-                previousNavigationViewBackVisibilty = (int)visibleProperty.GetValue(navigationView);
-                visibleProperty.SetValue(navigationView, visible);
+                _previousNavigationViewBackVisibilty = (int)visibleProperty.GetValue(_navigationView);
+                visibleProperty.SetValue(_navigationView, visible);
             }
 
             PropertyInfo enabledProperty = navType.GetProperty("IsBackEnabled");
             if (enabledProperty != null)
             {
-                previousNavigationViewBackEnabled = (bool)enabledProperty.GetValue(navigationView);
-                enabledProperty.SetValue(navigationView, enabled);
+                _previousNavigationViewBackEnabled = (bool)enabledProperty.GetValue(_navigationView);
+                enabledProperty.SetValue(_navigationView, enabled);
             }
         }
 
@@ -149,7 +149,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (ViewState == MasterDetailsViewState.Details)
             {
                 // let the OnFrameNavigating method handle it if
-                if (frame == null || !frame.CanGoBack)
+                if (_frame == null || !_frame.CanGoBack)
                 {
                     ClearSelectedItem();
                 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.BackButton.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.BackButton.cs
@@ -1,0 +1,166 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Windows.ApplicationModel;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// Panel that allows for a Master/Details pattern.
+    /// </summary>
+    /// <seealso cref="Windows.UI.Xaml.Controls.ItemsControl" />
+    public partial class MasterDetailsView
+    {
+        private AppViewBackButtonVisibility? previousSystemBackButtonVisibility;
+        private bool previousNavigationViewBackEnabled;
+
+        // Int used because the underlying type is an enum, but we don't have access to the enum
+        private int previousNavigationViewBackVisibilty;
+        private Button inlineBackButton;
+        private object navigationView;
+        private Frame frame;
+
+        /// <summary>
+        /// Sets the back button visibility based on the current visual state and selected item
+        /// </summary>
+        private void SetBackButtonVisibility(MasterDetailsViewState? previousState = null)
+        {
+            const int backButtonVisible = 1;
+
+            if (DesignMode.DesignModeEnabled)
+            {
+                return;
+            }
+
+            if (ViewState == MasterDetailsViewState.Details)
+            {
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (inlineBackButton != null))
+                {
+                    inlineBackButton.Visibility = Visibility.Visible;
+                }
+                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
+                {
+                    // Continue to support the system back button if it is being used
+                    SystemNavigationManager navigationManager = SystemNavigationManager.GetForCurrentView();
+                    if (navigationManager.AppViewBackButtonVisibility == AppViewBackButtonVisibility.Visible)
+                    {
+                        // Setting this indicates that the system back button is being used
+                        previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+                    }
+                    else if ((inlineBackButton != null) && ((navigationView == null) || (frame == null)))
+                    {
+                        // We can only use the new NavigationView if we also have a Frame
+                        // If there is no frame we have to use the inline button
+                        inlineBackButton.Visibility = Visibility.Visible;
+                    }
+                    else
+                    {
+                        SetNavigationViewBackButtonState(backButtonVisible, true);
+                    }
+                }
+                else if (BackButtonBehavior != BackButtonBehavior.Manual)
+                {
+                    SystemNavigationManager navigationManager = SystemNavigationManager.GetForCurrentView();
+                    previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+
+                    navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
+                }
+            }
+            else if (previousState == MasterDetailsViewState.Details)
+            {
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (inlineBackButton != null))
+                {
+                    inlineBackButton.Visibility = Visibility.Collapsed;
+                }
+                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
+                {
+                    if (!previousSystemBackButtonVisibility.HasValue)
+                    {
+                        if ((inlineBackButton != null) && ((navigationView == null) || (frame == null)))
+                        {
+                            inlineBackButton.Visibility = Visibility.Collapsed;
+                        }
+                        else
+                        {
+                            SetNavigationViewBackButtonState(previousNavigationViewBackVisibilty, previousNavigationViewBackEnabled);
+                        }
+                    }
+                }
+
+                if (previousSystemBackButtonVisibility.HasValue)
+                {
+                    // Make sure we show the back button if the stack can navigate back
+                    SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = previousSystemBackButtonVisibility.Value;
+                    previousSystemBackButtonVisibility = null;
+                }
+            }
+        }
+
+        private void SetNavigationViewBackButtonState(int visible, bool enabled)
+        {
+            if (navigationView == null)
+            {
+                return;
+            }
+
+            System.Type navType = navigationView.GetType();
+            PropertyInfo visibleProperty = navType.GetProperty("IsBackButtonVisible");
+            if (visibleProperty != null)
+            {
+                previousNavigationViewBackVisibilty = (int)visibleProperty.GetValue(navigationView);
+                visibleProperty.SetValue(navigationView, visible);
+            }
+
+            PropertyInfo enabledProperty = navType.GetProperty("IsBackEnabled");
+            if (enabledProperty != null)
+            {
+                previousNavigationViewBackEnabled = (bool)enabledProperty.GetValue(navigationView);
+                enabledProperty.SetValue(navigationView, enabled);
+            }
+        }
+
+        /// <summary>
+        /// Closes the details pane if we are in narrow state
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="args">The event args</param>
+        private void OnFrameNavigating(object sender, NavigatingCancelEventArgs args)
+        {
+            if ((args.NavigationMode == NavigationMode.Back) && (ViewState == MasterDetailsViewState.Details))
+            {
+                SelectedItem = null;
+                args.Cancel = true;
+            }
+        }
+
+        /// <summary>
+        /// Closes the details pane if we are in narrow state
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="args">The event args</param>
+        private void OnBackRequested(object sender, BackRequestedEventArgs args)
+        {
+            if (ViewState == MasterDetailsViewState.Details)
+            {
+                // let the OnFrameNavigating method handle it if
+                if (frame == null || !frame.CanGoBack)
+                {
+                    SelectedItem = null;
+                }
+
+                args.Handled = true;
+            }
+        }
+
+        private void OnInlineBackButtonClicked(object sender, RoutedEventArgs e)
+        {
+            SelectedItem = null;
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Events.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public event SelectionChangedEventHandler SelectionChanged;
 
         /// <summary>
-        /// Occurs when the view state changes
+        /// Occurs when the view state changes.
         /// </summary>
         public event EventHandler<MasterDetailsViewState> ViewStateChanged;
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(CompactModeThresholdWidth),
             typeof(double),
             typeof(MasterDetailsView),
-            new PropertyMetadata(640d, OnCompactModeThresholdWidthChanged));
+            new PropertyMetadata(640d));
 
         /// <summary>
         /// Identifies the <see cref="MasterCommandBar"/> dependency property.
@@ -446,8 +446,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             ((MasterDetailsView)d).OnSelectedItemChanged(e);
         }
 
-        private static void OnCompactModeThresholdWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
-
-        private static void OnBackButtonBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+        private static void OnBackButtonBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((MasterDetailsView)d).SetBackButtonVisibility();
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,6 +16,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class MasterDetailsView
     {
         /// <summary>
+        /// Identifies the <see cref="MasterPaneBackground"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="MasterPaneBackground"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterPaneBackgroundProperty = DependencyProperty.Register(
+            nameof(MasterPaneBackground),
+            typeof(Brush),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="DetailsPaneBackground"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="DetailsPaneBackground"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsPaneBackgroundProperty = DependencyProperty.Register(
+            nameof(DetailsPaneBackground),
+            typeof(Brush),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
         /// Identifies the <see cref="SelectedItem"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="SelectedItem"/> dependency property.</returns>
@@ -26,22 +46,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnSelectedItemChanged));
 
         /// <summary>
-        /// Identifies the <see cref="DetailsTemplate"/> dependency property.
+        /// Identifies the <see cref="NoItemsContent"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="DetailsTemplate"/> dependency property.</returns>
-        public static readonly DependencyProperty DetailsTemplateProperty = DependencyProperty.Register(
-            nameof(DetailsTemplate),
-            typeof(DataTemplate),
+        /// <returns>The identifier for the <see cref="NoItemsContent"/> dependency property.</returns>
+        public static readonly DependencyProperty NoItemsContentProperty = DependencyProperty.Register(
+            nameof(NoItemsContent),
+            typeof(object),
             typeof(MasterDetailsView),
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="MasterPaneBackground"/> dependency property.
+        /// Identifies the <see cref="NoItemsContentTemplate"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="MasterPaneBackground"/> dependency property.</returns>
-        public static readonly DependencyProperty MasterPaneBackgroundProperty = DependencyProperty.Register(
-            nameof(MasterPaneBackground),
-            typeof(Brush),
+        /// <returns>The identifier for the <see cref="NoItemsContentTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty NoItemsContentTemplateProperty = DependencyProperty.Register(
+            nameof(NoItemsContentTemplate),
+            typeof(DataTemplate),
             typeof(MasterDetailsView),
             new PropertyMetadata(null));
 
@@ -53,7 +73,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(MasterHeader),
             typeof(object),
             typeof(MasterDetailsView),
-            new PropertyMetadata(null, OnMasterHeaderChanged));
+            new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="MasterHeaderTemplate"/> dependency property.
@@ -86,16 +106,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="MasterPaneWidth"/> dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="MasterPaneWidth"/> dependency property.</returns>
-        public static readonly DependencyProperty MasterPaneWidthProperty = DependencyProperty.Register(
-            nameof(MasterPaneWidth),
-            typeof(double),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(320d));
-
-        /// <summary>
         /// Identifies the <see cref="NoSelectionContent"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="NoSelectionContent"/> dependency property.</returns>
@@ -116,17 +126,57 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="ViewState"/> dependency property
+        /// Identifies the <see cref="DetailsContentTemplateSelector"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="ViewState"/> dependency property.</returns>
-        public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(
-            nameof(ViewState),
-            typeof(MasterDetailsViewState),
+        /// <returns>The identifier for the <see cref="DetailsContentTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsContentTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(DetailsContentTemplateSelector),
+            typeof(DataTemplateSelector),
             typeof(MasterDetailsView),
-            new PropertyMetadata(default(MasterDetailsViewState)));
+            new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="MasterCommandBar"/> dependency property
+        /// Identifies the <see cref="DetailsTemplate"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="DetailsTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsTemplateProperty = DependencyProperty.Register(
+            nameof(DetailsTemplate),
+            typeof(DataTemplate),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="MasterItemTemplateSelector"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="MasterItemTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterItemTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(MasterItemTemplateSelector),
+            typeof(DataTemplateSelector),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="MasterPaneWidth"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="MasterPaneWidth"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterPaneWidthProperty = DependencyProperty.Register(
+            nameof(MasterPaneWidth),
+            typeof(GridLength),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(new GridLength(320)));
+
+        /// <summary>
+        /// Identifies the <see cref="CompactModeThresholdWidth"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="CompactModeThresholdWidth"/> dependency property.</returns>
+        public static readonly DependencyProperty CompactModeThresholdWidthProperty = DependencyProperty.Register(
+            nameof(CompactModeThresholdWidth),
+            typeof(double),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(640d, OnCompactModeThresholdWidthChanged));
+
+        /// <summary>
+        /// Identifies the <see cref="MasterCommandBar"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="MasterCommandBar"/> dependency property.</returns>
         public static readonly DependencyProperty MasterCommandBarProperty = DependencyProperty.Register(
@@ -136,7 +186,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnMasterCommandBarChanged));
 
         /// <summary>
-        /// Identifies the <see cref="DetailsCommandBar"/> dependency property
+        /// Identifies the <see cref="DetailsCommandBar"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="DetailsCommandBar"/> dependency property.</returns>
         public static readonly DependencyProperty DetailsCommandBarProperty = DependencyProperty.Register(
@@ -146,41 +196,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnDetailsCommandBarChanged));
 
         /// <summary>
-        /// Identifies the <see cref="CompactModeThresholdWidth"/> dependency property
+        /// Identifies the <see cref="BackButtonBehavior"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty CompactModeThresholdWidthProperty = DependencyProperty.Register(
-            nameof(CompactModeThresholdWidth),
-            typeof(double),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(720d, OnCompactModeThresholdWidthChanged));
-
-        /// <summary>
-        /// Identifies the <see cref="BackButtonBehavior"/> dependency property
-        /// </summary>
+        /// <returns>The identifier for the <see cref="BackButtonBehavior"/> dependency property.</returns>
         public static readonly DependencyProperty BackButtonBehaviorProperty = DependencyProperty.Register(
             nameof(BackButtonBehavior),
             typeof(BackButtonBehavior),
             typeof(MasterDetailsView),
-            new PropertyMetadata(BackButtonBehavior.System, OnBackButtonBehaviorChanged));
+            new PropertyMetadata(null, OnBackButtonBehaviorChanged));
 
         /// <summary>
-        /// Gets or sets the selected item.
+        /// Identifies the <see cref="ViewState"/> dependency property.
         /// </summary>
-        /// <returns>The selected item. The default is null.</returns>
-        public object SelectedItem
-        {
-            get { return GetValue(SelectedItemProperty); }
-            set { SetValue(SelectedItemProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the DataTemplate used to display the details.
-        /// </summary>
-        public DataTemplate DetailsTemplate
-        {
-            get { return (DataTemplate)GetValue(DetailsTemplateProperty); }
-            set { SetValue(DetailsTemplateProperty, value); }
-        }
+        /// <returns>The identifier for the <see cref="ViewState"/> dependency property.</returns>
+        public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(
+            nameof(ViewState),
+            typeof(MasterDetailsViewState),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(default(MasterDetailsViewState)));
 
         /// <summary>
         /// Gets or sets the Brush to apply to the background of the list area of the control.
@@ -193,7 +226,51 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the content for the master pane's header
+        /// Gets or sets the Brush to apply to the background of the details area of the control.
+        /// </summary>
+        /// <returns>The Brush to apply to the background of the details area of the control.</returns>
+        public Brush DetailsPaneBackground
+        {
+            get { return (Brush)GetValue(DetailsPaneBackgroundProperty); }
+            set { SetValue(DetailsPaneBackgroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the selected item.
+        /// </summary>
+        /// <returns>The selected item. The default is null.</returns>
+        public object SelectedItem
+        {
+            get { return GetValue(SelectedItemProperty); }
+            set { SetValue(SelectedItemProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the content for the master pane's no items presenter.
+        /// </summary>
+        /// <returns>
+        /// The content of the master pane's header. The default is null.
+        /// </returns>
+        public object NoItemsContent
+        {
+            get { return GetValue(NoItemsContentProperty); }
+            set { SetValue(NoItemsContentProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the DataTemplate used to display the master pane's no items presenter.
+        /// </summary>
+        /// <returns>
+        /// The template that specifies the visualization of the master pane no items object. The default is null.
+        /// </returns>
+        public DataTemplate NoItemsContentTemplate
+        {
+            get { return (DataTemplate)GetValue(NoItemsContentTemplateProperty); }
+            set { SetValue(NoItemsContentTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the content for the master pane's header.
         /// </summary>
         /// <returns>
         /// The content of the master pane's header. The default is null.
@@ -241,20 +318,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the width of the master pane when the view is expanded.
-        /// </summary>
-        /// <returns>
-        /// The width of the SplitView pane when it's fully expanded. The default is 320
-        /// device-independent pixel (DIP).
-        /// </returns>
-        public double MasterPaneWidth
-        {
-            get { return (double)GetValue(MasterPaneWidthProperty); }
-            set { SetValue(MasterPaneWidthProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the content to dsiplay when there is no item selected in the master list.
+        /// Gets or sets the content to display when there is no item selected in the master list.
         /// </summary>
         public object NoSelectionContent
         {
@@ -276,12 +340,52 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets the current visual state of the control
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the details presenter.
         /// </summary>
-        public MasterDetailsViewState ViewState
+        public DataTemplateSelector DetailsContentTemplateSelector
         {
-            get { return (MasterDetailsViewState)GetValue(ViewStateProperty); }
-            private set { SetValue(ViewStateProperty, value); }
+            get { return (DataTemplateSelector)GetValue(DetailsContentTemplateSelectorProperty); }
+            set { SetValue(DetailsContentTemplateSelectorProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the DataTemplate used to display the details.
+        /// </summary>
+        public DataTemplate DetailsTemplate
+        {
+            get { return (DataTemplate)GetValue(DetailsTemplateProperty); }
+            set { SetValue(DetailsTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the master list items.
+        /// </summary>
+        public DataTemplateSelector MasterItemTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(MasterItemTemplateSelectorProperty); }
+            set { SetValue(MasterItemTemplateSelectorProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the width of the master pane when the view is expanded.
+        /// </summary>
+        /// <returns>
+        /// The width of the SplitView pane when it's fully expanded. The default is 320
+        /// device-independent pixel (DIP).
+        /// </returns>
+        public GridLength MasterPaneWidth
+        {
+            get { return (GridLength)GetValue(MasterPaneWidthProperty); }
+            set { SetValue(MasterPaneWidthProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the Threshold width that will trigger the control to go into compact mode.
+        /// </summary>
+        public double CompactModeThresholdWidth
+        {
+            get { return (double)GetValue(CompactModeThresholdWidthProperty); }
+            set { SetValue(CompactModeThresholdWidthProperty, value); }
         }
 
         /// <summary>
@@ -303,16 +407,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the Threshold width that witll trigger the control to go into compact mode
-        /// </summary>
-        public double CompactModeThresholdWidth
-        {
-            get { return (double)GetValue(CompactModeThresholdWidthProperty); }
-            set { SetValue(CompactModeThresholdWidthProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the behavior to use for the back button
+        /// Gets or sets the behavior to use for the back button.
         /// </summary>
         /// <returns>The current BackButtonBehavior. The default is System.</returns>
         public BackButtonBehavior BackButtonBehavior
@@ -322,9 +417,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets gets the current visual state of the control.
+        /// </summary>
+        public MasterDetailsViewState ViewState
+        {
+            get { return (MasterDetailsViewState)GetValue(ViewStateProperty); }
+            set { SetValue(ViewStateProperty, value); }
+        }
+
+        /// <summary>
         /// Gets or sets a function for mapping the selected item to a different model.
         /// This new model will be the DataContext of the Details area.
         /// </summary>
         public Func<object, object> MapDetails { get; set; }
+
+        private static void OnDetailsCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((MasterDetailsView)d).OnDetailsCommandBarChanged();
+        }
+
+        private static void OnMasterCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((MasterDetailsView)d).OnMasterCommandBarChanged();
+        }
+
+        private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((MasterDetailsView)d).OnSelectedItemChanged(e);
+        }
+
+        private static void OnCompactModeThresholdWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+
+        private static void OnBackButtonBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
@@ -16,26 +16,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class MasterDetailsView
     {
         /// <summary>
-        /// Identifies the <see cref="MasterPaneBackground"/> dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="MasterPaneBackground"/> dependency property.</returns>
-        public static readonly DependencyProperty MasterPaneBackgroundProperty = DependencyProperty.Register(
-            nameof(MasterPaneBackground),
-            typeof(Brush),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <see cref="DetailsPaneBackground"/> dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="DetailsPaneBackground"/> dependency property.</returns>
-        public static readonly DependencyProperty DetailsPaneBackgroundProperty = DependencyProperty.Register(
-            nameof(DetailsPaneBackground),
-            typeof(Brush),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(null));
-
-        /// <summary>
         /// Identifies the <see cref="SelectedItem"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="SelectedItem"/> dependency property.</returns>
@@ -46,22 +26,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnSelectedItemChanged));
 
         /// <summary>
-        /// Identifies the <see cref="MasterNoItemsContent"/> dependency property.
+        /// Identifies the <see cref="DetailsTemplate"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="MasterNoItemsContent"/> dependency property.</returns>
-        public static readonly DependencyProperty MasterNoItemsContentProperty = DependencyProperty.Register(
-            nameof(MasterNoItemsContent),
-            typeof(object),
+        /// <returns>The identifier for the <see cref="DetailsTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsTemplateProperty = DependencyProperty.Register(
+            nameof(DetailsTemplate),
+            typeof(DataTemplate),
             typeof(MasterDetailsView),
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="MasterNoItemsContentTemplate"/> dependency property.
+        /// Identifies the <see cref="MasterPaneBackground"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="MasterNoItemsContentTemplate"/> dependency property.</returns>
-        public static readonly DependencyProperty MasterNoItemsContentTemplateProperty = DependencyProperty.Register(
-            nameof(MasterNoItemsContentTemplate),
-            typeof(DataTemplate),
+        /// <returns>The identifier for the <see cref="MasterPaneBackground"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterPaneBackgroundProperty = DependencyProperty.Register(
+            nameof(MasterPaneBackground),
+            typeof(Brush),
             typeof(MasterDetailsView),
             new PropertyMetadata(null));
 
@@ -105,6 +85,47 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             typeof(MasterDetailsView),
             new PropertyMetadata(null));
 
+
+        /// <summary>
+        /// Identifies the <see cref="DetailsPaneBackground"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="DetailsPaneBackground"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsPaneBackgroundProperty = DependencyProperty.Register(
+            nameof(DetailsPaneBackground),
+            typeof(Brush),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="MasterNoItemsContent"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="MasterNoItemsContent"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterNoItemsContentProperty = DependencyProperty.Register(
+            nameof(MasterNoItemsContent),
+            typeof(object),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="MasterNoItemsContentTemplate"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="MasterNoItemsContentTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterNoItemsContentTemplateProperty = DependencyProperty.Register(
+            nameof(MasterNoItemsContentTemplate),
+            typeof(DataTemplate),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="MasterPaneWidth"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="MasterPaneWidth"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterPaneWidthProperty = DependencyProperty.Register(
+            nameof(MasterPaneWidth),
+            typeof(GridLength),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(new GridLength(320)));
+
         /// <summary>
         /// Identifies the <see cref="NoSelectionContent"/> dependency property.
         /// </summary>
@@ -126,54 +147,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="DetailsContentTemplateSelector"/> dependency property.
+        /// Identifies the <see cref="ViewState"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="DetailsContentTemplateSelector"/> dependency property.</returns>
-        public static readonly DependencyProperty DetailsContentTemplateSelectorProperty = DependencyProperty.Register(
-            nameof(DetailsContentTemplateSelector),
-            typeof(DataTemplateSelector),
+        /// <returns>The identifier for the <see cref="ViewState"/> dependency property.</returns>
+        public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(
+            nameof(ViewState),
+            typeof(MasterDetailsViewState),
             typeof(MasterDetailsView),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <see cref="DetailsTemplate"/> dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="DetailsTemplate"/> dependency property.</returns>
-        public static readonly DependencyProperty DetailsTemplateProperty = DependencyProperty.Register(
-            nameof(DetailsTemplate),
-            typeof(DataTemplate),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <see cref="MasterItemTemplateSelector"/> dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="MasterItemTemplateSelector"/> dependency property.</returns>
-        public static readonly DependencyProperty MasterItemTemplateSelectorProperty = DependencyProperty.Register(
-            nameof(MasterItemTemplateSelector),
-            typeof(DataTemplateSelector),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <see cref="MasterPaneWidth"/> dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="MasterPaneWidth"/> dependency property.</returns>
-        public static readonly DependencyProperty MasterPaneWidthProperty = DependencyProperty.Register(
-            nameof(MasterPaneWidth),
-            typeof(GridLength),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(new GridLength(320)));
-
-        /// <summary>
-        /// Identifies the <see cref="CompactModeThresholdWidth"/> dependency property.
-        /// </summary>
-        /// <returns>The identifier for the <see cref="CompactModeThresholdWidth"/> dependency property.</returns>
-        public static readonly DependencyProperty CompactModeThresholdWidthProperty = DependencyProperty.Register(
-            nameof(CompactModeThresholdWidth),
-            typeof(double),
-            typeof(MasterDetailsView),
-            new PropertyMetadata(640d));
+            new PropertyMetadata(default(MasterDetailsViewState)));
 
         /// <summary>
         /// Identifies the <see cref="MasterCommandBar"/> dependency property.
@@ -196,6 +177,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnDetailsCommandBarChanged));
 
         /// <summary>
+        /// Identifies the <see cref="CompactModeThresholdWidth"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="CompactModeThresholdWidth"/> dependency property.</returns>
+        public static readonly DependencyProperty CompactModeThresholdWidthProperty = DependencyProperty.Register(
+            nameof(CompactModeThresholdWidth),
+            typeof(double),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(640d));
+
+        /// <summary>
         /// Identifies the <see cref="BackButtonBehavior"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="BackButtonBehavior"/> dependency property.</returns>
@@ -206,14 +197,43 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnBackButtonBehaviorChanged));
 
         /// <summary>
-        /// Identifies the <see cref="ViewState"/> dependency property.
+        /// Identifies the <see cref="DetailsContentTemplateSelector"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="ViewState"/> dependency property.</returns>
-        public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(
-            nameof(ViewState),
-            typeof(MasterDetailsViewState),
+        /// <returns>The identifier for the <see cref="DetailsContentTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsContentTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(DetailsContentTemplateSelector),
+            typeof(DataTemplateSelector),
             typeof(MasterDetailsView),
-            new PropertyMetadata(default(MasterDetailsViewState)));
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="MasterItemTemplateSelector"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="MasterItemTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterItemTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(MasterItemTemplateSelector),
+            typeof(DataTemplateSelector),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the selected item.
+        /// </summary>
+        /// <returns>The selected item. The default is null.</returns>
+        public object SelectedItem
+        {
+            get { return GetValue(SelectedItemProperty); }
+            set { SetValue(SelectedItemProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the DataTemplate used to display the details.
+        /// </summary>
+        public DataTemplate DetailsTemplate
+        {
+            get { return (DataTemplate)GetValue(DetailsTemplateProperty); }
+            set { SetValue(DetailsTemplateProperty, value); }
+        }
 
         /// <summary>
         /// Gets or sets the Brush to apply to the background of the list area of the control.
@@ -233,16 +253,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (Brush)GetValue(DetailsPaneBackgroundProperty); }
             set { SetValue(DetailsPaneBackgroundProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the selected item.
-        /// </summary>
-        /// <returns>The selected item. The default is null.</returns>
-        public object SelectedItem
-        {
-            get { return GetValue(SelectedItemProperty); }
-            set { SetValue(SelectedItemProperty, value); }
         }
 
         /// <summary>
@@ -318,6 +328,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets the width of the master pane when the view is expanded.
+        /// </summary>
+        /// <returns>
+        /// The width of the SplitView pane when it's fully expanded. The default is 320
+        /// device-independent pixel (DIP).
+        /// </returns>
+        public GridLength MasterPaneWidth
+        {
+            get { return (GridLength)GetValue(MasterPaneWidthProperty); }
+            set { SetValue(MasterPaneWidthProperty, value); }
+        }
+
+        /// <summary>
         /// Gets or sets the content to display when there is no item selected in the master list.
         /// </summary>
         public object NoSelectionContent
@@ -340,52 +363,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="DataTemplateSelector"/> for the details presenter.
+        /// Gets or sets gets the current visual state of the control.
         /// </summary>
-        public DataTemplateSelector DetailsContentTemplateSelector
+        public MasterDetailsViewState ViewState
         {
-            get { return (DataTemplateSelector)GetValue(DetailsContentTemplateSelectorProperty); }
-            set { SetValue(DetailsContentTemplateSelectorProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the DataTemplate used to display the details.
-        /// </summary>
-        public DataTemplate DetailsTemplate
-        {
-            get { return (DataTemplate)GetValue(DetailsTemplateProperty); }
-            set { SetValue(DetailsTemplateProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="DataTemplateSelector"/> for the master list items.
-        /// </summary>
-        public DataTemplateSelector MasterItemTemplateSelector
-        {
-            get { return (DataTemplateSelector)GetValue(MasterItemTemplateSelectorProperty); }
-            set { SetValue(MasterItemTemplateSelectorProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the width of the master pane when the view is expanded.
-        /// </summary>
-        /// <returns>
-        /// The width of the SplitView pane when it's fully expanded. The default is 320
-        /// device-independent pixel (DIP).
-        /// </returns>
-        public GridLength MasterPaneWidth
-        {
-            get { return (GridLength)GetValue(MasterPaneWidthProperty); }
-            set { SetValue(MasterPaneWidthProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the Threshold width that will trigger the control to go into compact mode.
-        /// </summary>
-        public double CompactModeThresholdWidth
-        {
-            get { return (double)GetValue(CompactModeThresholdWidthProperty); }
-            set { SetValue(CompactModeThresholdWidthProperty, value); }
+            get { return (MasterDetailsViewState)GetValue(ViewStateProperty); }
+            set { SetValue(ViewStateProperty, value); }
         }
 
         /// <summary>
@@ -407,6 +390,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets the Threshold width that will trigger the control to go into compact mode.
+        /// </summary>
+        public double CompactModeThresholdWidth
+        {
+            get { return (double)GetValue(CompactModeThresholdWidthProperty); }
+            set { SetValue(CompactModeThresholdWidthProperty, value); }
+        }
+
+        /// <summary>
         /// Gets or sets the behavior to use for the back button.
         /// </summary>
         /// <returns>The current BackButtonBehavior. The default is System.</returns>
@@ -417,12 +409,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets gets the current visual state of the control.
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the details presenter.
         /// </summary>
-        public MasterDetailsViewState ViewState
+        public DataTemplateSelector DetailsContentTemplateSelector
         {
-            get { return (MasterDetailsViewState)GetValue(ViewStateProperty); }
-            set { SetValue(ViewStateProperty, value); }
+            get { return (DataTemplateSelector)GetValue(DetailsContentTemplateSelectorProperty); }
+            set { SetValue(DetailsContentTemplateSelectorProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the master list items.
+        /// </summary>
+        public DataTemplateSelector MasterItemTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(MasterItemTemplateSelectorProperty); }
+            set { SetValue(MasterItemTemplateSelectorProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
@@ -46,21 +46,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnSelectedItemChanged));
 
         /// <summary>
-        /// Identifies the <see cref="NoItemsContent"/> dependency property.
+        /// Identifies the <see cref="MasterNoItemsContent"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="NoItemsContent"/> dependency property.</returns>
-        public static readonly DependencyProperty NoItemsContentProperty = DependencyProperty.Register(
-            nameof(NoItemsContent),
+        /// <returns>The identifier for the <see cref="MasterNoItemsContent"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterNoItemsContentProperty = DependencyProperty.Register(
+            nameof(MasterNoItemsContent),
             typeof(object),
             typeof(MasterDetailsView),
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="NoItemsContentTemplate"/> dependency property.
+        /// Identifies the <see cref="MasterNoItemsContentTemplate"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="NoItemsContentTemplate"/> dependency property.</returns>
-        public static readonly DependencyProperty NoItemsContentTemplateProperty = DependencyProperty.Register(
-            nameof(NoItemsContentTemplate),
+        /// <returns>The identifier for the <see cref="MasterNoItemsContentTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty MasterNoItemsContentTemplateProperty = DependencyProperty.Register(
+            nameof(MasterNoItemsContentTemplate),
             typeof(DataTemplate),
             typeof(MasterDetailsView),
             new PropertyMetadata(null));
@@ -251,10 +251,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>
         /// The content of the master pane's header. The default is null.
         /// </returns>
-        public object NoItemsContent
+        public object MasterNoItemsContent
         {
-            get { return GetValue(NoItemsContentProperty); }
-            set { SetValue(NoItemsContentProperty, value); }
+            get { return GetValue(MasterNoItemsContentProperty); }
+            set { SetValue(MasterNoItemsContentProperty, value); }
         }
 
         /// <summary>
@@ -263,10 +263,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>
         /// The template that specifies the visualization of the master pane no items object. The default is null.
         /// </returns>
-        public DataTemplate NoItemsContentTemplate
+        public DataTemplate MasterNoItemsContentTemplate
         {
-            get { return (DataTemplate)GetValue(NoItemsContentTemplateProperty); }
-            set { SetValue(NoItemsContentTemplateProperty, value); }
+            get { return (DataTemplate)GetValue(MasterNoItemsContentTemplateProperty); }
+            set { SetValue(MasterNoItemsContentTemplateProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// Panel that allows for a Master/Details pattern.
     /// </summary>
     [TemplatePart(Name = PartDetailsPresenter, Type = typeof(ContentPresenter))]
-    [TemplatePart(Name = PartDetailsPane, Type = typeof(FrameworkElement))]
+    [TemplatePart(Name = PartDetailsPanel, Type = typeof(FrameworkElement))]
     [TemplateVisualState(Name = NoSelectionNarrowState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = NoSelectionWideState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = HasSelectionWideState, GroupName = SelectionStates)]
@@ -36,9 +36,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private const string HasNoItemsState = "HasNoItemsState";
 
         // Control names:
-        private const string PartRootPane = "RootPane";
+        private const string PartRootPanel = "RootPanel";
         private const string PartDetailsPresenter = "DetailsPresenter";
-        private const string PartDetailsPane = "DetailsPane";
+        private const string PartDetailsPanel = "DetailsPanel";
         private const string PartMasterList = "MasterList";
         private const string PartBackButton = "MasterDetailsBackButton";
         private const string PartHeaderContentPresenter = "HeaderContentPresenter";
@@ -226,7 +226,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void FocusFirstFocusableElementInDetails()
         {
-            if (GetTemplateChild(PartDetailsPane) is DependencyObject details)
+            if (GetTemplateChild(PartDetailsPanel) is DependencyObject details)
             {
                 DependencyObject focusableElement = FocusManager.FindFirstFocusableElement(details);
                 (focusableElement as Control)?.Focus(FocusState.Programmatic);
@@ -306,7 +306,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
             }
 
-            _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PartRootPane);
+            _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PartRootPanel);
             if (_twoPaneView != null)
             {
                 _twoPaneView.ModeChanged += OnModeChanged;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -179,12 +179,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             MasterDetailsViewState previousState = ViewState;
 
+            if (twoPaneView is null)
+            {
+                ViewState = MasterDetailsViewState.Both;
+            }
+
             // Single pane:
-            if (twoPaneView.Mode == Microsoft.UI.Xaml.Controls.TwoPaneViewMode.SinglePane)
+            else if (twoPaneView.Mode == Microsoft.UI.Xaml.Controls.TwoPaneViewMode.SinglePane)
             {
                 ViewState = SelectedItem is null ? MasterDetailsViewState.Master : MasterDetailsViewState.Details;
                 twoPaneView.PanePriority = SelectedItem is null ? Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane1 : Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane2;
             }
+
             // Dual pane:
             else
             {
@@ -342,8 +348,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
                 }
-
-                UpdateView(true);
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -48,12 +48,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Used to prevent screen flickering if only the order of the selected item changed.
         /// </summary>
-        private bool ignoreClearSelectedItem;
+        private bool _ignoreClearSelectedItem;
 
-        private ContentPresenter detailsPresenter;
-        private Microsoft.UI.Xaml.Controls.TwoPaneView twoPaneView;
-        private VisualStateGroup selectionStateGroup;
+        private ContentPresenter _detailsPresenter;
+        private Microsoft.UI.Xaml.Controls.TwoPaneView _twoPaneView;
+        private VisualStateGroup _selectionStateGroup;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MasterDetailsView"/> class.
+        /// </summary>
         public MasterDetailsView()
         {
             DefaultStyleKey = typeof(MasterDetailsView);
@@ -90,15 +93,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void SetDetailsContent()
         {
-            if (detailsPresenter != null)
+            if (_detailsPresenter != null)
             {
                 // Update the content template:
-                if (!(detailsPresenter.ContentTemplateSelector is null))
+                if (!(_detailsPresenter.ContentTemplateSelector is null))
                 {
-                    detailsPresenter.ContentTemplate = detailsPresenter.ContentTemplateSelector.SelectTemplate(SelectedItem, detailsPresenter);
+                    _detailsPresenter.ContentTemplate = _detailsPresenter.ContentTemplateSelector.SelectTemplate(SelectedItem, _detailsPresenter);
                 }
                 // Update the content:
-                detailsPresenter.Content = MapDetails is null
+                _detailsPresenter.Content = MapDetails is null
                     ? SelectedItem
                     : !(SelectedItem is null) ? MapDetails(SelectedItem) : null;
 
@@ -120,9 +123,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public void ClearSelectedItem()
         {
-            ignoreClearSelectedItem = true;
+            _ignoreClearSelectedItem = true;
             SelectedItem = null;
-            ignoreClearSelectedItem = false;
+            _ignoreClearSelectedItem = false;
         }
 
         private void OnCommandBarChanged(string panelName, CommandBar commandbar)
@@ -152,7 +155,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void OnSelectedItemChanged(DependencyPropertyChangedEventArgs e)
         {
             // Prevent setting the SelectedItem to null if only the order changed (=> collection reset got triggered).
-            if (!ignoreClearSelectedItem && !(e.OldValue is null) && e.NewValue is null && Items.Contains(e.OldValue))
+            if (!_ignoreClearSelectedItem && !(e.OldValue is null) && e.NewValue is null && Items.Contains(e.OldValue))
             {
                 SelectedItem = e.OldValue;
                 return;
@@ -179,16 +182,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             MasterDetailsViewState previousState = ViewState;
 
-            if (twoPaneView is null)
+            if (_twoPaneView is null)
             {
                 ViewState = MasterDetailsViewState.Both;
             }
 
             // Single pane:
-            else if (twoPaneView.Mode == Microsoft.UI.Xaml.Controls.TwoPaneViewMode.SinglePane)
+            else if (_twoPaneView.Mode == Microsoft.UI.Xaml.Controls.TwoPaneViewMode.SinglePane)
             {
                 ViewState = SelectedItem is null ? MasterDetailsViewState.Master : MasterDetailsViewState.Details;
-                twoPaneView.PanePriority = SelectedItem is null ? Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane1 : Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane2;
+                _twoPaneView.PanePriority = SelectedItem is null ? Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane1 : Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane2;
             }
 
             // Dual pane:
@@ -279,24 +282,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             base.OnApplyTemplate();
 
-            if (!(inlineBackButton is null))
+            if (!(_inlineBackButton is null))
             {
-                inlineBackButton.Click -= OnInlineBackButtonClicked;
+                _inlineBackButton.Click -= OnInlineBackButtonClicked;
             }
 
-            inlineBackButton = (Button)GetTemplateChild(PART_BACK_BUTTON);
-            if (!(inlineBackButton is null))
+            _inlineBackButton = (Button)GetTemplateChild(PART_BACK_BUTTON);
+            if (!(_inlineBackButton is null))
             {
-                inlineBackButton.Click += OnInlineBackButtonClicked;
+                _inlineBackButton.Click += OnInlineBackButtonClicked;
             }
 
-            twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PART_ROOT_PANE);
-            if (!(twoPaneView is null))
+            _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PART_ROOT_PANE);
+            if (!(_twoPaneView is null))
             {
-                twoPaneView.ModeChanged += OnModeChanged;
+                _twoPaneView.ModeChanged += OnModeChanged;
             }
 
-            detailsPresenter = (ContentPresenter)GetTemplateChild(PART_DETAILS_PRESENTER);
+            _detailsPresenter = (ContentPresenter)GetTemplateChild(PART_DETAILS_PRESENTER);
 
             SetDetailsContent();
 
@@ -312,16 +315,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (!DesignMode.DesignModeEnabled)
             {
                 SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested;
-                if (!(frame is null))
+                if (!(_frame is null))
                 {
-                    frame.Navigating -= OnFrameNavigating;
+                    _frame.Navigating -= OnFrameNavigating;
                 }
 
-                selectionStateGroup = (VisualStateGroup)GetTemplateChild(SELECTION_STATES);
-                if (!(selectionStateGroup is null))
+                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SELECTION_STATES);
+                if (!(_selectionStateGroup is null))
                 {
-                    selectionStateGroup.CurrentStateChanged -= OnSelectionStateChanged;
-                    selectionStateGroup = null;
+                    _selectionStateGroup.CurrentStateChanged -= OnSelectionStateChanged;
+                    _selectionStateGroup = null;
                 }
             }
         }
@@ -331,22 +334,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (!DesignMode.DesignModeEnabled)
             {
                 SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
-                if (!(frame is null))
+                if (!(_frame is null))
                 {
-                    frame.Navigating -= OnFrameNavigating;
+                    _frame.Navigating -= OnFrameNavigating;
                 }
 
-                navigationView = this.FindAscendants().FirstOrDefault(p => p.GetType().FullName == "Microsoft.UI.Xaml.Controls.NavigationView");
-                frame = this.FindAscendant<Frame>();
-                if (!(frame is null))
+                _navigationView = this.FindAscendants().FirstOrDefault(p => p.GetType().FullName == "Microsoft.UI.Xaml.Controls.NavigationView");
+                _frame = this.FindAscendant<Frame>();
+                if (!(_frame is null))
                 {
-                    frame.Navigating += OnFrameNavigating;
+                    _frame.Navigating += OnFrameNavigating;
                 }
 
-                selectionStateGroup = (VisualStateGroup)GetTemplateChild(SELECTION_STATES);
-                if (!(selectionStateGroup is null))
+                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SELECTION_STATES);
+                if (!(_selectionStateGroup is null))
                 {
-                    selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
+                    _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -16,34 +16,34 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// Panel that allows for a Master/Details pattern.
     /// </summary>
-    [TemplatePart(Name = PART_DETAILS_PRESENTER, Type = typeof(ContentPresenter))]
-    [TemplatePart(Name = PART_DETAILS_PANE, Type = typeof(FrameworkElement))]
-    [TemplateVisualState(Name = NO_SELECTION_NARROW, GroupName = SELECTION_STATES)]
-    [TemplateVisualState(Name = NO_SELECTION_WIDE, GroupName = SELECTION_STATES)]
-    [TemplateVisualState(Name = HAS_SELECTION_WIDE, GroupName = SELECTION_STATES)]
-    [TemplateVisualState(Name = HAS_SELECTION_NARROW, GroupName = SELECTION_STATES)]
+    [TemplatePart(Name = PartDetailsPresenter, Type = typeof(ContentPresenter))]
+    [TemplatePart(Name = PartDetailsPane, Type = typeof(FrameworkElement))]
+    [TemplateVisualState(Name = NoSelectionNarrowState, GroupName = SelectionStates)]
+    [TemplateVisualState(Name = NoSelectionWideState, GroupName = SelectionStates)]
+    [TemplateVisualState(Name = HasSelectionWideState, GroupName = SelectionStates)]
+    [TemplateVisualState(Name = HasSelectionNarrowState, GroupName = SelectionStates)]
     public partial class MasterDetailsView : ItemsControl
     {
         // All view states:
-        private const string SELECTION_STATES = "SelectionStates";
-        private const string NO_SELECTION_WIDE = "NoSelectionWide";
-        private const string HAS_SELECTION_WIDE = "HasSelectionWide";
-        private const string NO_SELECTION_NARROW = "NoSelectionNarrow";
-        private const string HAS_SELECTION_NARROW = "HasSelectionNarrow";
+        private const string SelectionStates = "SelectionStates";
+        private const string NoSelectionWideState = "NoSelectionWide";
+        private const string HasSelectionWideState = "HasSelectionWide";
+        private const string NoSelectionNarrowState = "NoSelectionNarrow";
+        private const string HasSelectionNarrowState = "HasSelectionNarrow";
 
-        private const string HAS_ITEMS_STATES = "HasItemsStates";
-        private const string HAS_ITEMS_STATE = "HasItemsState";
-        private const string HAS_NO_ITEMS_STATE = "HasNoItemsState";
+        private const string HasItemsStates = "HasItemsStates";
+        private const string HasItemsState = "HasItemsState";
+        private const string HasNoItemsState = "HasNoItemsState";
 
         // Control names:
-        private const string PART_ROOT_PANE = "RootPane";
-        private const string PART_DETAILS_PRESENTER = "DetailsPresenter";
-        private const string PART_DETAILS_PANE = "DetailsPane";
-        private const string PART_MASTER_LIST = "MasterList";
-        private const string PART_BACK_BUTTON = "MasterDetailsBackButton";
-        private const string PART_HEADER_CONTENT_PRESENTER = "HeaderContentPresenter";
-        private const string PART_MASTER_COMMAND_BAR = "MasterCommandBarPanel";
-        private const string PART_DETAILS_COMMAND_BAR = "DetailsCommandBarPanel";
+        private const string PartRootPane = "RootPane";
+        private const string PartDetailsPresenter = "DetailsPresenter";
+        private const string PartDetailsPane = "DetailsPane";
+        private const string PartMasterList = "MasterList";
+        private const string PartBackButton = "MasterDetailsBackButton";
+        private const string PartHeaderContentPresenter = "HeaderContentPresenter";
+        private const string PartMasterCommandBarPanel = "MasterCommandBarPanel";
+        private const string PartDetailsCommandBarPanel = "DetailsCommandBarPanel";
 
         /// <summary>
         /// Used to prevent screen flickering if only the order of the selected item changed.
@@ -75,17 +75,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             string hasSelectionState;
             if (ViewState == MasterDetailsViewState.Both)
             {
-                noSelectionState = NO_SELECTION_WIDE;
-                hasSelectionState = HAS_SELECTION_WIDE;
+                noSelectionState = NoSelectionWideState;
+                hasSelectionState = HasSelectionWideState;
             }
             else
             {
-                noSelectionState = NO_SELECTION_NARROW;
-                hasSelectionState = HAS_SELECTION_NARROW;
+                noSelectionState = NoSelectionNarrowState;
+                hasSelectionState = HasSelectionNarrowState;
             }
 
             VisualStateManager.GoToState(this, SelectedItem is null ? noSelectionState : hasSelectionState, animate);
-            VisualStateManager.GoToState(this, Items.Count > 0 ? HAS_ITEMS_STATE : HAS_NO_ITEMS_STATE, animate);
+            VisualStateManager.GoToState(this, Items.Count > 0 ? HasItemsState : HasNoItemsState, animate);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void SetMasterHeaderVisibility()
         {
-            if (GetTemplateChild(PART_HEADER_CONTENT_PRESENTER) is FrameworkElement headerPresenter)
+            if (GetTemplateChild(PartHeaderContentPresenter) is FrameworkElement headerPresenter)
             {
                 headerPresenter.Visibility = MasterHeader != null
                     ? Visibility.Visible
@@ -144,12 +144,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnMasterCommandBarChanged()
         {
-            OnCommandBarChanged(PART_MASTER_COMMAND_BAR, MasterCommandBar);
+            OnCommandBarChanged(PartMasterCommandBarPanel, MasterCommandBar);
         }
 
         private void OnDetailsCommandBarChanged()
         {
-            OnCommandBarChanged(PART_DETAILS_COMMAND_BAR, DetailsCommandBar);
+            OnCommandBarChanged(PartDetailsCommandBarPanel, DetailsCommandBar);
         }
 
         private void OnSelectedItemChanged(DependencyPropertyChangedEventArgs e)
@@ -228,7 +228,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void FocusFirstFocusableElementInDetails()
         {
-            if (GetTemplateChild(PART_DETAILS_PANE) is DependencyObject details)
+            if (GetTemplateChild(PartDetailsPane) is DependencyObject details)
             {
                 DependencyObject focusableElement = FocusManager.FindFirstFocusableElement(details);
                 (focusableElement as Control)?.Focus(FocusState.Programmatic);
@@ -240,7 +240,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void FocusItemList()
         {
-            if (GetTemplateChild(PART_MASTER_LIST) is Control masterList)
+            if (GetTemplateChild(PartMasterList) is Control masterList)
             {
                 masterList.Focus(FocusState.Programmatic);
             }
@@ -267,7 +267,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void SetListSelectionWithKeyboardFocus(bool singleSelectionFollowsFocus)
         {
-            if (GetTemplateChild(PART_MASTER_COMMAND_BAR) is ListViewBase masterList)
+            if (GetTemplateChild(PartMasterCommandBarPanel) is ListViewBase masterList)
             {
                 masterList.SingleSelectionFollowsFocus = singleSelectionFollowsFocus;
             }
@@ -287,19 +287,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _inlineBackButton.Click -= OnInlineBackButtonClicked;
             }
 
-            _inlineBackButton = (Button)GetTemplateChild(PART_BACK_BUTTON);
+            _inlineBackButton = (Button)GetTemplateChild(PartBackButton);
             if (!(_inlineBackButton is null))
             {
                 _inlineBackButton.Click += OnInlineBackButtonClicked;
             }
 
-            _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PART_ROOT_PANE);
+            _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PartRootPane);
             if (!(_twoPaneView is null))
             {
                 _twoPaneView.ModeChanged += OnModeChanged;
             }
 
-            _detailsPresenter = (ContentPresenter)GetTemplateChild(PART_DETAILS_PRESENTER);
+            _detailsPresenter = (ContentPresenter)GetTemplateChild(PartDetailsPresenter);
 
             SetDetailsContent();
 
@@ -320,7 +320,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     _frame.Navigating -= OnFrameNavigating;
                 }
 
-                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SELECTION_STATES);
+                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
                 if (!(_selectionStateGroup is null))
                 {
                     _selectionStateGroup.CurrentStateChanged -= OnSelectionStateChanged;
@@ -346,7 +346,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     _frame.Navigating += OnFrameNavigating;
                 }
 
-                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SELECTION_STATES);
+                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
                 if (!(_selectionStateGroup is null))
                 {
                     _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Toolkit.Uwp.UI.Extensions;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.ApplicationModel;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -100,6 +100,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _detailsPresenter.ContentTemplate = _detailsPresenter.ContentTemplateSelector.SelectTemplate(SelectedItem, _detailsPresenter);
                 }
+
                 // Update the content:
                 _detailsPresenter.Content = MapDetails == null
                     ? SelectedItem

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 hasSelectionState = HasSelectionNarrowState;
             }
 
-            VisualStateManager.GoToState(this, SelectedItem is null ? noSelectionState : hasSelectionState, animate);
+            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : hasSelectionState, animate);
             VisualStateManager.GoToState(this, Items.Count > 0 ? HasItemsState : HasNoItemsState, animate);
         }
 
@@ -96,14 +96,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (_detailsPresenter != null)
             {
                 // Update the content template:
-                if (!(_detailsPresenter.ContentTemplateSelector is null))
+                if (_detailsPresenter.ContentTemplateSelector != null)
                 {
                     _detailsPresenter.ContentTemplate = _detailsPresenter.ContentTemplateSelector.SelectTemplate(SelectedItem, _detailsPresenter);
                 }
                 // Update the content:
-                _detailsPresenter.Content = MapDetails is null
+                _detailsPresenter.Content = MapDetails == null
                     ? SelectedItem
-                    : !(SelectedItem is null) ? MapDetails(SelectedItem) : null;
+                    : SelectedItem != null ? MapDetails(SelectedItem) : null;
             }
         }
 
@@ -129,15 +129,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnCommandBarChanged(string panelName, CommandBar commandbar)
         {
-            if (!(GetTemplateChild(panelName) is Panel panel))
+            if (GetTemplateChild(panelName) is Panel panel)
             {
-                return;
-            }
-
-            panel.Children.Clear();
-            if (commandbar != null)
-            {
-                panel.Children.Add(commandbar);
+                panel.Children.Clear();
+                if (commandbar != null)
+                {
+                    panel.Children.Add(commandbar);
+                }
             }
         }
 
@@ -154,7 +152,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void OnSelectedItemChanged(DependencyPropertyChangedEventArgs e)
         {
             // Prevent setting the SelectedItem to null if only the order changed (=> collection reset got triggered).
-            if (!_ignoreClearSelectedItem && !(e.OldValue is null) && e.NewValue is null && Items.Contains(e.OldValue))
+            if (!_ignoreClearSelectedItem && e.OldValue != null && e.NewValue == null && Items.Contains(e.OldValue))
             {
                 SelectedItem = e.OldValue;
                 return;
@@ -165,7 +163,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             UpdateView(true);
 
             // If there is no selection, do not remove the DetailsPresenter content but let it animate out.
-            if (!(SelectedItem is null))
+            if (SelectedItem != null)
             {
                 SetDetailsContent();
             }
@@ -181,7 +179,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             MasterDetailsViewState previousState = ViewState;
 
-            if (_twoPaneView is null)
+            if (_twoPaneView == null)
             {
                 ViewState = MasterDetailsViewState.Both;
             }
@@ -189,8 +187,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // Single pane:
             else if (_twoPaneView.Mode == Microsoft.UI.Xaml.Controls.TwoPaneViewMode.SinglePane)
             {
-                ViewState = SelectedItem is null ? MasterDetailsViewState.Master : MasterDetailsViewState.Details;
-                _twoPaneView.PanePriority = SelectedItem is null ? Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane1 : Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane2;
+                ViewState = SelectedItem == null ? MasterDetailsViewState.Master : MasterDetailsViewState.Details;
+                _twoPaneView.PanePriority = SelectedItem == null ? Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane1 : Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane2;
             }
 
             // Dual pane:
@@ -290,25 +288,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             base.OnApplyTemplate();
 
-            if (!(_inlineBackButton is null))
+            if (_inlineBackButton != null)
             {
                 _inlineBackButton.Click -= OnInlineBackButtonClicked;
             }
 
             _inlineBackButton = (Button)GetTemplateChild(PartBackButton);
-            if (!(_inlineBackButton is null))
+            if (_inlineBackButton != null)
             {
                 _inlineBackButton.Click += OnInlineBackButtonClicked;
             }
 
             _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
-            if (!(_selectionStateGroup is null))
+            if (_selectionStateGroup != null)
             {
                 _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
             }
 
             _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PartRootPane);
-            if (!(_twoPaneView is null))
+            if (_twoPaneView != null)
             {
                 _twoPaneView.ModeChanged += OnModeChanged;
             }
@@ -329,13 +327,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (!DesignMode.DesignModeEnabled)
             {
                 SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested;
-                if (!(_frame is null))
+                if (_frame != null)
                 {
                     _frame.Navigating -= OnFrameNavigating;
                 }
 
                 _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
-                if (!(_selectionStateGroup is null))
+                if (_selectionStateGroup != null)
                 {
                     _selectionStateGroup.CurrentStateChanged -= OnSelectionStateChanged;
                     _selectionStateGroup = null;
@@ -348,14 +346,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (!DesignMode.DesignModeEnabled)
             {
                 SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
-                if (!(_frame is null))
+                if (_frame != null)
                 {
                     _frame.Navigating -= OnFrameNavigating;
                 }
 
                 _navigationView = this.FindAscendants().FirstOrDefault(p => p.GetType().FullName == "Microsoft.UI.Xaml.Controls.NavigationView");
                 _frame = this.FindAscendant<Frame>();
-                if (!(_frame is null))
+                if (_frame != null)
                 {
                     _frame.Navigating += OnFrameNavigating;
                 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _detailsPresenter.Content = MapDetails is null
                     ? SelectedItem
                     : !(SelectedItem is null) ? MapDetails(SelectedItem) : null;
-
             }
         }
 
@@ -274,6 +273,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Invoked once the items changed and ensures the visual state is constant.
+        /// </summary>
+        protected override void OnItemsChanged(object e)
+        {
+            base.OnItemsChanged(e);
+            UpdateView(true);
+        }
+
+        /// <summary>
         /// Invoked whenever application code or internal processes (such as a rebuilding layout pass) call
         /// ApplyTemplate. In simplest terms, this means the method is called just before a UI element displays
         /// in your app. Override this method to influence the default post-template logic of a class.
@@ -291,6 +299,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (!(_inlineBackButton is null))
             {
                 _inlineBackButton.Click += OnInlineBackButtonClicked;
+            }
+
+            _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
+            if (!(_selectionStateGroup is null))
+            {
+                _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
             }
 
             _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PartRootPane);
@@ -344,12 +358,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 if (!(_frame is null))
                 {
                     _frame.Navigating += OnFrameNavigating;
-                }
-
-                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
-                if (!(_selectionStateGroup is null))
-                {
-                    _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
@@ -34,10 +34,10 @@
                                                       Content="{TemplateBinding MasterHeader}"
                                                       ContentTemplate="{TemplateBinding MasterHeaderTemplate}"
                                                       Visibility="Collapsed" />
-                                    <ContentPresenter x:Name="NoItemsPresenter"
+                                    <ContentPresenter x:Name="MasterNoItemsPresenter"
                                                       Grid.Row="1"
-                                                      Content="{TemplateBinding NoItemsContent}"
-                                                      ContentTemplate="{TemplateBinding NoItemsContentTemplate}" />
+                                                      Content="{TemplateBinding MasterNoItemsContent}"
+                                                      ContentTemplate="{TemplateBinding MasterNoItemsContentTemplate}" />
                                     <ListView x:Name="MasterList"
                                               Grid.Row="1"
                                               IsTabStop="False"
@@ -202,13 +202,13 @@
                                 <VisualState x:Name="HasItemsState">
                                     <VisualState.Setters>
                                         <Setter Target="MasterList.Visibility" Value="Visible" />
-                                        <Setter Target="NoItemsPresenter.Visibility" Value="Collapsed" />
+                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="HasNoItemsState">
                                     <VisualState.Setters>
                                         <Setter Target="MasterList.Visibility" Value="Collapsed" />
-                                        <Setter Target="NoItemsPresenter.Visibility" Value="Visible" />
+                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
@@ -14,14 +14,14 @@
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}">
-                        <muxc:TwoPaneView x:Name="RootPane"
+                        <muxc:TwoPaneView x:Name="RootPanel"
                                           MinWideModeWidth="{TemplateBinding CompactModeThresholdWidth}"
                                           Pane1Length="{TemplateBinding MasterPaneWidth}"
                                           PanePriority="Pane1"
                                           TallModeConfiguration="SinglePane"
                                           WideModeConfiguration="LeftRight">
                             <muxc:TwoPaneView.Pane1>
-                                <Grid x:Name="MasterPane"
+                                <Grid x:Name="MasterPanel"
                                       Background="{TemplateBinding MasterPaneBackground}">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
@@ -56,12 +56,12 @@
                                 </Grid>
                             </muxc:TwoPaneView.Pane1>
                             <muxc:TwoPaneView.Pane2>
-                                <Grid x:Name="DetailsPane"
+                                <Grid x:Name="DetailsPanel"
                                       Background="{TemplateBinding DetailsPaneBackground}">
                                     <ContentPresenter x:Name="NoSelectionPresenter"
                                                       Content="{TemplateBinding NoSelectionContent}"
                                                       ContentTemplate="{TemplateBinding NoSelectionContentTemplate}" />
-                                    <Grid x:Name="SelectionDetailsPane">
+                                    <Grid x:Name="SelectionDetailsPanel">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="*" />
@@ -101,7 +101,7 @@
                             <VisualStateGroup x:Name="SelectionStates">
                                 <VisualState x:Name="NoSelectionWide">
                                     <VisualState.Setters>
-                                        <Setter Target="SelectionDetailsPane.Visibility" Value="Collapsed" />
+                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="HasSelectionWide">
@@ -111,7 +111,7 @@
                                 </VisualState>
                                 <VisualState x:Name="NoSelectionNarrow">
                                     <VisualState.Setters>
-                                        <Setter Target="SelectionDetailsPane.Visibility" Value="Collapsed" />
+                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="HasSelectionNarrow">
@@ -124,7 +124,7 @@
                                     <VisualTransition From="NoSelectionWide"
                                                       To="HasSelectionWide">
                                         <Storyboard>
-                                            <DrillInThemeAnimation EntranceTargetName="SelectionDetailsPane"
+                                            <DrillInThemeAnimation EntranceTargetName="SelectionDetailsPanel"
                                                                    ExitTargetName="NoSelectionPresenter" />
                                         </Storyboard>
                                     </VisualTransition>
@@ -142,7 +142,7 @@
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
                                             <DoubleAnimation BeginTime="0:0:0"
-                                                             Storyboard.TargetName="SelectionDetailsPane"
+                                                             Storyboard.TargetName="SelectionDetailsPanel"
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="0"
                                                              To="1"
@@ -167,7 +167,7 @@
                                                       To="NoSelectionWide">
                                         <Storyboard>
                                             <DrillOutThemeAnimation EntranceTargetName="NoSelectionPresenter"
-                                                                    ExitTargetName="SelectionDetailsPane" />
+                                                                    ExitTargetName="SelectionDetailsPanel" />
                                         </Storyboard>
                                     </VisualTransition>
                                     <VisualTransition From="HasSelectionNarrow"
@@ -184,7 +184,7 @@
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
                                             <DoubleAnimation BeginTime="0:0:0"
-                                                             Storyboard.TargetName="MasterPane"
+                                                             Storyboard.TargetName="MasterPanel"
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="0"
                                                              To="1"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls">
+                    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+                    xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
     <Style TargetType="controls:MasterDetailsView">
         <Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
@@ -13,92 +14,122 @@
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}">
-                        <Grid x:Name="RootPanel">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="MasterColumn"
-                                                  Width="Auto" />
-                                <ColumnDefinition x:Name="DetailsColumn"
-                                                  Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid x:Name="MasterPanel"
-                                  Width="{TemplateBinding MasterPaneWidth}"
-                                  Background="{TemplateBinding MasterPaneBackground}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="0,0,1,0">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <ContentPresenter x:Name="HeaderContentPresenter"
-                                                  Margin="12,0"
-                                                  x:DeferLoadStrategy="Lazy"
-                                                  Content="{TemplateBinding MasterHeader}"
-                                                  ContentTemplate="{TemplateBinding MasterHeaderTemplate}"
-                                                  Visibility="Collapsed" />
-                                <ListView x:Name="MasterList"
-                                          Grid.Row="1"
-                                          IsTabStop="False"
-                                          ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
-                                          ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
-                                          ItemTemplate="{TemplateBinding ItemTemplate}"
-                                          ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                          ItemsSource="{TemplateBinding ItemsSource}"
-                                          SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
-                                <Grid x:Name="MasterCommandBarPanel" Grid.Row="2"></Grid>
-                            </Grid>
-                            <Grid x:Name="DetailsPanel"
-                                  Grid.Column="1">
-                                <ContentPresenter x:Name="NoSelectionPresenter"
-                                                  Content="{TemplateBinding NoSelectionContent}"
-                                                  ContentTemplate="{TemplateBinding NoSelectionContentTemplate}" />
-                                <Grid x:Name="SelectionDetailsPanel">
+                        <muxc:TwoPaneView x:Name="RootPane"
+                                          MinWideModeWidth="{TemplateBinding CompactModeThresholdWidth}"
+                                          Pane1Length="{TemplateBinding MasterPaneWidth}"
+                                          PanePriority="Pane1"
+                                          TallModeConfiguration="SinglePane"
+                                          WideModeConfiguration="LeftRight">
+                            <muxc:TwoPaneView.Pane1>
+                                <Grid x:Name="MasterPane"
+                                      Background="{TemplateBinding MasterPaneBackground}">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="*" />
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Grid Background="{TemplateBinding Background}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Button x:Name="MasterDetailsBackButton"
-                                                Background="Transparent"
-                                                Height="44" 
-                                                Width="48" 
-                                                Visibility="Collapsed">
-                                            <SymbolIcon Symbol="Back"/>
-                                        </Button>
-                                        <ContentPresenter x:Name="DetailsHeaderPresenter"
-                                                          Content="{TemplateBinding DetailsHeader}"
-                                                          ContentTemplate="{TemplateBinding DetailsHeaderTemplate}"
-                                                          Grid.Column="1"/>
-                                    </Grid>
-                                    <ContentPresenter x:Name="DetailsPresenter"
-                                                      Background="{TemplateBinding Background}"
-                                                      ContentTemplate="{TemplateBinding DetailsTemplate}"
-                                                      Grid.Row="1">
-                                    </ContentPresenter>
-                                    <Grid x:Name="DetailsCommandBarPanel" Grid.Row="2"></Grid>
+                                    <ContentPresenter x:Name="HeaderContentPresenter"
+                                                      Margin="12,0"
+                                                      x:DeferLoadStrategy="Lazy"
+                                                      Content="{TemplateBinding MasterHeader}"
+                                                      ContentTemplate="{TemplateBinding MasterHeaderTemplate}"
+                                                      Visibility="Collapsed" />
+                                    <ContentPresenter x:Name="NoItemsPresenter"
+                                                      Grid.Row="1"
+                                                      Content="{TemplateBinding NoItemsContent}"
+                                                      ContentTemplate="{TemplateBinding NoItemsContentTemplate}" />
+                                    <ListView x:Name="MasterList"
+                                              Grid.Row="1"
+                                              IsTabStop="False"
+                                              ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+                                              ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
+                                              ItemTemplate="{TemplateBinding ItemTemplate}"
+                                              ItemTemplateSelector="{TemplateBinding MasterItemTemplateSelector}"
+                                              ItemsSource="{TemplateBinding ItemsSource}"
+                                              SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              Visibility="Collapsed" />
+                                    <Grid x:Name="MasterCommandBarPanel"
+                                          Grid.Row="2" />
                                     <Grid.RenderTransform>
-                                        <TranslateTransform x:Name="DetailsPresenterTransform" />
+                                        <TranslateTransform x:Name="MasterPresenterTransform" />
                                     </Grid.RenderTransform>
                                 </Grid>
-                            </Grid>
-                        </Grid>
+                            </muxc:TwoPaneView.Pane1>
+                            <muxc:TwoPaneView.Pane2>
+                                <Grid x:Name="DetailsPane"
+                                      Background="{TemplateBinding DetailsPaneBackground}">
+                                    <ContentPresenter x:Name="NoSelectionPresenter"
+                                                      Content="{TemplateBinding NoSelectionContent}"
+                                                      ContentTemplate="{TemplateBinding NoSelectionContentTemplate}" />
+                                    <Grid x:Name="SelectionDetailsPane">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Button x:Name="MasterDetailsBackButton"
+                                                    Width="48"
+                                                    Height="44"
+                                                    Background="Transparent"
+                                                    Visibility="Collapsed">
+                                                <SymbolIcon Symbol="Back" />
+                                            </Button>
+                                            <ContentPresenter x:Name="DetailsHeaderPresenter"
+                                                              Grid.Column="1"
+                                                              Content="{TemplateBinding DetailsHeader}"
+                                                              ContentTemplate="{TemplateBinding DetailsHeaderTemplate}" />
+                                        </Grid>
+                                        <ContentPresenter x:Name="DetailsPresenter"
+                                                          Grid.Row="1"
+                                                          ContentTemplate="{TemplateBinding DetailsTemplate}"
+                                                          ContentTemplateSelector="{TemplateBinding DetailsContentTemplateSelector}" />
+                                        <Grid x:Name="DetailsCommandBarPanel"
+                                              Grid.Row="2" />
+                                        <Grid.RenderTransform>
+                                            <TranslateTransform x:Name="DetailsPresenterTransform" />
+                                        </Grid.RenderTransform>
+                                    </Grid>
+                                </Grid>
+                            </muxc:TwoPaneView.Pane2>
+                        </muxc:TwoPaneView>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="SelectionStates">
+                                <VisualState x:Name="NoSelectionWide">
+                                    <VisualState.Setters>
+                                        <Setter Target="SelectionDetailsPane.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="HasSelectionWide">
+                                    <VisualState.Setters>
+                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="NoSelectionNarrow">
+                                    <VisualState.Setters>
+                                        <Setter Target="SelectionDetailsPane.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="HasSelectionNarrow">
+                                    <VisualState.Setters>
+                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="NoSelectionWide"
-                                                      To="HasSelection">
+                                                      To="HasSelectionWide">
                                         <Storyboard>
-                                            <DrillInThemeAnimation EntranceTargetName="SelectionDetailsPanel"
+                                            <DrillInThemeAnimation EntranceTargetName="SelectionDetailsPane"
                                                                    ExitTargetName="NoSelectionPresenter" />
                                         </Storyboard>
                                     </VisualTransition>
                                     <VisualTransition From="NoSelectionNarrow"
-                                                      To="HasSelection">
+                                                      To="HasSelectionNarrow">
                                         <Storyboard>
                                             <DoubleAnimation BeginTime="0:0:0"
                                                              Storyboard.TargetName="DetailsPresenterTransform"
@@ -111,7 +142,7 @@
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
                                             <DoubleAnimation BeginTime="0:0:0"
-                                                             Storyboard.TargetName="SelectionDetailsPanel"
+                                                             Storyboard.TargetName="SelectionDetailsPane"
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="0"
                                                              To="1"
@@ -120,85 +151,65 @@
                                                     <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
-                                        </Storyboard>
-                                    </VisualTransition>
-                                    <VisualTransition From="HasSelection"
-                                                      To="NoSelectionWide">
-                                        <Storyboard>
-                                            <DrillOutThemeAnimation EntranceTargetName="NoSelectionPresenter"
-                                                                    ExitTargetName="SelectionDetailsPanel" />
-                                        </Storyboard>
-                                    </VisualTransition>
-                                    <VisualTransition From="HasSelection"
-                                                      To="NoSelectionNarrow">
-                                        <Storyboard>
                                             <DoubleAnimation BeginTime="0:0:0"
-                                                             Storyboard.TargetName="DetailsPresenterTransform"
-                                                             Storyboard.TargetProperty="X"
-                                                             From="0"
-                                                             To="200"
-                                                             Duration="0:0:0.25" />
-                                            <DoubleAnimation BeginTime="0:0:0.08"
-                                                             Storyboard.TargetName="SelectionDetailsPanel"
+                                                             Storyboard.TargetName="NoSelectionPresenter"
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="1"
                                                              To="0"
-                                                             Duration="0:0:0.17">
+                                                             Duration="0:0:0">
                                                 <DoubleAnimation.EasingFunction>
                                                     <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
-                                            <DoubleAnimation BeginTime="0:0:0.0"
-                                                             Storyboard.TargetName="MasterPanel"
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="HasSelectionWide"
+                                                      To="NoSelectionWide">
+                                        <Storyboard>
+                                            <DrillOutThemeAnimation EntranceTargetName="NoSelectionPresenter"
+                                                                    ExitTargetName="SelectionDetailsPane" />
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="HasSelectionNarrow"
+                                                      To="NoSelectionNarrow">
+                                        <Storyboard>
+                                            <DoubleAnimation BeginTime="0:0:0"
+                                                             Storyboard.TargetName="MasterPresenterTransform"
+                                                             Storyboard.TargetProperty="X"
+                                                             From="-200"
+                                                             To="0"
+                                                             Duration="0:0:0.25">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <QuarticEase EasingMode="EaseOut" />
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                            <DoubleAnimation BeginTime="0:0:0"
+                                                             Storyboard.TargetName="MasterPane"
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="0"
                                                              To="1"
                                                              Duration="0:0:0.25">
                                                 <DoubleAnimation.EasingFunction>
-                                                    <QuarticEase EasingMode="EaseIn" />
+                                                    <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
-                                <VisualState x:Name="NoSelectionWide">
-                                    <VisualState.Setters>
-                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="MasterPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="HasSelectionWide">
-                                    <VisualState.Setters>
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="MasterPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="HasSelectionNarrow">
-                                    <VisualState.Setters>
-                                        <Setter Target="MasterPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="NoSelectionNarrow">
-                                    <VisualState.Setters>
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="MasterPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
                             </VisualStateGroup>
-                            <VisualStateGroup x:Name="WidthStates">
-                                <VisualState x:Name="NarrowState">
+
+                            <VisualStateGroup x:Name="HasItemsStates">
+                                <VisualState x:Name="HasItemsState">
                                     <VisualState.Setters>
-                                        <Setter Target="MasterColumn.Width" Value="*" />
-                                        <Setter Target="DetailsColumn.Width" Value="0" />
-                                        <Setter Target="DetailsPanel.(Grid.Column)" Value="0" />
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="MasterPanel.BorderThickness" Value="0" />
-                                        <Setter Target="MasterPanel.Width" Value="NaN" />
+                                        <Setter Target="MasterList.Visibility" Value="Visible" />
+                                        <Setter Target="NoItemsPresenter.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState x:Name="WideState">
+                                <VisualState x:Name="HasNoItemsState">
+                                    <VisualState.Setters>
+                                        <Setter Target="MasterList.Visibility" Value="Collapsed" />
+                                        <Setter Target="NoItemsPresenter.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="ColorCode.UWP" Version="2.0.6" />
+    <PackageReference Include="Microsoft.UI.Xaml" Version="2.3.200213001" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <ProjectReference Include="..\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations.csproj" />
     <ProjectReference Include="..\Microsoft.Toolkit.Uwp\Microsoft.Toolkit.Uwp.csproj" />

--- a/UnitTests/UnitTests.Notifications.UWP/UnitTests.Notifications.UWP.csproj
+++ b/UnitTests/UnitTests.Notifications.UWP/UnitTests.Notifications.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>UnitTests.Notifications.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/UnitTests/UnitTests.Notifications.WinRT/UnitTests.Notifications.WinRT.csproj
+++ b/UnitTests/UnitTests.Notifications.WinRT/UnitTests.Notifications.WinRT.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>UnitTests.Notifications.WinRT</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>UnitTests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature
- Documentation content changes

## What is the current behavior?
The [MasterDetailsView](https://docs.microsoft.com/en-us/windows/communitytoolkit/controls/masterdetailsview) does not take advantage of multiple screens on Windows 10X devices.


## What is the new behavior?
The new and refactored [MasterDetailsView](https://docs.microsoft.com/en-us/windows/communitytoolkit/controls/masterdetailsview) control is aware of multiple screens when used on Windows 10X devices.
We archive this by replacing the current `grid`-based layout with the new [Two-pane view](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/two-pane-view) based layout.

## Additional changes
- I added additional properties: `DetailsPaneBackground`, `DetailsContentTemplateSelector`, `MasterNoItemsContent`, `MasterNoItemsContentTemplate` and `MasterItemTemplateSelector`.
- I added a new NuGet dependency: [Microsoft.UI.Xaml](https://github.com/microsoft/microsoft-ui-xaml) to the `Microsoft.Toolkit.Uwp.UI.Controls` so I would be able to use the [TwoPaneView](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.twopaneview) class regardlessof the current Windows 10 version. **Need feedback here!**
- Due to the new NuGet package I had to increment the `TargetPlatformVersion` from `10.0.17763.0` to `10.0.18362.0`
- I updated the `bug_report.md` template to reflect these changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/304
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
### Old behavior
![Old Toolkit](https://user-images.githubusercontent.com/11741404/77059461-408ba480-69d7-11ea-9e68-9d15d299d7f2.png)

### New behavior 
![New Toolkit](https://user-images.githubusercontent.com/11741404/77059480-47b2b280-69d7-11ea-8b3a-d7522a2c2c42.png)
