### PR TITLE
Fix crash with unbounded sizing for WrapLayout.

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/StaggeredLayout/StaggeredLayoutPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/StaggeredLayout/StaggeredLayoutPage.xaml.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var repeater = control.FindChildByName("StaggeredRepeater") as ItemsRepeater;
+            var repeater = control.FindDescendantByName("StaggeredRepeater") as ItemsRepeater;
 
             if (repeater != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayout.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayout.bind
@@ -19,18 +19,14 @@
 
   <Grid Padding="48">
     <winui:ItemsRepeaterScrollHost> <!-- Needed for 1803 and below -->
-      <ScrollViewer 
-        HorizontalScrollMode="Auto" 
-        HorizontalScrollBarVisibility="@[ScrollHorizontal:Enum:ScrollBarVisibility.Disabled]@"
-        VerticalScrollBarVisibility="@[ScrollVertical:Enum:ScrollBarVisibility.Visible]@">
+      <ScrollViewer x:Name="WrapScrollParent">
         <winui:ItemsRepeater x:Name="WrapRepeater"
                              Background="{ThemeResource Brush-Grey-04}"
                              ItemTemplate="{StaticResource WrapTemplate}">
           <winui:ItemsRepeater.Layout>
             <controls:WrapLayout x:Name="Wrap"
                                  VerticalSpacing="@[VerticalSpacing:Slider:5:0-200]@"
-                                 HorizontalSpacing="@[HorizontalSpacing:Slider:5:0-200]@"
-                                 Orientation="@[Orientation:Enum:Orientation.Horizontal]@"/>
+                                 HorizontalSpacing="@[HorizontalSpacing:Slider:5:0-200]@"/>
           </winui:ItemsRepeater.Layout>
         </winui:ItemsRepeater>
       </ScrollViewer>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayout.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayout.bind
@@ -19,14 +19,18 @@
 
   <Grid Padding="48">
     <winui:ItemsRepeaterScrollHost> <!-- Needed for 1803 and below -->
-      <ScrollViewer>
+      <ScrollViewer 
+        HorizontalScrollMode="Auto" 
+        HorizontalScrollBarVisibility="@[ScrollHorizontal:Enum:ScrollBarVisibility.Disabled]@"
+        VerticalScrollBarVisibility="@[ScrollVertical:Enum:ScrollBarVisibility.Visible]@">
         <winui:ItemsRepeater x:Name="WrapRepeater"
                              Background="{ThemeResource Brush-Grey-04}"
                              ItemTemplate="{StaticResource WrapTemplate}">
           <winui:ItemsRepeater.Layout>
             <controls:WrapLayout x:Name="Wrap"
                                  VerticalSpacing="@[VerticalSpacing:Slider:5:0-200]@"
-                                 HorizontalSpacing="@[HorizontalSpacing:Slider:5:0-200]@"/>
+                                 HorizontalSpacing="@[HorizontalSpacing:Slider:5:0-200]@"
+                                 Orientation="@[Orientation:Enum:Orientation.Horizontal]@"/>
           </winui:ItemsRepeater.Layout>
         </winui:ItemsRepeater>
       </ScrollViewer>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml
@@ -6,10 +6,17 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:winui="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Page.Resources>
         <controls:WrapLayout x:Key="WrapLayoutPlaceholder"/>
     </Page.Resources>
+
+    <winui:ItemsRepeaterScrollHost>
+        <ScrollViewer x:Name="WrapScrollParent">
+            <winui:ItemsRepeater x:Name="WrapRepeater"/>
+        </ScrollViewer>
+    </winui:ItemsRepeaterScrollHost>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml.cs
@@ -39,16 +39,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var repeater = control.FindChildByName("WrapRepeater") as ItemsRepeater;
+            var repeater = control.FindDescendantByName("WrapRepeater") as ItemsRepeater;
 
             if (repeater != null)
             {
                 repeater.ItemsSource = _items;
+
+                _wrapLayout = repeater.Layout as WrapLayout;
             }
 
-            _wrapScrollParent = control.FindChildByName("WrapScrollParent") as ScrollViewer;
-            var wrapLayoutParent = _wrapScrollParent?.FindDescendant<ItemsRepeater>();
-            _wrapLayout = wrapLayoutParent.Layout as WrapLayout;
+            _wrapScrollParent = control.FindDescendantByName("WrapScrollParent") as ScrollViewer;
         }
 
         private class Item

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI;
@@ -19,10 +20,14 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
     {
         private ObservableCollection<Item> _items = new ObservableCollection<Item>();
         private Random _random;
+        private ScrollViewer _wrapScrollParent;
+        private WrapLayout _wrapLayout;
 
         public WrapLayoutPage()
         {
             this.InitializeComponent();
+
+            SampleController.Current.RegisterNewCommand("Switch Orientation", SwitchButton_Click);
 
             _random = new Random(DateTime.Now.Millisecond);
             for (int i = 0; i < _random.Next(1000, 5000); i++)
@@ -40,6 +45,10 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             {
                 repeater.ItemsSource = _items;
             }
+
+            _wrapScrollParent = control.FindChildByName("WrapScrollParent") as ScrollViewer;
+            var wrapLayoutParent = _wrapScrollParent?.FindDescendant<ItemsRepeater>();
+            _wrapLayout = wrapLayoutParent.Layout as WrapLayout;
         }
 
         private class Item
@@ -51,6 +60,29 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             public int Height { get; internal set; }
 
             public Color Color { get; internal set; }
+        }
+
+        private void SwitchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            if (_wrapLayout != null && _wrapScrollParent != null)
+            {
+                if (_wrapLayout.Orientation == Orientation.Horizontal)
+                {
+                    _wrapLayout.Orientation = Orientation.Vertical;
+                    ScrollViewer.SetVerticalScrollMode(_wrapScrollParent, ScrollMode.Disabled);
+                    ScrollViewer.SetVerticalScrollBarVisibility(_wrapScrollParent, ScrollBarVisibility.Disabled);
+                    ScrollViewer.SetHorizontalScrollMode(_wrapScrollParent, ScrollMode.Auto);
+                    ScrollViewer.SetHorizontalScrollBarVisibility(_wrapScrollParent, ScrollBarVisibility.Auto);
+                }
+                else
+                {
+                    _wrapLayout.Orientation = Orientation.Horizontal;
+                    ScrollViewer.SetVerticalScrollMode(_wrapScrollParent, ScrollMode.Auto);
+                    ScrollViewer.SetVerticalScrollBarVisibility(_wrapScrollParent, ScrollBarVisibility.Auto);
+                    ScrollViewer.SetHorizontalScrollMode(_wrapScrollParent, ScrollMode.Disabled);
+                    ScrollViewer.SetHorizontalScrollBarVisibility(_wrapScrollParent, ScrollBarVisibility.Disabled);
+                }
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/WrapLayout/WrapLayout.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/WrapLayout/WrapLayout.cs
@@ -255,8 +255,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // this way is faster than an if condition in every loop for checking the last item
             totalMeasure.U = parentMeasure.U;
 
-            // Propagating an infinite size causes a crash. This can happen if the parent is scrollable and infinite in the oposite 
+            // Propagating an infinite size causes a crash. This can happen if the parent is scrollable and infinite in the opposite
             // axis to the pannel. Clearing to zero prevents the crash.
+            // This is likely an incorrect use of the control by the developer, however we need stability here so setting a default that wont crash.
             if (double.IsInfinity(totalMeasure.U))
             {
                 totalMeasure.U = 0.0;
@@ -265,7 +266,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             totalMeasure.V = state.GetHeight();
 
             totalMeasure.U = Math.Ceiling(totalMeasure.U);
-            return Orientation == Orientation.Horizontal ? new Size(totalMeasure.U, totalMeasure.V) : new Size(totalMeasure.V, totalMeasure.U); ;
+            return Orientation == Orientation.Horizontal ? new Size(totalMeasure.U, totalMeasure.V) : new Size(totalMeasure.V, totalMeasure.U);
         }
 
         /// <inheritdoc />

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/WrapLayout/WrapLayout.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/WrapLayout/WrapLayout.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             totalMeasure.U = parentMeasure.U;
 
             // Propagating an infinite size causes a crash. This can happen if the parent is scrollable and infinite in the opposite
-            // axis to the pannel. Clearing to zero prevents the crash.
+            // axis to the panel. Clearing to zero prevents the crash.
             // This is likely an incorrect use of the control by the developer, however we need stability here so setting a default that wont crash.
             if (double.IsInfinity(totalMeasure.U))
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/WrapLayout/WrapLayout.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/WrapLayout/WrapLayout.cs
@@ -254,11 +254,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // for the last condition it is zeros so adding it will make no difference
             // this way is faster than an if condition in every loop for checking the last item
             totalMeasure.U = parentMeasure.U;
+
+            // Propagating an infinite size causes a crash. This can happen if the parent is scrollable and infinite in the oposite 
+            // axis to the pannel. Clearing to zero prevents the crash.
+            if (double.IsInfinity(totalMeasure.U))
+            {
+                totalMeasure.U = 0.0;
+            }
+
             totalMeasure.V = state.GetHeight();
 
             totalMeasure.U = Math.Ceiling(totalMeasure.U);
-
-            return Orientation == Orientation.Horizontal ? new Size(totalMeasure.U, totalMeasure.V) : new Size(totalMeasure.V, totalMeasure.U);
+            return Orientation == Orientation.Horizontal ? new Size(totalMeasure.U, totalMeasure.V) : new Size(totalMeasure.V, totalMeasure.U); ;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Also add some new stuff to the sample for easier manipulation.

## Fixes #3327 <!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged. -->
https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3327

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
WrapLayout throws when contained in a control with an infinite size in the axis opposite to the WrapLayout.

## What is the new behavior?
It doesnt crash now. And there are some neat controls on the sample to help swap axis.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
