### PR TITLE
Fix for #2899.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public event InAppNotificationClosedEventHandler Closed;
 
-        private AutomationPeer peer;
-
         private void DismissButton_Click(object sender, RoutedEventArgs e)
         {
             Dismiss(InAppNotificationDismissKind.User);
@@ -54,15 +52,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _openAnimationTimer.Stop();
                 Opened?.Invoke(this, EventArgs.Empty);
                 SetValue(AutomationProperties.NameProperty, StringExtensions.GetLocalized("WindowsCommunityToolkit_InAppNotification_NameProperty", "/Microsoft.Toolkit.Uwp.UI.Controls/Resources"));
-                peer = FrameworkElementAutomationPeer.CreatePeerForElement(ContentTemplateRoot);
-                if (Content?.GetType() == typeof(string))
+                if (ContentTemplateRoot != null)
                 {
-                    AutomateTextNotification(Content.ToString());
+                    var peer = FrameworkElementAutomationPeer.CreatePeerForElement(ContentTemplateRoot);
+                    if (Content?.GetType() == typeof(string))
+                    {
+                        AutomateTextNotification(peer, Content.ToString());
+                    }
                 }
             }
         }
 
-        private void AutomateTextNotification(string message)
+        private void AutomateTextNotification(AutomationPeer peer, string message)
         {
             if (peer != null)
             {


### PR DESCRIPTION
## Fixes #2899

## PR Type
What kind of change does this PR introduce?

- Bugfix 


## What is the current behavior?
Crash if in app notification is shows and the control is not being shown on the current page.

## What is the new behavior?
No more exception, it just gracefully checks for null on this one property.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
