### PR TITLE
Improved codegen in Guard APIs

### DIFF
--- a/Microsoft.Toolkit/Diagnostics/Generated/Guard.Collection.g.cs
+++ b/Microsoft.Toolkit/Diagnostics/Generated/Guard.Collection.g.cs
@@ -28,10 +28,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(Span<T> span, string name)
         {
-            if (span.Length != 0)
+            if (span.Length == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(span, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(span, name);
         }
 
         /// <summary>
@@ -44,10 +46,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(Span<T> span, string name)
         {
-            if (span.Length == 0)
+            if (span.Length != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithSpan<T>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithSpan<T>(name);
         }
 
         /// <summary>
@@ -61,10 +65,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(Span<T> span, int size, string name)
         {
-            if (span.Length != size)
+            if (span.Length == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -78,10 +84,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(Span<T> span, int size, string name)
         {
-            if (span.Length == size)
+            if (span.Length != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -95,10 +103,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(Span<T> span, int size, string name)
         {
-            if (span.Length <= size)
+            if (span.Length > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(span, size, name);
         }
 
         /// <summary>
@@ -112,10 +122,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(Span<T> span, int size, string name)
         {
-            if (span.Length < size)
+            if (span.Length >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -129,10 +141,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(Span<T> span, int size, string name)
         {
-            if (span.Length >= size)
+            if (span.Length < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(span, size, name);
         }
 
         /// <summary>
@@ -146,10 +160,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(Span<T> span, int size, string name)
         {
-            if (span.Length > size)
+            if (span.Length <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -163,10 +179,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(Span<T> source, Span<T> destination, string name)
         {
-            if (source.Length != destination.Length)
+            if (source.Length == destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -180,10 +198,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(Span<T> source, Span<T> destination, string name)
         {
-            if (source.Length > destination.Length)
+            if (source.Length <= destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -197,10 +217,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, Span<T> span, string name)
         {
-            if ((uint)index >= (uint)span.Length)
+            if ((uint)index < (uint)span.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, span, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, span, name);
         }
 
         /// <summary>
@@ -214,10 +236,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, Span<T> span, string name)
         {
-            if ((uint)index < (uint)span.Length)
+            if ((uint)index >= (uint)span.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, span, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, span, name);
         }
 
         /// <summary>
@@ -230,10 +254,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(ReadOnlySpan<T> span, string name)
         {
-            if (span.Length != 0)
+            if (span.Length == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(span, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(span, name);
         }
 
         /// <summary>
@@ -246,10 +272,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(ReadOnlySpan<T> span, string name)
         {
-            if (span.Length == 0)
+            if (span.Length != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithReadOnlySpan<T>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithReadOnlySpan<T>(name);
         }
 
         /// <summary>
@@ -263,10 +291,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(ReadOnlySpan<T> span, int size, string name)
         {
-            if (span.Length != size)
+            if (span.Length == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -280,10 +310,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(ReadOnlySpan<T> span, int size, string name)
         {
-            if (span.Length == size)
+            if (span.Length != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -297,10 +329,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(ReadOnlySpan<T> span, int size, string name)
         {
-            if (span.Length <= size)
+            if (span.Length > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(span, size, name);
         }
 
         /// <summary>
@@ -314,10 +348,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(ReadOnlySpan<T> span, int size, string name)
         {
-            if (span.Length < size)
+            if (span.Length >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -331,10 +367,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(ReadOnlySpan<T> span, int size, string name)
         {
-            if (span.Length >= size)
+            if (span.Length < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(span, size, name);
         }
 
         /// <summary>
@@ -348,10 +386,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(ReadOnlySpan<T> span, int size, string name)
         {
-            if (span.Length > size)
+            if (span.Length <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(span, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(span, size, name);
         }
 
         /// <summary>
@@ -365,10 +405,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(ReadOnlySpan<T> source, Span<T> destination, string name)
         {
-            if (source.Length != destination.Length)
+            if (source.Length == destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -382,10 +424,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(ReadOnlySpan<T> source, Span<T> destination, string name)
         {
-            if (source.Length > destination.Length)
+            if (source.Length <= destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -399,10 +443,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, ReadOnlySpan<T> span, string name)
         {
-            if ((uint)index >= (uint)span.Length)
+            if ((uint)index < (uint)span.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, span, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, span, name);
         }
 
         /// <summary>
@@ -416,10 +462,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, ReadOnlySpan<T> span, string name)
         {
-            if ((uint)index < (uint)span.Length)
+            if ((uint)index >= (uint)span.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, span, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, span, name);
         }
 
         /// <summary>
@@ -432,10 +480,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(Memory<T> memory, string name)
         {
-            if (memory.Length != 0)
+            if (memory.Length == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(memory, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(memory, name);
         }
 
         /// <summary>
@@ -448,10 +498,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(Memory<T> memory, string name)
         {
-            if (memory.Length == 0)
+            if (memory.Length != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<Memory<T>>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<Memory<T>>(name);
         }
 
         /// <summary>
@@ -465,10 +517,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(Memory<T> memory, int size, string name)
         {
-            if (memory.Length != size)
+            if (memory.Length == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -482,10 +536,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(Memory<T> memory, int size, string name)
         {
-            if (memory.Length == size)
+            if (memory.Length != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -499,10 +555,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(Memory<T> memory, int size, string name)
         {
-            if (memory.Length <= size)
+            if (memory.Length > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(memory, size, name);
         }
 
         /// <summary>
@@ -516,10 +574,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(Memory<T> memory, int size, string name)
         {
-            if (memory.Length < size)
+            if (memory.Length >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -533,10 +593,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(Memory<T> memory, int size, string name)
         {
-            if (memory.Length >= size)
+            if (memory.Length < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(memory, size, name);
         }
 
         /// <summary>
@@ -550,10 +612,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(Memory<T> memory, int size, string name)
         {
-            if (memory.Length > size)
+            if (memory.Length <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -567,10 +631,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(Memory<T> source, Memory<T> destination, string name)
         {
-            if (source.Length != destination.Length)
+            if (source.Length == destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -584,10 +650,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(Memory<T> source, Memory<T> destination, string name)
         {
-            if (source.Length > destination.Length)
+            if (source.Length <= destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -601,10 +669,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, Memory<T> memory, string name)
         {
-            if ((uint)index >= (uint)memory.Length)
+            if ((uint)index < (uint)memory.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, memory, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, memory, name);
         }
 
         /// <summary>
@@ -618,10 +688,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, Memory<T> memory, string name)
         {
-            if ((uint)index < (uint)memory.Length)
+            if ((uint)index >= (uint)memory.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, memory, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, memory, name);
         }
 
         /// <summary>
@@ -634,10 +706,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(ReadOnlyMemory<T> memory, string name)
         {
-            if (memory.Length != 0)
+            if (memory.Length == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(memory, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(memory, name);
         }
 
         /// <summary>
@@ -650,10 +724,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(ReadOnlyMemory<T> memory, string name)
         {
-            if (memory.Length == 0)
+            if (memory.Length != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<ReadOnlyMemory<T>>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<ReadOnlyMemory<T>>(name);
         }
 
         /// <summary>
@@ -667,10 +743,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(ReadOnlyMemory<T> memory, int size, string name)
         {
-            if (memory.Length != size)
+            if (memory.Length == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -684,10 +762,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(ReadOnlyMemory<T> memory, int size, string name)
         {
-            if (memory.Length == size)
+            if (memory.Length != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -701,10 +781,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(ReadOnlyMemory<T> memory, int size, string name)
         {
-            if (memory.Length <= size)
+            if (memory.Length > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(memory, size, name);
         }
 
         /// <summary>
@@ -718,10 +800,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(ReadOnlyMemory<T> memory, int size, string name)
         {
-            if (memory.Length < size)
+            if (memory.Length >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -735,10 +819,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(ReadOnlyMemory<T> memory, int size, string name)
         {
-            if (memory.Length >= size)
+            if (memory.Length < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(memory, size, name);
         }
 
         /// <summary>
@@ -752,10 +838,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(ReadOnlyMemory<T> memory, int size, string name)
         {
-            if (memory.Length > size)
+            if (memory.Length <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(memory, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(memory, size, name);
         }
 
         /// <summary>
@@ -769,10 +857,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(ReadOnlyMemory<T> source, Memory<T> destination, string name)
         {
-            if (source.Length != destination.Length)
+            if (source.Length == destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -786,10 +876,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(ReadOnlyMemory<T> source, Memory<T> destination, string name)
         {
-            if (source.Length > destination.Length)
+            if (source.Length <= destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -803,10 +895,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, ReadOnlyMemory<T> memory, string name)
         {
-            if ((uint)index >= (uint)memory.Length)
+            if ((uint)index < (uint)memory.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, memory, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, memory, name);
         }
 
         /// <summary>
@@ -820,10 +914,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, ReadOnlyMemory<T> memory, string name)
         {
-            if ((uint)index < (uint)memory.Length)
+            if ((uint)index >= (uint)memory.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, memory, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, memory, name);
         }
 
         /// <summary>
@@ -836,10 +932,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(T[] array, string name)
         {
-            if (array.Length != 0)
+            if (array.Length == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(array, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(array, name);
         }
 
         /// <summary>
@@ -852,10 +950,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(T[] array, string name)
         {
-            if (array.Length == 0)
+            if (array.Length != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<T[]>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<T[]>(name);
         }
 
         /// <summary>
@@ -869,10 +969,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(T[] array, int size, string name)
         {
-            if (array.Length != size)
+            if (array.Length == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(array, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(array, size, name);
         }
 
         /// <summary>
@@ -886,10 +988,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(T[] array, int size, string name)
         {
-            if (array.Length == size)
+            if (array.Length != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(array, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(array, size, name);
         }
 
         /// <summary>
@@ -903,10 +1007,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(T[] array, int size, string name)
         {
-            if (array.Length <= size)
+            if (array.Length > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(array, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(array, size, name);
         }
 
         /// <summary>
@@ -920,10 +1026,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(T[] array, int size, string name)
         {
-            if (array.Length < size)
+            if (array.Length >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(array, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(array, size, name);
         }
 
         /// <summary>
@@ -937,10 +1045,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(T[] array, int size, string name)
         {
-            if (array.Length >= size)
+            if (array.Length < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(array, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(array, size, name);
         }
 
         /// <summary>
@@ -954,10 +1064,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(T[] array, int size, string name)
         {
-            if (array.Length > size)
+            if (array.Length <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(array, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(array, size, name);
         }
 
         /// <summary>
@@ -971,10 +1083,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(T[] source, T[] destination, string name)
         {
-            if (source.Length != destination.Length)
+            if (source.Length == destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -988,10 +1102,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(T[] source, T[] destination, string name)
         {
-            if (source.Length > destination.Length)
+            if (source.Length <= destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -1005,10 +1121,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, T[] array, string name)
         {
-            if ((uint)index >= (uint)array.Length)
+            if ((uint)index < (uint)array.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, array, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, array, name);
         }
 
         /// <summary>
@@ -1022,10 +1140,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, T[] array, string name)
         {
-            if ((uint)index < (uint)array.Length)
+            if ((uint)index >= (uint)array.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, array, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, array, name);
         }
 
         /// <summary>
@@ -1038,10 +1158,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(List<T> list, string name)
         {
-            if (list.Count != 0)
+            if (list.Count == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty((ICollection<T>)list, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty((ICollection<T>)list, name);
         }
 
         /// <summary>
@@ -1054,10 +1176,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(List<T> list, string name)
         {
-            if (list.Count == 0)
+            if (list.Count != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<List<T>>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<List<T>>(name);
         }
 
         /// <summary>
@@ -1071,10 +1195,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(List<T> list, int size, string name)
         {
-            if (list.Count != size)
+            if (list.Count == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo((ICollection<T>)list, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo((ICollection<T>)list, size, name);
         }
 
         /// <summary>
@@ -1088,10 +1214,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(List<T> list, int size, string name)
         {
-            if (list.Count == size)
+            if (list.Count != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo((ICollection<T>)list, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo((ICollection<T>)list, size, name);
         }
 
         /// <summary>
@@ -1105,10 +1233,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(List<T> list, int size, string name)
         {
-            if (list.Count <= size)
+            if (list.Count > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan((ICollection<T>)list, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan((ICollection<T>)list, size, name);
         }
 
         /// <summary>
@@ -1122,10 +1252,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(List<T> list, int size, string name)
         {
-            if (list.Count < size)
+            if (list.Count >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo((ICollection<T>)list, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo((ICollection<T>)list, size, name);
         }
 
         /// <summary>
@@ -1139,10 +1271,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(List<T> list, int size, string name)
         {
-            if (list.Count >= size)
+            if (list.Count < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan((ICollection<T>)list, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan((ICollection<T>)list, size, name);
         }
 
         /// <summary>
@@ -1156,10 +1290,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(List<T> list, int size, string name)
         {
-            if (list.Count > size)
+            if (list.Count <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo((ICollection<T>)list, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo((ICollection<T>)list, size, name);
         }
 
         /// <summary>
@@ -1173,10 +1309,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(List<T> source, List<T> destination, string name)
         {
-            if (source.Count != destination.Count)
+            if (source.Count == destination.Count)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo((ICollection<T>)source, destination.Count, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo((ICollection<T>)source, destination.Count, name);
         }
 
         /// <summary>
@@ -1190,10 +1328,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(List<T> source, List<T> destination, string name)
         {
-            if (source.Count > destination.Count)
+            if (source.Count <= destination.Count)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo((ICollection<T>)source, destination.Count, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo((ICollection<T>)source, destination.Count, name);
         }
 
         /// <summary>
@@ -1207,10 +1347,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, List<T> list, string name)
         {
-            if ((uint)index >= (uint)list.Count)
+            if ((uint)index < (uint)list.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, (ICollection<T>)list, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, (ICollection<T>)list, name);
         }
 
         /// <summary>
@@ -1224,10 +1366,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, List<T> list, string name)
         {
-            if ((uint)index < (uint)list.Count)
+            if ((uint)index >= (uint)list.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, (ICollection<T>)list, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, (ICollection<T>)list, name);
         }
 
         /// <summary>
@@ -1240,10 +1384,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(ICollection<T> collection, string name)
         {
-            if (collection.Count != 0)
+            if (collection.Count == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(collection, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(collection, name);
         }
 
         /// <summary>
@@ -1256,10 +1402,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(ICollection<T> collection, string name)
         {
-            if (collection.Count == 0)
+            if (collection.Count != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<ICollection<T>>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<ICollection<T>>(name);
         }
 
         /// <summary>
@@ -1273,10 +1421,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(ICollection<T> collection, int size, string name)
         {
-            if (collection.Count != size)
+            if (collection.Count == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1290,10 +1440,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(ICollection<T> collection, int size, string name)
         {
-            if (collection.Count == size)
+            if (collection.Count != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1307,10 +1459,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(ICollection<T> collection, int size, string name)
         {
-            if (collection.Count <= size)
+            if (collection.Count > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(collection, size, name);
         }
 
         /// <summary>
@@ -1324,10 +1478,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(ICollection<T> collection, int size, string name)
         {
-            if (collection.Count < size)
+            if (collection.Count >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1341,10 +1497,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(ICollection<T> collection, int size, string name)
         {
-            if (collection.Count >= size)
+            if (collection.Count < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(collection, size, name);
         }
 
         /// <summary>
@@ -1358,10 +1516,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(ICollection<T> collection, int size, string name)
         {
-            if (collection.Count > size)
+            if (collection.Count <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1375,10 +1535,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(ICollection<T> source, ICollection<T> destination, string name)
         {
-            if (source.Count != destination.Count)
+            if (source.Count == destination.Count)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
         }
 
         /// <summary>
@@ -1392,10 +1554,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(ICollection<T> source, ICollection<T> destination, string name)
         {
-            if (source.Count > destination.Count)
+            if (source.Count <= destination.Count)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
         }
 
         /// <summary>
@@ -1409,10 +1573,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, ICollection<T> collection, string name)
         {
-            if ((uint)index >= (uint)collection.Count)
+            if ((uint)index < (uint)collection.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, collection, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, collection, name);
         }
 
         /// <summary>
@@ -1426,10 +1592,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, ICollection<T> collection, string name)
         {
-            if ((uint)index < (uint)collection.Count)
+            if ((uint)index >= (uint)collection.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, collection, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, collection, name);
         }
 
         /// <summary>
@@ -1442,10 +1610,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(IReadOnlyCollection<T> collection, string name)
         {
-            if (collection.Count != 0)
+            if (collection.Count == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(collection, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(collection, name);
         }
 
         /// <summary>
@@ -1458,10 +1628,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(IReadOnlyCollection<T> collection, string name)
         {
-            if (collection.Count == 0)
+            if (collection.Count != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<IReadOnlyCollection<T>>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<IReadOnlyCollection<T>>(name);
         }
 
         /// <summary>
@@ -1475,10 +1647,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(IReadOnlyCollection<T> collection, int size, string name)
         {
-            if (collection.Count != size)
+            if (collection.Count == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1492,10 +1666,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(IReadOnlyCollection<T> collection, int size, string name)
         {
-            if (collection.Count == size)
+            if (collection.Count != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1509,10 +1685,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(IReadOnlyCollection<T> collection, int size, string name)
         {
-            if (collection.Count <= size)
+            if (collection.Count > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(collection, size, name);
         }
 
         /// <summary>
@@ -1526,10 +1704,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(IReadOnlyCollection<T> collection, int size, string name)
         {
-            if (collection.Count < size)
+            if (collection.Count >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1543,10 +1723,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(IReadOnlyCollection<T> collection, int size, string name)
         {
-            if (collection.Count >= size)
+            if (collection.Count < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(collection, size, name);
         }
 
         /// <summary>
@@ -1560,10 +1742,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(IReadOnlyCollection<T> collection, int size, string name)
         {
-            if (collection.Count > size)
+            if (collection.Count <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(collection, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(collection, size, name);
         }
 
         /// <summary>
@@ -1577,10 +1761,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(IReadOnlyCollection<T> source, ICollection<T> destination, string name)
         {
-            if (source.Count != destination.Count)
+            if (source.Count == destination.Count)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
         }
 
         /// <summary>
@@ -1594,10 +1780,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(IReadOnlyCollection<T> source, ICollection<T> destination, string name)
         {
-            if (source.Count > destination.Count)
+            if (source.Count <= destination.Count)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination.Count, name);
         }
 
         /// <summary>
@@ -1611,10 +1799,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor<T>(int index, IReadOnlyCollection<T> collection, string name)
         {
-            if ((uint)index >= (uint)collection.Count)
+            if ((uint)index < (uint)collection.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, collection, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, collection, name);
         }
 
         /// <summary>
@@ -1628,10 +1818,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, IReadOnlyCollection<T> collection, string name)
         {
-            if ((uint)index < (uint)collection.Count)
+            if ((uint)index >= (uint)collection.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, collection, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, collection, name);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/Generated/Guard.Collection.tt
+++ b/Microsoft.Toolkit/Diagnostics/Generated/Guard.Collection.tt
@@ -29,10 +29,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty<T>(<#=item.Type#> <#=item.Name#>, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> != 0)
+            if (<#=item.Name#>.<#=item.Size#> == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(<#=item.Cast#><#=item.Name#>, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(<#=item.Cast#><#=item.Name#>, name);
         }
 
         /// <summary>
@@ -45,29 +47,31 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty<T>(<#=item.Type#> <#=item.Name#>, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> == 0)
+            if (<#=item.Name#>.<#=item.Size#> != 0)
             {
+                return;
+            }
+
 <#
     if (item.Type == "Span<T>")
     {
 #>
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithSpan<T>(name);
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithSpan<T>(name);
 <#
     }
     else if (item.Type == "ReadOnlySpan<T>")
     {
 #>
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithReadOnlySpan<T>(name);
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmptyWithReadOnlySpan<T>(name);
 <#
     }
     else
     {
 #>
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<<#=item.Type#>>(name);
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty<<#=item.Type#>>(name);
 <#
     }
 #>
-            }
         }
 
         /// <summary>
@@ -81,10 +85,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(<#=item.Type#> <#=item.Name#>, int size, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> != size)
+            if (<#=item.Name#>.<#=item.Size#> == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
         }
 
         /// <summary>
@@ -98,10 +104,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo<T>(<#=item.Type#> <#=item.Name#>, int size, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> == size)
+            if (<#=item.Name#>.<#=item.Size#> != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
         }
 
         /// <summary>
@@ -115,10 +123,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan<T>(<#=item.Type#> <#=item.Name#>, int size, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> <= size)
+            if (<#=item.Name#>.<#=item.Size#> > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(<#=item.Cast#><#=item.Name#>, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(<#=item.Cast#><#=item.Name#>, size, name);
         }
 
         /// <summary>
@@ -132,10 +142,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo<T>(<#=item.Type#> <#=item.Name#>, int size, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> < size)
+            if (<#=item.Name#>.<#=item.Size#> >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
         }
 
         /// <summary>
@@ -149,10 +161,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan<T>(<#=item.Type#> <#=item.Name#>, int size, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> >= size)
+            if (<#=item.Name#>.<#=item.Size#> < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(<#=item.Cast#><#=item.Name#>, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(<#=item.Cast#><#=item.Name#>, size, name);
         }
 
         /// <summary>
@@ -166,10 +180,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(<#=item.Type#> <#=item.Name#>, int size, string name)
         {
-            if (<#=item.Name#>.<#=item.Size#> > size)
+            if (<#=item.Name#>.<#=item.Size#> <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(<#=item.Cast#><#=item.Name#>, size, name);
         }
 
         /// <summary>
@@ -183,23 +199,25 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo<T>(<#=item.Type#> source, <#=item.DestinationType#> destination, string name)
         {
-            if (source.<#=item.Size#> != destination.<#=item.Size#>)
+            if (source.<#=item.Size#> == destination.<#=item.Size#>)
             {
+                return;
+            }
+
 <#
     if (item.HasCountProperty)
     {
 #>
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(<#=item.Cast#>source, destination.<#=item.Size#>, name);
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(<#=item.Cast#>source, destination.<#=item.Size#>, name);
 <#
     }
     else
     {
 #>
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, <#=item.Cast#>destination, name);
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, <#=item.Cast#>destination, name);
 <#
     }
 #>
-            }
         }
 
         /// <summary>
@@ -213,23 +231,25 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo<T>(<#=item.Type#> source, <#=item.DestinationType#> destination, string name)
         {
-            if (source.<#=item.Size#> > destination.<#=item.Size#>)
+            if (source.<#=item.Size#> <= destination.<#=item.Size#>)
             {
+                return;
+            }
+
 <#
     if (item.HasCountProperty)
     {
 #>
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(<#=item.Cast#>source, destination.<#=item.Size#>, name);
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(<#=item.Cast#>source, destination.<#=item.Size#>, name);
 <#
     }
     else
     {
 #>
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, <#=item.Cast#>destination, name);
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, <#=item.Cast#>destination, name);
 <#
     }
 #>
-            }
         }
 
         /// <summary>
@@ -250,10 +270,12 @@ GenerateTextForItems(EnumerableTypes, item =>
     // For more info and code sample, see the original conversation here:
     // https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3131#discussion_r390682835
 #>
-            if ((uint)index >= (uint)<#=item.Name#>.<#=item.Size#>)
+            if ((uint)index < (uint)<#=item.Name#>.<#=item.Size#>)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, <#=item.Cast#><#=item.Name#>, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, <#=item.Cast#><#=item.Name#>, name);
         }
 
         /// <summary>
@@ -267,10 +289,12 @@ GenerateTextForItems(EnumerableTypes, item =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor<T>(int index, <#=item.Type#> <#=item.Name#>, string name)
         {
-            if ((uint)index < (uint)<#=item.Name#>.<#=item.Size#>)
+            if ((uint)index >= (uint)<#=item.Name#>.<#=item.Size#>)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, <#=item.Cast#><#=item.Name#>, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, <#=item.Cast#><#=item.Name#>, name);
         }
 <#
 });

--- a/Microsoft.Toolkit/Diagnostics/Generated/Guard.Comparable.Numeric.g.cs
+++ b/Microsoft.Toolkit/Diagnostics/Generated/Guard.Comparable.Numeric.g.cs
@@ -27,10 +27,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(byte value, byte target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -44,10 +46,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(byte value, byte target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -61,10 +65,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(byte value, byte maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -78,10 +84,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(byte value, byte maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -95,10 +103,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(byte value, byte minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -112,10 +122,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(byte value, byte minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -133,10 +145,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(byte value, byte minimum, byte maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -154,10 +168,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(byte value, byte minimum, byte maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -175,10 +191,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(byte value, byte minimum, byte maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -196,10 +214,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(byte value, byte minimum, byte maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -217,10 +237,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(byte value, byte minimum, byte maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -238,10 +260,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(byte value, byte minimum, byte maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -254,10 +278,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(sbyte value, sbyte target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -271,10 +297,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(sbyte value, sbyte target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -288,10 +316,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(sbyte value, sbyte maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -305,10 +335,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(sbyte value, sbyte maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -322,10 +354,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(sbyte value, sbyte minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -339,10 +373,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(sbyte value, sbyte minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -360,10 +396,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(sbyte value, sbyte minimum, sbyte maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -381,10 +419,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(sbyte value, sbyte minimum, sbyte maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -402,10 +442,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(sbyte value, sbyte minimum, sbyte maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -423,10 +465,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(sbyte value, sbyte minimum, sbyte maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -444,10 +488,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(sbyte value, sbyte minimum, sbyte maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -465,10 +511,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(sbyte value, sbyte minimum, sbyte maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -481,10 +529,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(short value, short target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -498,10 +548,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(short value, short target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -515,10 +567,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(short value, short maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -532,10 +586,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(short value, short maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -549,10 +605,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(short value, short minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -566,10 +624,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(short value, short minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -587,10 +647,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(short value, short minimum, short maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -608,10 +670,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(short value, short minimum, short maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -629,10 +693,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(short value, short minimum, short maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -650,10 +716,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(short value, short minimum, short maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -671,10 +739,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(short value, short minimum, short maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -692,10 +762,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(short value, short minimum, short maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -708,10 +780,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(ushort value, ushort target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -725,10 +799,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(ushort value, ushort target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -742,10 +818,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(ushort value, ushort maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -759,10 +837,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(ushort value, ushort maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -776,10 +856,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(ushort value, ushort minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -793,10 +875,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(ushort value, ushort minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -814,10 +898,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(ushort value, ushort minimum, ushort maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -835,10 +921,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(ushort value, ushort minimum, ushort maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -856,10 +944,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(ushort value, ushort minimum, ushort maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -877,10 +967,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(ushort value, ushort minimum, ushort maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -898,10 +990,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(ushort value, ushort minimum, ushort maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -919,10 +1013,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(ushort value, ushort minimum, ushort maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -935,10 +1031,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(char value, char target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -952,10 +1050,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(char value, char target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -969,10 +1069,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(char value, char maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -986,10 +1088,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(char value, char maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -1003,10 +1107,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(char value, char minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -1020,10 +1126,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(char value, char minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -1041,10 +1149,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(char value, char minimum, char maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1062,10 +1172,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(char value, char minimum, char maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1083,10 +1195,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(char value, char minimum, char maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1104,10 +1218,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(char value, char minimum, char maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1125,10 +1241,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(char value, char minimum, char maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1146,10 +1264,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(char value, char minimum, char maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1162,10 +1282,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(int value, int target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1179,10 +1301,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(int value, int target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1196,10 +1320,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(int value, int maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -1213,10 +1339,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(int value, int maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -1230,10 +1358,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(int value, int minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -1247,10 +1377,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(int value, int minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -1268,10 +1400,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(int value, int minimum, int maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1289,10 +1423,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(int value, int minimum, int maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1310,10 +1446,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(int value, int minimum, int maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1331,10 +1469,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(int value, int minimum, int maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1352,10 +1492,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(int value, int minimum, int maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1373,10 +1515,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(int value, int minimum, int maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1389,10 +1533,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(uint value, uint target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1406,10 +1552,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(uint value, uint target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1423,10 +1571,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(uint value, uint maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -1440,10 +1590,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(uint value, uint maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -1457,10 +1609,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(uint value, uint minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -1474,10 +1628,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(uint value, uint minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -1495,10 +1651,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(uint value, uint minimum, uint maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1516,10 +1674,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(uint value, uint minimum, uint maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1537,10 +1697,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(uint value, uint minimum, uint maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1558,10 +1720,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(uint value, uint minimum, uint maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1579,10 +1743,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(uint value, uint minimum, uint maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1600,10 +1766,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(uint value, uint minimum, uint maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1616,10 +1784,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(float value, float target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1633,10 +1803,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(float value, float target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1650,10 +1822,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(float value, float maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -1667,10 +1841,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(float value, float maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -1684,10 +1860,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(float value, float minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -1701,10 +1879,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(float value, float minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -1722,10 +1902,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(float value, float minimum, float maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1743,10 +1925,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(float value, float minimum, float maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1764,10 +1948,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(float value, float minimum, float maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1785,10 +1971,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(float value, float minimum, float maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1806,10 +1994,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(float value, float minimum, float maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1827,10 +2017,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(float value, float minimum, float maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1843,10 +2035,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(long value, long target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1860,10 +2054,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(long value, long target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -1877,10 +2073,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(long value, long maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -1894,10 +2092,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(long value, long maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -1911,10 +2111,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(long value, long minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -1928,10 +2130,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(long value, long minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -1949,10 +2153,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(long value, long minimum, long maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1970,10 +2176,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(long value, long minimum, long maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -1991,10 +2199,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(long value, long minimum, long maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2012,10 +2222,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(long value, long minimum, long maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2033,10 +2245,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(long value, long minimum, long maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2054,10 +2268,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(long value, long minimum, long maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2070,10 +2286,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(ulong value, ulong target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -2087,10 +2305,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(ulong value, ulong target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -2104,10 +2324,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(ulong value, ulong maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -2121,10 +2343,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(ulong value, ulong maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -2138,10 +2362,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(ulong value, ulong minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -2155,10 +2381,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(ulong value, ulong minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -2176,10 +2404,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(ulong value, ulong minimum, ulong maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2197,10 +2427,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(ulong value, ulong minimum, ulong maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2218,10 +2450,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(ulong value, ulong minimum, ulong maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2239,10 +2473,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(ulong value, ulong minimum, ulong maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2260,10 +2496,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(ulong value, ulong minimum, ulong maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2281,10 +2519,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(ulong value, ulong minimum, ulong maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2297,10 +2537,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(double value, double target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -2314,10 +2556,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(double value, double target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -2331,10 +2575,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(double value, double maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -2348,10 +2594,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(double value, double maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -2365,10 +2613,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(double value, double minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -2382,10 +2632,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(double value, double minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -2403,10 +2655,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(double value, double minimum, double maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2424,10 +2678,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(double value, double minimum, double maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2445,10 +2701,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(double value, double minimum, double maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2466,10 +2724,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(double value, double minimum, double maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2487,10 +2747,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(double value, double minimum, double maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2508,10 +2770,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(double value, double minimum, double maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2524,10 +2788,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(decimal value, decimal target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -2541,10 +2807,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(decimal value, decimal target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -2558,10 +2826,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(decimal value, decimal maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -2575,10 +2845,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(decimal value, decimal maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -2592,10 +2864,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(decimal value, decimal minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -2609,10 +2883,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(decimal value, decimal minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -2630,10 +2906,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(decimal value, decimal minimum, decimal maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2651,10 +2929,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(decimal value, decimal minimum, decimal maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2672,10 +2952,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(decimal value, decimal minimum, decimal maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2693,10 +2975,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(decimal value, decimal minimum, decimal maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2714,10 +2998,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(decimal value, decimal minimum, decimal maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -2735,10 +3021,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(decimal value, decimal minimum, decimal maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/Generated/Guard.Comparable.Numeric.tt
+++ b/Microsoft.Toolkit/Diagnostics/Generated/Guard.Comparable.Numeric.tt
@@ -28,10 +28,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEqualTo(<#=type#> value, <#=type#> target, string name)
         {
-            if (value != target)
+            if (value == target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -45,10 +47,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEqualTo(<#=type#> value, <#=type#> target, string name)
         {
-            if (value == target)
+            if (value != target)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -62,10 +66,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThan(<#=type#> value, <#=type#> maximum, string name)
         {
-            if (value >= maximum)
+            if (value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -79,10 +85,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsLessThanOrEqualTo(<#=type#> value, <#=type#> maximum, string name)
         {
-            if (value > maximum)
+            if (value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -96,10 +104,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThan(<#=type#> value, <#=type#> minimum, string name)
         {
-            if (value <= minimum)
+            if (value > minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -113,10 +123,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsGreaterThanOrEqualTo(<#=type#> value, <#=type#> minimum, string name)
         {
-            if (value < minimum)
+            if (value >= minimum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -134,10 +146,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRange(<#=type#> value, <#=type#> minimum, <#=type#> maximum, string name)
         {
-            if (value < minimum || value >= maximum)
+            if (value >= minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -155,10 +169,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRange(<#=type#> value, <#=type#> minimum, <#=type#> maximum, string name)
         {
-            if (value >= minimum && value < maximum)
+            if (value < minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -176,10 +192,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetween(<#=type#> value, <#=type#> minimum, <#=type#> maximum, string name)
         {
-            if (value <= minimum || value >= maximum)
+            if (value > minimum && value < maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -197,10 +215,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetween(<#=type#> value, <#=type#> minimum, <#=type#> maximum, string name)
         {
-            if (value > minimum && value < maximum)
+            if (value <= minimum || value >= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -218,10 +238,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsBetweenOrEqualTo(<#=type#> value, <#=type#> minimum, <#=type#> maximum, string name)
         {
-            if (value < minimum || value > maximum)
+            if (value >= minimum && value <= maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -239,10 +261,12 @@ GenerateTextForItems(NumericTypes, type =>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotBetweenOrEqualTo(<#=type#> value, <#=type#> minimum, <#=type#> maximum, string name)
         {
-            if (value >= minimum && value <= maximum)
+            if (value < minimum || value > maximum)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
 <#
 });

--- a/Microsoft.Toolkit/Diagnostics/Guard.Comparable.Generic.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.Comparable.Generic.cs
@@ -25,10 +25,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsDefault<T>(T value, string name)
             where T : struct, IEquatable<T>
         {
-            if (!value.Equals(default))
+            if (value.Equals(default))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsDefault(value, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsDefault(value, name);
         }
 
         /// <summary>
@@ -42,10 +44,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNotDefault<T>(T value, string name)
             where T : struct, IEquatable<T>
         {
-            if (value.Equals(default))
+            if (!value.Equals(default))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotDefault<T>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotDefault<T>(name);
         }
 
         /// <summary>
@@ -61,10 +65,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsEqualTo<T>(T value, T target, string name)
             where T : notnull, IEquatable<T>
         {
-            if (!value.Equals(target))
+            if (value.Equals(target))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -80,10 +86,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNotEqualTo<T>(T value, T target, string name)
             where T : notnull, IEquatable<T>
         {
-            if (value.Equals(target))
+            if (!value.Equals(target))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEqualTo(value, target, name);
         }
 
         /// <summary>
@@ -110,10 +118,12 @@ namespace Microsoft.Toolkit.Diagnostics
                 byte valueByte = Unsafe.As<T, byte>(ref value);
                 byte targetByte = Unsafe.As<T, byte>(ref target);
 
-                if (valueByte != targetByte)
+                if (valueByte == targetByte)
                 {
-                    ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
+                    return;
                 }
+
+                ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
             }
             else if (typeof(T) == typeof(ushort) ||
                      typeof(T) == typeof(short) ||
@@ -122,10 +132,12 @@ namespace Microsoft.Toolkit.Diagnostics
                 ushort valueUShort = Unsafe.As<T, ushort>(ref value);
                 ushort targetUShort = Unsafe.As<T, ushort>(ref target);
 
-                if (valueUShort != targetUShort)
+                if (valueUShort == targetUShort)
                 {
-                    ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
+                    return;
                 }
+
+                ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
             }
             else if (typeof(T) == typeof(uint) ||
                      typeof(T) == typeof(int) ||
@@ -134,10 +146,12 @@ namespace Microsoft.Toolkit.Diagnostics
                 uint valueUInt = Unsafe.As<T, uint>(ref value);
                 uint targetUInt = Unsafe.As<T, uint>(ref target);
 
-                if (valueUInt != targetUInt)
+                if (valueUInt == targetUInt)
                 {
-                    ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
+                    return;
                 }
+
+                ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
             }
             else if (typeof(T) == typeof(ulong) ||
                      typeof(T) == typeof(long) ||
@@ -146,10 +160,12 @@ namespace Microsoft.Toolkit.Diagnostics
                 ulong valueULong = Unsafe.As<T, ulong>(ref value);
                 ulong targetULong = Unsafe.As<T, ulong>(ref target);
 
-                if (valueULong != targetULong)
+                if (valueULong == targetULong)
                 {
-                    ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
+                    return;
                 }
+
+                ThrowHelper.ThrowArgumentExceptionForsBitwiseEqualTo(value, target, name);
             }
             else
             {
@@ -183,10 +199,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsLessThan<T>(T value, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(maximum) >= 0)
+            if (value.CompareTo(maximum) < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThan(value, maximum, name);
         }
 
         /// <summary>
@@ -202,10 +220,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsLessThanOrEqualTo<T>(T value, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(maximum) > 0)
+            if (value.CompareTo(maximum) >= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsLessThanOrEqualTo(value, maximum, name);
         }
 
         /// <summary>
@@ -221,10 +241,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsGreaterThan<T>(T value, T minimum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) <= 0)
+            if (value.CompareTo(minimum) > 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThan(value, minimum, name);
         }
 
         /// <summary>
@@ -240,10 +262,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsGreaterThanOrEqualTo<T>(T value, T minimum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) < 0)
+            if (value.CompareTo(minimum) >= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsGreaterThanOrEqualTo(value, minimum, name);
         }
 
         /// <summary>
@@ -263,10 +287,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsInRange<T>(T value, T minimum, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) < 0 || value.CompareTo(maximum) >= 0)
+            if (value.CompareTo(minimum) >= 0 && value.CompareTo(maximum) < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -286,10 +312,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNotInRange<T>(T value, T minimum, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) >= 0 && value.CompareTo(maximum) < 0)
+            if (value.CompareTo(minimum) < 0 || value.CompareTo(maximum) >= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRange(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -309,10 +337,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsBetween<T>(T value, T minimum, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) <= 0 || value.CompareTo(maximum) >= 0)
+            if (value.CompareTo(minimum) > 0 && value.CompareTo(maximum) < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -332,10 +362,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNotBetween<T>(T value, T minimum, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) > 0 && value.CompareTo(maximum) < 0)
+            if (value.CompareTo(minimum) <= 0 || value.CompareTo(maximum) >= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetween(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -355,10 +387,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsBetweenOrEqualTo<T>(T value, T minimum, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) < 0 || value.CompareTo(maximum) > 0)
+            if (value.CompareTo(minimum) >= 0 && value.CompareTo(maximum) <= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsBetweenOrEqualTo(value, minimum, maximum, name);
         }
 
         /// <summary>
@@ -378,10 +412,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNotBetweenOrEqualTo<T>(T value, T minimum, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(minimum) >= 0 && value.CompareTo(maximum) <= 0)
+            if (value.CompareTo(minimum) < 0 || value.CompareTo(maximum) > 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotBetweenOrEqualTo(value, minimum, maximum, name);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/Guard.Comparable.Generic.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.Comparable.Generic.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsLessThanOrEqualTo<T>(T value, T maximum, string name)
             where T : notnull, IComparable<T>
         {
-            if (value.CompareTo(maximum) >= 0)
+            if (value.CompareTo(maximum) <= 0)
             {
                 return;
             }

--- a/Microsoft.Toolkit/Diagnostics/Guard.Comparable.Numeric.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.Comparable.Numeric.cs
@@ -36,10 +36,12 @@ namespace Microsoft.Toolkit.Diagnostics
             // The difference is then cast to uint as that's the maximum possible
             // value it can have, and comparing two 32 bit integer values
             // results in shorter and slightly faster code than using doubles.
-            if ((uint)Math.Abs((double)((long)value - target)) > delta)
+            if ((uint)Math.Abs((double)((long)value - target)) <= delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
         }
 
         /// <summary>
@@ -53,10 +55,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotCloseTo(int value, int target, uint delta, string name)
         {
-            if ((uint)Math.Abs((double)((long)value - target)) <= delta)
+            if ((uint)Math.Abs((double)((long)value - target)) > delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
         }
 
         /// <summary>
@@ -72,10 +76,12 @@ namespace Microsoft.Toolkit.Diagnostics
         {
             // This method and the one below are not inlined because
             // using the decimal type results in quite a bit of code.
-            if ((ulong)Math.Abs((decimal)value - target) > delta)
+            if ((ulong)Math.Abs((decimal)value - target) <= delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
         }
 
         /// <summary>
@@ -89,10 +95,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void IsNotCloseTo(long value, long target, ulong delta, string name)
         {
-            if ((ulong)Math.Abs((decimal)value - target) <= delta)
+            if ((ulong)Math.Abs((decimal)value - target) > delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
         }
 
         /// <summary>
@@ -106,10 +114,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsCloseTo(float value, float target, float delta, string name)
         {
-            if (Math.Abs(value - target) > delta)
+            if (Math.Abs(value - target) <= delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
         }
 
         /// <summary>
@@ -123,10 +133,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotCloseTo(float value, float target, float delta, string name)
         {
-            if (Math.Abs(value - target) <= delta)
+            if (Math.Abs(value - target) > delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
         }
 
         /// <summary>
@@ -140,10 +152,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsCloseTo(double value, double target, double delta, string name)
         {
-            if (Math.Abs(value - target) > delta)
+            if (Math.Abs(value - target) <= delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsCloseTo(value, target, delta, name);
         }
 
         /// <summary>
@@ -157,10 +171,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotCloseTo(double value, double target, double delta, string name)
         {
-            if (Math.Abs(value - target) <= delta)
+            if (Math.Abs(value - target) > delta)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotCloseTo(value, target, delta, name);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/Guard.IO.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.IO.cs
@@ -24,10 +24,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CanRead(Stream stream, string name)
         {
-            if (!stream.CanRead)
+            if (stream.CanRead)
             {
-                ThrowHelper.ThrowArgumentExceptionForCanRead(stream, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForCanRead(stream, name);
         }
 
         /// <summary>
@@ -39,10 +41,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CanWrite(Stream stream, string name)
         {
-            if (!stream.CanWrite)
+            if (stream.CanWrite)
             {
-                ThrowHelper.ThrowArgumentExceptionForCanWrite(stream, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForCanWrite(stream, name);
         }
 
         /// <summary>
@@ -54,10 +58,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CanSeek(Stream stream, string name)
         {
-            if (!stream.CanSeek)
+            if (stream.CanSeek)
             {
-                ThrowHelper.ThrowArgumentExceptionForCanSeek(stream, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForCanSeek(stream, name);
         }
 
         /// <summary>
@@ -69,10 +75,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsAtStartPosition(Stream stream, string name)
         {
-            if (stream.Position != 0)
+            if (stream.Position == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsAtStartPosition(stream, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsAtStartPosition(stream, name);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/Guard.String.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.String.cs
@@ -24,10 +24,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNullOrEmpty(string? text, string name)
         {
-            if (!string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNullOrEmpty(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNullOrEmpty(text, name);
         }
 
         /// <summary>
@@ -39,10 +41,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotNullOrEmpty([NotNull] string? text, string name)
         {
-            if (string.IsNullOrEmpty(text))
+            if (!string.IsNullOrEmpty(text))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotNullOrEmpty(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotNullOrEmpty(text, name);
 #pragma warning disable CS8777 // Does not return when text is null (.NET Standard 2.0 string.IsNullOrEmpty lacks flow attribute)
         }
 #pragma warning restore CS8777
@@ -56,10 +60,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNullOrWhitespace(string? text, string name)
         {
-            if (!string.IsNullOrWhiteSpace(text))
+            if (string.IsNullOrWhiteSpace(text))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNullOrWhitespace(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNullOrWhitespace(text, name);
         }
 
         /// <summary>
@@ -71,10 +77,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotNullOrWhitespace([NotNull] string? text, string name)
         {
-            if (string.IsNullOrWhiteSpace(text))
+            if (!string.IsNullOrWhiteSpace(text))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhitespace(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhitespace(text, name);
 #pragma warning disable CS8777 // Does not return when text is null
         }
 #pragma warning restore CS8777
@@ -88,10 +96,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsEmpty(string text, string name)
         {
-            if (text.Length != 0)
+            if (text.Length == 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsEmpty(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsEmpty(text, name);
         }
 
         /// <summary>
@@ -103,10 +113,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotEmpty(string text, string name)
         {
-            if (text.Length == 0)
+            if (text.Length != 0)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotEmpty(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotEmpty(text, name);
         }
 
         /// <summary>
@@ -118,10 +130,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsWhitespace(string text, string name)
         {
-            if (!string.IsNullOrWhiteSpace(text))
+            if (string.IsNullOrWhiteSpace(text))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsWhitespace(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsWhitespace(text, name);
         }
 
         /// <summary>
@@ -133,10 +147,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotWhitespace(string text, string name)
         {
-            if (string.IsNullOrWhiteSpace(text))
+            if (!string.IsNullOrWhiteSpace(text))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotWhitespace(text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotWhitespace(text, name);
         }
 
         /// <summary>
@@ -149,10 +165,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo(string text, int size, string name)
         {
-            if (text.Length != size)
+            if (text.Length == size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(text, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(text, size, name);
         }
 
         /// <summary>
@@ -165,10 +183,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeNotEqualTo(string text, int size, string name)
         {
-            if (text.Length == size)
+            if (text.Length != size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(text, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeNotEqualTo(text, size, name);
         }
 
         /// <summary>
@@ -181,10 +201,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThan(string text, int size, string name)
         {
-            if (text.Length <= size)
+            if (text.Length > size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(text, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThan(text, size, name);
         }
 
         /// <summary>
@@ -197,10 +219,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeGreaterThanOrEqualTo(string text, int size, string name)
         {
-            if (text.Length < size)
+            if (text.Length >= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(text, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeGreaterThanOrEqualTo(text, size, name);
         }
 
         /// <summary>
@@ -213,10 +237,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThan(string text, int size, string name)
         {
-            if (text.Length >= size)
+            if (text.Length < size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(text, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThan(text, size, name);
         }
 
         /// <summary>
@@ -229,10 +255,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo(string text, int size, string name)
         {
-            if (text.Length > size)
+            if (text.Length <= size)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(text, size, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(text, size, name);
         }
 
         /// <summary>
@@ -246,10 +274,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeEqualTo(string source, string destination, string name)
         {
-            if (source.Length != destination.Length)
+            if (source.Length == destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -263,10 +293,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasSizeLessThanOrEqualTo(string source, string destination, string name)
         {
-            if (source.Length > destination.Length)
+            if (source.Length <= destination.Length)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasSizeLessThanOrEqualTo(source, destination, name);
         }
 
         /// <summary>
@@ -279,10 +311,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsInRangeFor(int index, string text, string name)
         {
-            if ((uint)index >= (uint)text.Length)
+            if ((uint)index < (uint)text.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsInRangeFor(index, text, name);
         }
 
         /// <summary>
@@ -295,10 +329,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotInRangeFor(int index, string text, string name)
         {
-            if ((uint)index < (uint)text.Length)
+            if ((uint)index >= (uint)text.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, text, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForIsNotInRangeFor(index, text, name);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/Guard.Tasks.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.Tasks.cs
@@ -24,10 +24,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsCompleted(Task task, string name)
         {
-            if (!task.IsCompleted)
+            if (task.IsCompleted)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsCompleted(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsCompleted(task, name);
         }
 
         /// <summary>
@@ -39,10 +41,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotCompleted(Task task, string name)
         {
-            if (task.IsCompleted)
+            if (!task.IsCompleted)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotCompleted(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotCompleted(task, name);
         }
 
         /// <summary>
@@ -54,10 +58,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsCompletedSuccessfully(Task task, string name)
         {
-            if (task.Status != TaskStatus.RanToCompletion)
+            if (task.Status == TaskStatus.RanToCompletion)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsCompletedSuccessfully(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsCompletedSuccessfully(task, name);
         }
 
         /// <summary>
@@ -69,10 +75,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotCompletedSuccessfully(Task task, string name)
         {
-            if (task.Status == TaskStatus.RanToCompletion)
+            if (task.Status != TaskStatus.RanToCompletion)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotCompletedSuccessfully(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotCompletedSuccessfully(task, name);
         }
 
         /// <summary>
@@ -84,10 +92,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsFaulted(Task task, string name)
         {
-            if (!task.IsFaulted)
+            if (task.IsFaulted)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsFaulted(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsFaulted(task, name);
         }
 
         /// <summary>
@@ -99,10 +109,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotFaulted(Task task, string name)
         {
-            if (task.IsFaulted)
+            if (!task.IsFaulted)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotFaulted(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotFaulted(task, name);
         }
 
         /// <summary>
@@ -114,10 +126,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsCanceled(Task task, string name)
         {
-            if (!task.IsCanceled)
+            if (task.IsCanceled)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsCanceled(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsCanceled(task, name);
         }
 
         /// <summary>
@@ -129,10 +143,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotCanceled(Task task, string name)
         {
-            if (task.IsCanceled)
+            if (!task.IsCanceled)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotCanceled(task, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotCanceled(task, name);
         }
 
         /// <summary>
@@ -145,10 +161,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasStatusEqualTo(Task task, TaskStatus status, string name)
         {
-            if (task.Status != status)
+            if (task.Status == status)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasStatusEqualTo(task, status, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasStatusEqualTo(task, status, name);
         }
 
         /// <summary>
@@ -161,10 +179,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void HasStatusNotEqualTo(Task task, TaskStatus status, string name)
         {
-            if (task.Status == status)
+            if (task.Status != status)
             {
-                ThrowHelper.ThrowArgumentExceptionForHasStatusNotEqualTo(task, status, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForHasStatusNotEqualTo(task, status, name);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/Guard.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.cs
@@ -28,10 +28,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNull<T>(T? value, string name)
             where T : class
         {
-            if (!(value is null))
+            if (value is null)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNull(value, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNull(value, name);
         }
 
         /// <summary>
@@ -46,10 +48,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNull<T>(T? value, string name)
             where T : struct
         {
-            if (!(value is null))
+            if (value is null)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNull(value, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNull(value, name);
         }
 
         /// <summary>
@@ -63,10 +67,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNotNull<T>([NotNull] T? value, string name)
             where T : class
         {
-            if (value is null)
+            if (!(value is null))
             {
-                ThrowHelper.ThrowArgumentNullExceptionForIsNotNull<T>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentNullExceptionForIsNotNull<T>(name);
         }
 
         /// <summary>
@@ -81,10 +87,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsNotNull<T>([NotNull] T? value, string name)
             where T : struct
         {
-            if (value is null)
+            if (!(value is null))
             {
-                ThrowHelper.ThrowArgumentNullExceptionForIsNotNull<T?>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentNullExceptionForIsNotNull<T?>(name);
         }
 
         /// <summary>
@@ -97,10 +105,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsOfType<T>(object value, string name)
         {
-            if (value.GetType() != typeof(T))
+            if (value.GetType() == typeof(T))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsOfType<T>(value, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsOfType<T>(value, name);
         }
 
         /// <summary>
@@ -113,10 +123,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotOfType<T>(object value, string name)
         {
-            if (value.GetType() == typeof(T))
+            if (value.GetType() != typeof(T))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotOfType<T>(value, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotOfType<T>(value, name);
         }
 
         /// <summary>
@@ -129,10 +141,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsOfType(object value, Type type, string name)
         {
-            if (value.GetType() != type)
+            if (value.GetType() == type)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsOfType(value, type, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsOfType(value, type, name);
         }
 
         /// <summary>
@@ -145,10 +159,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotOfType(object value, Type type, string name)
         {
-            if (value.GetType() == type)
+            if (value.GetType() != type)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotOfType(value, type, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotOfType(value, type, name);
         }
 
         /// <summary>
@@ -161,10 +177,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsAssignableToType<T>(object value, string name)
         {
-            if (!(value is T))
+            if (value is T)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsAssignableToType<T>(value, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsAssignableToType<T>(value, name);
         }
 
         /// <summary>
@@ -177,10 +195,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotAssignableToType<T>(object value, string name)
         {
-            if (value is T)
+            if (!(value is T))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotAssignableToType<T>(value, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotAssignableToType<T>(value, name);
         }
 
         /// <summary>
@@ -193,10 +213,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsAssignableToType(object value, Type type, string name)
         {
-            if (!type.IsInstanceOfType(value))
+            if (type.IsInstanceOfType(value))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsAssignableToType(value, type, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsAssignableToType(value, type, name);
         }
 
         /// <summary>
@@ -209,10 +231,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsNotAssignableToType(object value, Type type, string name)
         {
-            if (type.IsInstanceOfType(value))
+            if (!type.IsInstanceOfType(value))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsNotAssignableToType(value, type, name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotAssignableToType(value, type, name);
         }
 
         /// <summary>
@@ -228,10 +252,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsReferenceEqualTo<T>(T value, T target, string name)
             where T : class
         {
-            if (!ReferenceEquals(value, target))
+            if (ReferenceEquals(value, target))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsReferenceEqualTo<T>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsReferenceEqualTo<T>(name);
         }
 
         /// <summary>
@@ -247,10 +273,12 @@ namespace Microsoft.Toolkit.Diagnostics
         public static void IsReferenceNotEqualTo<T>(T value, T target, string name)
             where T : class
         {
-            if (ReferenceEquals(value, target))
+            if (!ReferenceEquals(value, target))
             {
-                ThrowHelper.ThrowArgumentExceptionForIsReferenceNotEqualTo<T>(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsReferenceNotEqualTo<T>(name);
         }
 
         /// <summary>
@@ -262,10 +290,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsTrue([DoesNotReturnIf(false)] bool value, string name)
         {
-            if (!value)
+            if (value)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsTrue(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsTrue(name);
         }
 
         /// <summary>
@@ -278,10 +308,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsTrue([DoesNotReturnIf(false)] bool value, string name, string message)
         {
-            if (!value)
+            if (value)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsTrue(name, message);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsTrue(name, message);
         }
 
         /// <summary>
@@ -293,10 +325,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsFalse([DoesNotReturnIf(true)] bool value, string name)
         {
-            if (value)
+            if (!value)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsFalse(name);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsFalse(name);
         }
 
         /// <summary>
@@ -309,10 +343,12 @@ namespace Microsoft.Toolkit.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsFalse([DoesNotReturnIf(true)] bool value, string name, string message)
         {
-            if (value)
+            if (!value)
             {
-                ThrowHelper.ThrowArgumentExceptionForIsFalse(name, message);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForIsFalse(name, message);
         }
     }
 }

--- a/Microsoft.Toolkit/Diagnostics/ThrowHelper.ThrowExceptions.cs
+++ b/Microsoft.Toolkit/Diagnostics/ThrowHelper.ThrowExceptions.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
 
 #nullable enable
 
@@ -38,7 +37,6 @@ namespace Microsoft.Toolkit.Diagnostics
         /// <param name="name">The argument name.</param>
         /// <param name="message">The message to include in the exception.</param>
         /// <exception cref="ArgumentException">Thrown with <paramref name="message"/> and <paramref name="name"/>.</exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [DoesNotReturn]
         private static void ThrowArgumentException(string name, string message)
         {
@@ -51,7 +49,6 @@ namespace Microsoft.Toolkit.Diagnostics
         /// <param name="name">The argument name.</param>
         /// <param name="message">The message to include in the exception.</param>
         /// <exception cref="ArgumentNullException">Thrown with <paramref name="name"/> and <paramref name="message"/>.</exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [DoesNotReturn]
         private static void ThrowArgumentNullException(string name, string message)
         {
@@ -64,7 +61,6 @@ namespace Microsoft.Toolkit.Diagnostics
         /// <param name="name">The argument name.</param>
         /// <param name="message">The message to include in the exception.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown with <paramref name="name"/> and <paramref name="message"/>.</exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [DoesNotReturn]
         private static void ThrowArgumentOutOfRangeException(string name, string message)
         {


### PR DESCRIPTION
## Speed improvement for #3131 and #3167 

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
- Speed improvement


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The JIT compiler always assumes that forward branches are taken, unless it can see that the branch always throws. This doesn't happen in our throw methods, as we have a secondary `ThrowHelper.Throw...` method that actually creates the exceptions to throw in the correct format.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
To work around this, all the `Guard` conditions have been inverted to guarantee that the forward branch considered taken is the one corresponding to the successful path for the check being done. This also improves code readability, as the conditions in each `Guard` API are no longer inverted.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->