### PR TITLE
Mhawker/ttb updates

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TabView/TabViewPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TabView/TabViewPage.xaml.cs
@@ -69,5 +69,5 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             TabViewNotification.Show("Tore Tab '" + str + "' Outside of TabView.", 2000);
         }
         #pragma warning restore CS0618 // Type or member is obsolete
-    }    
+    }
 }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TokenizingTextBox/TokenizingTextBoxXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TokenizingTextBox/TokenizingTextBoxXaml.bind
@@ -16,7 +16,7 @@
       <controls:TokenizingTextBox
           x:Name="TokenBox"
           PlaceholderText="Add Actions"
-          QueryIcon="{ex:SymbolIconSource Glyph=Setting, FontSize=16}"
+          QueryIcon="{ex:SymbolIconSource Glyph=Setting}"
           MaxHeight="104"
           HorizontalAlignment="Stretch"
           TextMemberPath="Text"
@@ -52,7 +52,7 @@
             PlaceholderText="Select Names"
             MaxHeight="104"
             HorizontalAlignment="Stretch"
-            QueryIcon="{ex:SymbolIconSource Glyph=Find, FontSize=16}"
+            QueryIcon="{ex:SymbolIconSource Glyph=Find}"
             TextMemberPath="Text"
             TokenDelimiter=","
             IsItemClickEnabled="True">

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             //   We toggle the visibility of the Placeholder ContentControl in order to force it's layout to update properly
             var placeholder = ContainerFromItem(_lastTextEdit).FindDescendantByName("PlaceholderTextContentPresenter");
 
-            if (placeholder.Visibility == Visibility.Visible)
+            if (placeholder?.Visibility == Visibility.Visible)
             {
                 placeholder.Visibility = Visibility.Collapsed;
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.Deferred;
 using Microsoft.Toolkit.Uwp.Extensions;
+using Microsoft.Toolkit.Uwp.UI.Extensions;
+using Microsoft.Toolkit.Uwp.UI.Helpers;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -435,6 +437,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             last?._autoSuggestTextBox.Focus(FocusState.Keyboard);
 
             TokenItemAdded?.Invoke(this, data);
+
+            GuardAgainstPlaceholderTextLayoutIssue();
         }
 
         private void UpdateCurrentTextEdit(PretokenStringContainer edit)
@@ -475,7 +479,34 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             TokenItemRemoved?.Invoke(this, data);
 
+            GuardAgainstPlaceholderTextLayoutIssue();
+
             return true;
