### PR TITLE
Optimize Sample App Sample Loading

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
         public async Task<string> GetCSharpSourceAsync()
         {
-            using (var codeStream = await StreamHelper.GetPackagedFileStreamAsync($"SamplePages/{Name}/{CodeFile}"))
+            using (var codeStream = await StreamHelper.GetPackagedFileStreamAsync(CodeFile.StartsWith('/') ? CodeFile : $"SamplePages/{Name}/{CodeFile}"))
             {
                 using (var streamreader = new StreamReader(codeStream.AsStream()))
                 {
@@ -191,7 +191,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
         public async Task<string> GetJavaScriptSourceAsync()
         {
-            using (var codeStream = await StreamHelper.GetPackagedFileStreamAsync($"SamplePages/{Name}/{JavaScriptCodeFile}"))
+            using (var codeStream = await StreamHelper.GetPackagedFileStreamAsync(JavaScriptCodeFile.StartsWith('/') ? JavaScriptCodeFile : $"SamplePages/{Name}/{JavaScriptCodeFile}"))
             {
                 using (var streamreader = new StreamReader(codeStream.AsStream()))
                 {
@@ -452,7 +452,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             if (_propertyDescriptor == null)
             {
                 // Get Xaml code
-                using (var codeStream = await StreamHelper.GetPackagedFileStreamAsync($"SamplePages/{Name}/{XamlCodeFile}"))
+                using (var codeStream = await StreamHelper.GetPackagedFileStreamAsync(XamlCodeFile.StartsWith('/') ? XamlCodeFile : $"SamplePages/{Name}/{XamlCodeFile}"))
                 {
                     XamlCode = await codeStream.ReadTextAsync(Encoding.UTF8);
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/Models/Samples.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Models/Samples.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                         if (sample.IsSupported)
                         {
                             finalSamples.Add(sample);
-                            await sample.PreparePropertyDescriptorAsync();
                         }
                     }
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
@@ -224,24 +224,26 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                     _onlyDocumentation = true;
                 }
 
-                DataContext = CurrentSample;
-
-                var propertyDesc = CurrentSample.PropertyDescriptor;
-
                 InfoAreaPivot.Items.Clear();
-
-                if (propertyDesc != null)
-                {
-                    _xamlRenderer.DataContext = propertyDesc.Expando;
-                }
-
-                if (propertyDesc != null && propertyDesc.Options.Count > 0)
-                {
-                    InfoAreaPivot.Items.Add(PropertiesPivotItem);
-                }
 
                 if (CurrentSample.HasXAMLCode)
                 {
+                    // Load Sample Properties before we load sample (if we haven't before)
+                    await CurrentSample.PreparePropertyDescriptorAsync();
+
+                    // We only have properties on examples with live XAML
+                    var propertyDesc = CurrentSample.PropertyDescriptor;
+
+                    if (propertyDesc != null)
+                    {
+                        _xamlRenderer.DataContext = propertyDesc.Expando;
+                    }
+
+                    if (propertyDesc != null && propertyDesc.Options.Count > 0)
+                    {
+                        InfoAreaPivot.Items.Add(PropertiesPivotItem);
+                    }
+
                     if (AnalyticsInfo.VersionInfo.GetDeviceFormFactor() != DeviceFormFactor.Desktop || CurrentSample.DisableXamlEditorRendering)
                     {
                         // Only makes sense (and works) for now to show Live Xaml on Desktop, so fallback to old system here otherwise.
@@ -299,6 +301,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 {
                     GithubButton.Visibility = Visibility.Visible;
                 }
+
+                DataContext = CurrentSample;
 
                 if (InfoAreaPivot.Items.Count == 0)
                 {

--- a/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                         _xamlRenderer.DataContext = propertyDesc.Expando;
                     }
 
-                    if (propertyDesc != null && propertyDesc.Options.Count > 0)
+                    if (propertyDesc?.Options.Count > 0)
                     {
                         InfoAreaPivot.Items.Add(PropertiesPivotItem);
                     }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
@@ -824,7 +824,7 @@
       {
         "Name": "ThemeListener",
         "Type": "ThemeListenerPage",
-        "Subcategory": "Developer",
+        "Subcategory": "Systems",
         "About": "The ThemeListener allows you to keep track of changes to the System Theme.",
         "Icon": "/Assets/Helpers.png",
         "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/helpers/ThemeListener.md"
@@ -842,6 +842,7 @@
       {
         "Name": "ViewportBehavior",
         "Type": "ViewportBehaviorPage",
+        "Subcategory": "Systems",
         "About": "Behavior for listening element enter or exit viewport",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Animations/ViewportBehavior",
         "CodeFile": "ViewportBehaviorCode.bind",


### PR DESCRIPTION
We were loading all the .bind files for ALL the samples when we loaded `samples.json` in order to read in the property slider info to generate the properties panel.

This change now moves that workload to when the sample is requested/loaded in the UI. This should improve the start-up time of the sample app.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Load all sample descriptors at the start of the app.

## What is the new behavior?
Load specific sample descriptor when sample is requested.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] If new feature, add to [Feature List](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/readme.md#-features)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
I also added support for Morten's PR #3030 to be able to put multiple samples in one folder by supporting Absolute paths for Code Files in samples.json.

Also, this cleans-up a missing sub-category in the Helpers category.