### PR TITLE
Removed full pdb workaround, switching to portable pdbs.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,10 @@
       <PropertyGroup>
         <TargetPlatformVersion>10.0.$(DefaultTargetPlatformVersion).0</TargetPlatformVersion>
         <TargetPlatformMinVersion>10.0.$(DefaultTargetPlatformMinVersion).0</TargetPlatformMinVersion>
-        <DebugType>Full</DebugType>
+      </PropertyGroup>
+
+      <PropertyGroup Condition="'$(DebugType)' == ''">
+        <DebugType>Portable</DebugType>
       </PropertyGroup>
 
       <ItemGroup>

--- a/Microsoft.Toolkit.HighPerformance/Microsoft.Toolkit.HighPerformance.csproj
+++ b/Microsoft.Toolkit.HighPerformance/Microsoft.Toolkit.HighPerformance.csproj
@@ -21,9 +21,6 @@
       - NullableRef&lt;T&gt;: a stack-only struct similar to Ref&lt;T&gt;, which also supports nullable references.
   </Description>
     <PackageTags>UWP Toolkit Windows core standard unsafe span memory string array stream buffer extensions helpers parallel performance</PackageTags>
-
-    <!-- This is a temporary workaround for https://github.com/dotnet/sdk/issues/955 -->
-    <DebugType>Full</DebugType>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(TargetFramework)' == 'netstandard1.4' ">

--- a/Microsoft.Toolkit.Parsers/Microsoft.Toolkit.Parsers.csproj
+++ b/Microsoft.Toolkit.Parsers/Microsoft.Toolkit.Parsers.csproj
@@ -12,9 +12,6 @@
 
     </Description>
     <PackageTags>UWP Toolkit Windows Parsers Parsing Markdown RSS</PackageTags>
-
-    <!-- This is a temporary workaround for https://github.com/dotnet/sdk/issues/955 -->
-    <DebugType>Full</DebugType>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
+++ b/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
@@ -11,8 +11,6 @@
     </Description>
     <PackageTags>UWP Community Toolkit Windows Microsoft Graph OneDrive Twitter Translator LinkedIn service login OAuth</PackageTags>
 
-    <!-- This is a temporary workaround for https://github.com/dotnet/sdk/issues/955 -->
-    <DebugType>Full</DebugType>
     <NoWarn>CS8002;CS0618</NoWarn>
   </PropertyGroup>
 

--- a/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
+++ b/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
@@ -58,6 +58,7 @@
   
   <PropertyGroup Condition="'$(TargetFramework)' == 'native'">
     <OutputType>winmdobj</OutputType>
+    <DebugType>Full</DebugType>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <!-- Workaround for issue NuGet/Home#8388; change behavior during NuGet restore time vs. final build to avoid NuGet conflict in VS 2019 -->
     <NugetTargetMoniker Condition="'$(DesignTimeBuild)' == 'true'">native</NugetTargetMoniker>

--- a/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer.csproj
+++ b/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer.csproj
@@ -7,9 +7,6 @@
     <PackageTags>UWP Toolkit Windows Platform Specific Analyzer</PackageTags>
     
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    
-    <!-- This is a temporary workaround for https://github.com/dotnet/sdk/issues/955 -->
-    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.Toolkit/Microsoft.Toolkit.csproj
+++ b/Microsoft.Toolkit/Microsoft.Toolkit.csproj
@@ -11,9 +11,6 @@
       - String extensions and array extensions: These extensions make working with string and arrays easier.
     </Description>
     <PackageTags>UWP Toolkit Windows IncrementalLoadingCollection String Array extensions helpers</PackageTags>
-
-    <!-- This is a temporary workaround for https://github.com/dotnet/sdk/issues/955 -->
-    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <!-- .NET Standard 2.0 doesn't have the Span<T> type -->


### PR DESCRIPTION
## Fixes #1951

## PR Type
What kind of change does this PR introduce?

- Bugfix 

## What is the current behavior?
PDBs are not automatically loaded, which makes debugging much harder.


## What is the new behavior?
PDBs are now the portable kind, since VS now handles that beautifully.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes