### PR TITLE
Deprecate TabView, RadialGradientBrush, Singleton, FacebookService

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
@@ -18,6 +18,8 @@
         "Name": "TabView",
         "Type": "TabViewPage",
         "Subcategory": "Layout",
+        "BadgeUpdateVersionRequired": "DEPRECATED",
+        "DeprecatedWarning": "Please migrate to the TabView control from WinUI, this control will be removed in a future release. https://aka.ms/winui",
         "About": "A control for displaying multiple items in the same space and allows a user to easily switch between them.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Controls/TabView",
         "XamlCodeFile": "TabViewXaml.bind",
@@ -1095,6 +1097,8 @@
       {
         "Name": "RadialGradientBrush",
         "Type": "RadialGradientBrushPage",
+        "BadgeUpdateVersionRequired": "DEPRECATED",
+        "DeprecatedWarning": "Please migrate to the RadialGradientBrush control from WinUI, this control will be removed in a future release. https://aka.ms/winui",
         "About": "A composition brush which creates a radial gradient effect.",
         "CodeUrl": "https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI.Media/Brushes/RadialGradientBrush.cs",
         "XamlCodeFile": "RadialGradientBrushXaml.bind",

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
@@ -665,7 +665,7 @@
         "CodeFile": "FacebookCode.bind",
         "Icon": "/SamplePages/Facebook Service/FacebookLogo.png",
         "BadgeUpdateVersionRequired": "DEPRECATED",
-        "DeprecatedWarning": "These helpers will be removed in the next release.",
+        "DeprecatedWarning": "The underlying library, winsdkfb, which the FacebookService relies on is not currently maintained.",
         "DocumentationUrl": "https://raw.githubusercontent.com/MicrosoftDocs/WindowsCommunityToolkitDocs/master/docs/services/Facebook.md"
       },
       {

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
     /// <summary>
     /// Class for connecting to Facebook.
     /// </summary>
+    [Obsolete("The underlying library these helpers rely on is not currently maintained.")]
     public class FacebookService
     {
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
     /// <summary>
     /// Class for connecting to Facebook.
     /// </summary>
-    [Obsolete("The underlying library these helpers rely on is not currently maintained.")]
+    [Obsolete("The underlying library, winsdkfb, which the FacebookService relies on is not currently maintained.")]
     public class FacebookService
     {
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TabView/TabView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TabView/TabView.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// TabView is a control for displaying a set of tabs and their content.
     /// </summary>
+    [Obsolete("Please migrate to the TabView control from WinUI, this control will be removed in a future release. https://aka.ms/winui")]
     [TemplatePart(Name = TabContentPresenterName, Type = typeof(ContentPresenter))]
     [TemplatePart(Name = TabViewContainerName, Type = typeof(Grid))]
     [TemplatePart(Name = TabsItemsPresenterName, Type = typeof(ItemsPresenter))]

--- a/Microsoft.Toolkit.Uwp.UI.Media/Brushes/RadialGradientBrush.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Brushes/RadialGradientBrush.cs
@@ -4,6 +4,7 @@
 
 //// UWP Replacement for WPF RadialGradientBrush: https://msdn.microsoft.com/en-us/library/system.windows.media.radialgradientbrush(v=vs.110).aspx.
 
+using System;
 using System.Numerics;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Brushes;
@@ -18,6 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media
     /// RadialGradientBrush - This GradientBrush defines its Gradient as an interpolation
     /// within an Ellipse.
     /// </summary>
+    [Obsolete("Please migrate to the RadialGradientBrush control from WinUI, this control will be removed in a future release. https://aka.ms/winui")]
     [ContentProperty(Name = nameof(GradientStops))]
     public partial class RadialGradientBrush : CanvasBrushBase
     {

--- a/Microsoft.Toolkit/Helpers/Singleton.cs
+++ b/Microsoft.Toolkit/Helpers/Singleton.cs
@@ -8,23 +8,20 @@ using System.Collections.Concurrent;
 namespace Microsoft.Toolkit.Helpers
 {
     /// <summary>
-    /// Provides an easy-to-use thread-safe Singleton Pattern via <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}">ConcurrentDictionary</see>.
+    /// Obsolete see https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3134.
     /// </summary>
     /// <typeparam name="T">The type to be used for creating the Singleton instance.</typeparam>
     /// <example>
-    /// Use by adding a static property to your class for a traditional access pattern:
+    /// Instead of this helper, migrate your code to this pattern instead:
     /// <code>
     /// // Setup Singleton
-    /// public static class MyClass {
-    ///     public static MyClass Instance => Singleton&lt;MyClass&gt;.Instance;
-    ///
-    ///     public void MyMethod() { }
+    /// public class MyClass
+    /// {
+    ///     public static MyClass Instance { get; } = new MyClass();
     /// }
-    ///
-    /// // Use Singleton Instance
-    /// MyClass.Instance.MyMethod();
     /// </code>
     /// </example>
+    [Obsolete("This helper will be removed in a future release, see example tag for code replacement. https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3134")]
     public static class Singleton<T>
         where T : new()
     {


### PR DESCRIPTION
## Related #3203

Marking things that will be removed in 7.0. Both TabView and RadialGradientBrush have graduated 🎉🎉🎉. There's one element missing from the WinUI RadialGradientBrush, but we'll see if we can get it in their 2.5, it should be a simple add. (@chingucoding were you looking at https://github.com/microsoft/microsoft-ui-xaml/issues/2385 or the MenuBar one or both?)

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