+        }
+
+        private void GuardAgainstPlaceholderTextLayoutIssue()
+        {
+            // If the *PlaceholderText is visible* on the last AutoSuggestBox, it can incorrectly layout itself
+            // when the *ASB has focus*. We think this is an optimization in the platform, but haven't been able to
+            // isolate a straight-reproduction of this issue outside of this control (though we have eliminated
+            // most Toolkit influences like ASB/TextBox Style, the InterspersedObservableCollection, etc...).
+            // The only Toolkit component involved here should be WrapPanel (which is a straight-forward Panel).
+            // We also know the ASB itself is adjusting it's size correctly, it's the inner component.
+            //
+            // To combat this issue:
+            //   We toggle the visibility of the Placeholder ContentControl in order to force it's layout to update properly
+            var placeholder = ContainerFromItem(_lastTextEdit).FindDescendantByName("PlaceholderTextContentPresenter");
+
+            if (placeholder.Visibility == Visibility.Visible)
+            {
+                placeholder.Visibility = Visibility.Collapsed;
+
+                // After we ensure we've hid the control, make it visible again (this is inperceptable to the user).
+                _ = CompositionTargetHelper.ExecuteAfterCompositionRenderingAsync(() =>
+                {
+                    placeholder.Visibility = Visibility.Visible;
+                });
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.xaml
@@ -12,8 +12,7 @@
     <Thickness x:Key="TokenizingTextBoxPresenterMargin">0,0,6,0</Thickness>
     <x:Double x:Key="TokenizingTextBoxTokenSpacing">2</x:Double>
     <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
-    <x:Double x:Key="TokenizingTextBoxIconFontSize">16</x:Double> <!-- 'Example' hard-coded currently in link:TokenizingTextBoxItem.AutoSuggestBox.cs#L110, but can be overwritten in developer's resources as 'normal' -->
-
+    
     <controls:TokenizingTextBoxStyleSelector x:Key="TokenizingTextBoxStyleSelector"
                                              TextStyle="{StaticResource TokenizingTextBoxItemTextStyle}"
                                              TokenStyle="{StaticResource TokenizingTextBoxItemTokenStyle}"/>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.xaml
@@ -12,6 +12,7 @@
     <Thickness x:Key="TokenizingTextBoxPresenterMargin">0,0,6,0</Thickness>
     <x:Double x:Key="TokenizingTextBoxTokenSpacing">2</x:Double>
     <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
+    <x:Double x:Key="TokenizingTextBoxIconFontSize">16</x:Double>
 
     <controls:TokenizingTextBoxStyleSelector x:Key="TokenizingTextBoxStyleSelector"
                                              TextStyle="{StaticResource TokenizingTextBoxItemTextStyle}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBox.xaml
@@ -12,7 +12,7 @@
     <Thickness x:Key="TokenizingTextBoxPresenterMargin">0,0,6,0</Thickness>
     <x:Double x:Key="TokenizingTextBoxTokenSpacing">2</x:Double>
     <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
-    <x:Double x:Key="TokenizingTextBoxIconFontSize">16</x:Double>
+    <x:Double x:Key="TokenizingTextBoxIconFontSize">16</x:Double> <!-- 'Example' hard-coded currently in link:TokenizingTextBoxItem.AutoSuggestBox.cs#L110, but can be overwritten in developer's resources as 'normal' -->
 
     <controls:TokenizingTextBoxStyleSelector x:Key="TokenizingTextBoxStyleSelector"
                                              TextStyle="{StaticResource TokenizingTextBoxItemTextStyle}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
@@ -101,6 +101,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 // Setup a binding to the QueryIcon of the Parent if we're the last box.
                 if (Content is PretokenStringContainer str && str.IsLast)
                 {
+                    // Workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/2568
+                    if (Owner.QueryIcon is FontIconSource fis &&
+                        fis.ReadLocalValue(FontIconSource.FontSizeProperty) == DependencyProperty.UnsetValue)
+                    {
+                        // This can be expensive, could we optimize?
+                        // Also, this is changing the FontSize on the IconSource (which could be shared?)
+                        fis.FontSize = Owner.TryFindResource("TokenizingTextBoxIconFontSize") as double? ?? 16;
+                    }
+
                     var iconBinding = new Binding()
                     {
                         Source = Owner,

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.xaml
@@ -290,17 +290,12 @@
     <Style x:Key="TokenizingTextBoxItemTextStyle" TargetType="controls:TokenizingTextBoxItem">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}" />
-        <!-- <Setter Property="BorderThickness" Value="{StaticResource TokenizingTextBoxItemBorderThickness}" />
-        <Setter Property="HorizontalContentAlignment" Value="{StaticResource TokenizingTextBoxItemHorizontalContentAlignment}" />
-        <Setter Property="Padding" Value="{StaticResource TokenizingTextBoxItemPadding}" />
-        <Setter Property="VerticalContentAlignment" Value="{StaticResource TokenizingTextBoxItemVerticalContentAlignment}" />-->
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="UseSystemFocusVisuals" Value="False" />
         <Setter Property="MinWidth" Value="128" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:TokenizingTextBoxItem">
-                    <!-- TODO: Thinking we should just give a reference to the parent for each item when we construct the container? -->
                     <AutoSuggestBox Name="PART_AutoSuggestBox"
                                     UpdateTextOnSelect="False"
                                     DisplayMemberPath="{Binding Path=Owner.DisplayMemberPath, RelativeSource={RelativeSource Mode=TemplatedParent}}"
@@ -311,7 +306,6 @@
                                     Style="{StaticResource SystemAutoSuggestBoxStyle}"
                                     Text="{Binding Text, Mode=TwoWay}"
                                     TextBoxStyle="{StaticResource TokenizingTextBoxTextBoxStyle}"/>
-                    <!-- TODO: Visual State to style autosuggestbox based on focus? -->
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.xaml
@@ -15,12 +15,14 @@
                           Background="{ThemeResource TextControlButtonBackground}"
                           BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}">
+                        <!-- FontSize is ignored here, see https://github.com/microsoft/microsoft-ui-xaml/issues/2568 -->
+                        <!-- Set in code-behind link:TokenizingTextBoxItem.AutoSuggestBox.cs#L104 -->
                         <TextBlock x:Name="GlyphElement"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"
                                    AutomationProperties.AccessibilityView="Raw"
                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                   FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
+                                   FontSize="{ThemeResource TokenizingTextBoxIconFontSize}"
                                    FontStyle="Normal"
                                    Foreground="{ThemeResource TextControlButtonForeground}"
                                    Text="&#xE10A;" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.xaml
@@ -4,7 +4,8 @@
 
     <!--<Thickness x:Key="ButtonPadding">8,4,8,5</Thickness> Not sure if we'll also need this later-->
     <Thickness x:Key="TextControlThemePadding">10,3,6,6</Thickness><!-- Need local copy of this, as including WinUI overrides this to something that adds too much padding for our inner box -->
-    
+    <x:Double x:Key="TokenizingTextBoxIconFontSize">16</x:Double><!-- 'Example' hard-coded currently in link:TokenizingTextBoxItem.AutoSuggestBox.cs#L110, but can be overwritten in developer's resources as 'normal' -->
+
     <!--#region Button Styles -->
     <Style x:Key="TokenizingTextBoxDeleteButtonStyle"
            TargetType="Button">

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -286,5 +286,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
             return ContentPropertySearch(type.GetTypeInfo().BaseType);
         }
+
+        /// <summary>
+        /// Provides a WPF compatible version of TryFindResource to provide a static resource lookup.
+        /// If the key is not found in the current element's resources, the logical tree is then searched element-by-element to look for the resource in each element's resources.
+        /// If none of the elements contain the resource, the Application's resources are then searched.
+        /// <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.tryfindresource"/>
+        /// <seealso href="https://docs.microsoft.com/en-us/dotnet/desktop-wpf/fundamentals/xaml-resources-define#static-resource-lookup-behavior"/>
+        /// </summary>
+        /// <param name="start"><see cref="FrameworkElement"/> to start searching for Resource.</param>
+        /// <param name="resourceKey">Key to search for.</param>
+        /// <returns>Requested resource or null.</returns>
+        public static object TryFindResource(this FrameworkElement start, object resourceKey)
+        {
+            object value = null;
+            var current = start;
+
+            // Look in our dictionary and then walk-up parents
+            while (current != null)
+            {
+                if (current.Resources?.TryGetValue(resourceKey, out value) == true)
+                {
+                    return value;
+                }
+
+                current = current.Parent as FrameworkElement;
+            }
+
+            // Finally try application resources.
+            Application.Current?.Resources?.TryGetValue(resourceKey, out value);
+
+            return value;
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Helpers/CompositionTargetHelper.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Helpers/CompositionTargetHelper.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Diagnostics;
+using Windows.UI.Xaml.Media;
+
+namespace Microsoft.Toolkit.Uwp.UI.Helpers
+{
+    /// <summary>
+    /// Provides helpers for the <see cref="CompositionTarget"/> class.
+    /// </summary>
+    public static class CompositionTargetHelper
+    {
+        /// <summary>
+        /// Provides a method to execute code after the rendering pass is completed.
+        /// <seealso href="https://github.com/microsoft/microsoft-ui-xaml/blob/c045cde57c5c754683d674634a0baccda34d58c4/dev/dll/SharedHelpers.cpp#L399"/>
+        /// </summary>
+        /// <param name="action">Action to be executed after render pass</param>
+        /// <returns>Awaitable Task</returns>
+        public static Task<bool> ExecuteAfterCompositionRenderingAsync(Action action)
+        {
+            Guard.IsNotNull(action, nameof(action));
+
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+
+            try
+            {
+                void Callback(object sender, object args)
+                {
+                    CompositionTarget.Rendering -= Callback;
+
+                    action();
+
+                    taskCompletionSource.SetResult(true);
+                }
+
+                CompositionTarget.Rendering += Callback;
+            }
+            catch (Exception e)
+            {
+                taskCompletionSource.SetException(e); // Note this can just sometimes be a wrong thread exception, see WinUI function notes.
+            }
+
+            return taskCompletionSource.Task;
+        }
+    }
+}


### PR DESCRIPTION
## Related #3289 

- [x] Fix FontSize Styling Issue
  - [x] Adds `TryFindResource` (from WPF) compatible function
  - [ ] UnitTest that?
- [x] Test out Rendering callback for layout issue
- [x] Started [DOC PR HERE](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/348)
- ~~Use existing `Parent` property instead of new `Owner` for TTBI~~ read-only

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
Layout was incorrect when ASB had focus, and had no text, and added/removed token
FontSize had to be manually set

## What is the new behavior?
We now toggle the visibility of the offending PlaceholderText ContentControl which resolves the issue for now.

Now we only set FontSize to our desired size if it's not overwritten by the developer. It can also be overridden by a style property.

![image](https://user-images.githubusercontent.com/24302614/83611987-a4cdf700-a536-11ea-97d6-c65d31f0f36b.png)

I have my resource which the lower box icon is inheriting properly, the top example is overriding it with a local value.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
