### PR TITLE
Fixed wrong icon extension being used in sample

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/IconExtensions/IconExtensionsXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/IconExtensions/IconExtensionsXaml.bind
@@ -58,8 +58,8 @@
                     Width="300" Margin="12" Height="68">
         <SwipeControl.LeftItems>
           <SwipeItems Mode="Reveal">
-            <SwipeItem Text="Accept" IconSource="{ex:FontIconSource Glyph=Accept}"/>
-            <SwipeItem Text="Flag" IconSource="{ex:FontIconSource Glyph=Flag}"/>
+            <SwipeItem Text="Accept" IconSource="{ex:SymbolIconSource Glyph=Accept}"/>
+            <SwipeItem Text="Flag" IconSource="{ex:SymbolIconSource Glyph=Flag}"/>
           </SwipeItems>
         </SwipeControl.LeftItems>
         <TextBlock Text="Swipe Right"


### PR DESCRIPTION
## Sample page fix for #3110 and #3129 

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
 - Sample app changes
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Wrong extension used in the sample page

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Not wrong extension used in sample page 😄

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [ ] ~~Tests for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Header has been added to all new source files (run *build/UpdateHeaders.bat*)~~
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->
