### PR TITLE
Let BaseObjectStorageHelper use custom JsonSerializerOptions

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Windows.Storage;
 
 namespace Microsoft.Toolkit.Uwp.Helpers
@@ -16,6 +15,19 @@ namespace Microsoft.Toolkit.Uwp.Helpers
     /// </summary>
     public abstract class BaseObjectStorageHelper : IObjectStorageHelper
     {
+        private readonly IObjectSerializer serializer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseObjectStorageHelper"/> class,
+        /// which can read and write data using the provided <see cref="IObjectSerializer"/>;
+        /// if none is provided, a default Json serializer will be used.
+        /// </summary>
+        /// <param name="objectSerializer">The serializer to use.</param>
+        public BaseObjectStorageHelper(IObjectSerializer objectSerializer = null)
+        {
+            serializer = objectSerializer ?? new JsonObjectSerializer();
+        }
+
         /// <summary>
         /// Gets or sets the settings container.
         /// </summary>
@@ -78,7 +90,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 return (T)Convert.ChangeType(value, type);
             }
 
-            return JsonConvert.DeserializeObject<T>((string)value);
+            return serializer.Deserialize<T>((string)value);
         }
 
         /// <summary>
@@ -97,7 +109,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 string value = (string)composite[key];
                 if (value != null)
                 {
-                    return JsonConvert.DeserializeObject<T>(value);
+                    return serializer.Deserialize<T>(value);
                 }
             }
 
@@ -123,7 +135,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             }
             else
             {
-                Settings.Values[key] = JsonConvert.SerializeObject(value);
+                Settings.Values[key] = serializer.Serialize(value);
             }
         }
 
@@ -146,11 +158,11 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 {
                     if (composite.ContainsKey(setting.Key))
                     {
-                        composite[setting.Key] = JsonConvert.SerializeObject(setting.Value);
+                        composite[setting.Key] = serializer.Serialize(setting.Value);
                     }
                     else
                     {
-                        composite.Add(setting.Key, JsonConvert.SerializeObject(setting.Value));
+                        composite.Add(setting.Key, serializer.Serialize(setting.Value));
                     }
                 }
             }
@@ -159,7 +171,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 ApplicationDataCompositeValue composite = new ApplicationDataCompositeValue();
                 foreach (KeyValuePair<string, T> setting in values)
                 {
-                    composite.Add(setting.Key, JsonConvert.SerializeObject(setting.Value));
+                    composite.Add(setting.Key, serializer.Serialize(setting.Value));
                 }
 
                 Settings.Values[compositeKey] = composite;
@@ -186,7 +198,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         public async Task<T> ReadFileAsync<T>(string filePath, T @default = default(T))
         {
             string value = await StorageFileHelper.ReadTextFromFileAsync(Folder, filePath);
-            return (value != null) ? JsonConvert.DeserializeObject<T>(value) : @default;
+            return (value != null) ? serializer.Deserialize<T>(value) : @default;
         }
 
         /// <summary>
@@ -199,7 +211,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <returns>The <see cref="StorageFile"/> where the object was saved</returns>
         public Task<StorageFile> SaveFileAsync<T>(string filePath, T value)
         {
-            return StorageFileHelper.WriteTextToFileAsync(Folder, JsonConvert.SerializeObject(value), filePath, CreationCollisionOption.ReplaceExisting);
+            return StorageFileHelper.WriteTextToFileAsync(Folder, serializer.Serialize(value), filePath, CreationCollisionOption.ReplaceExisting);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/IObjectSerializer.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/IObjectSerializer.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.Helpers
+{
+    /// <summary>
+    /// A basic serialization service.
+    /// </summary>
+    public interface IObjectSerializer
+    {
+        /// <summary>
+        /// Serialize an object into a string.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to serialize.</typeparam>
+        /// <param name="value">The object to serialize.</param>
+        /// <returns>The serialized object.</returns>
+        string Serialize<T>(T value);
+
+        /// <summary>
+        /// Deserialize a string into an object.
+        /// </summary>
+        /// <typeparam name="T">The type of the deserialized object.</typeparam>
+        /// <param name="value">The string to deserialize.</param>
+        /// <returns>The deserialized object.</returns>
+        T Deserialize<T>(string value);
+    }
+}

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/JsonObjectSerializer.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/JsonObjectSerializer.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Toolkit.Uwp.Helpers
+{
+    internal class JsonObjectSerializer : IObjectSerializer
+    {
+        public string Serialize<T>(T value) => JsonConvert.SerializeObject(value);
+
+        public T Deserialize<T>(string value) => JsonConvert.DeserializeObject<T>(value);
+    }
+}

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/LocalObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/LocalObjectStorageHelper.cs
@@ -12,9 +12,13 @@ namespace Microsoft.Toolkit.Uwp.Helpers
     public class LocalObjectStorageHelper : BaseObjectStorageHelper
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LocalObjectStorageHelper"/> class.
+        /// Initializes a new instance of the <see cref="LocalObjectStorageHelper"/> class,
+        /// which can read and write data using the provided <see cref="IObjectSerializer"/>;
+        /// if none is provided, a default Json serializer will be used.
         /// </summary>
-        public LocalObjectStorageHelper()
+        /// <param name="objectSerializer">The serializer to use.</param>
+        public LocalObjectStorageHelper(IObjectSerializer objectSerializer = null)
+            : base(objectSerializer)
         {
             Settings = ApplicationData.Current.LocalSettings;
             Folder = ApplicationData.Current.LocalFolder;

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/RoamingObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/RoamingObjectStorageHelper.cs
@@ -12,9 +12,13 @@ namespace Microsoft.Toolkit.Uwp.Helpers
     public class RoamingObjectStorageHelper : BaseObjectStorageHelper
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RoamingObjectStorageHelper"/> class.
+        /// Initializes a new instance of the <see cref="RoamingObjectStorageHelper"/> class,
+        /// which can read and write data using the provided <see cref="IObjectSerializer"/>;
+        /// if none is provided, a default Json serializer will be used.
         /// </summary>
-        public RoamingObjectStorageHelper()
+        /// <param name="objectSerializer">The serializer to use.</param>
+        public RoamingObjectStorageHelper(IObjectSerializer objectSerializer = null)
+            : base(objectSerializer)
         {
             Settings = ApplicationData.Current.RoamingSettings;
             Folder = ApplicationData.Current.RoamingFolder;


### PR DESCRIPTION
Fixes #3175

## PR Type
What kind of change does this PR introduce?

- Feature

## What is the current behavior?
JsonConvert calls in BaseObjectStorageHelper always use default JsonSerializerSettings, and a caller cannot provide custom ones.

## What is the new behavior?
A JsonSerializerSettings object can be provided to Local/RoamingObjectStorageHelper, and will then be used in all serialization and deserialization calls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/306
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
- [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [ ] ~~Tests for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes
