### PR TITLE
Fix Sample app in release mode

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,7 +23,7 @@
   </Choose>
   
   <Choose>
-    <When Condition="$(TargetFramework.Contains('uap10.0')) == false and '$(TargetFramework)' != 'native' and '$(IsTestSampleProject)' != 'true'">
+    <When Condition="'$(TargetFramework.Contains(`uap10.0`))' == 'false' and '$(TargetFramework)' != 'native' and '$(IsSampleProject)' != 'true'">
       <PropertyGroup>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)toolkit.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
## Fixes Sample app build on Release mode

## PR Type
What kind of change does this PR introduce?

- Bugfix 

## What is the current behavior?
Sample app was not building on Release mode due to wrong logic to enable strong name.

## What is the new behavior?
Fixed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes