### PR TITLE
Fix acrylic brush noise texture placement

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Prebuilt.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Prebuilt.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media.Pipelines
 
             if (noiseUri != null)
             {
-                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay, Placement.Background);
+                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay);
             }
 
             return pipeline;
@@ -72,7 +72,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media.Pipelines
 
             if (noiseUri != null)
             {
-                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay, Placement.Background);
+                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay);
             }
 
             return pipeline;
@@ -106,7 +106,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media.Pipelines
 
             if (noiseUri != null)
             {
-                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay, Placement.Background);
+                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay);
             }
 
             return pipeline;
@@ -133,7 +133,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media.Pipelines
 
             if (noiseUri != null)
             {
-                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay, Placement.Background);
+                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay);
             }
 
             return pipeline;
@@ -169,7 +169,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media.Pipelines
 
             if (noiseUri != null)
             {
-                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay, Placement.Background);
+                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay);
             }
 
             return pipeline;
@@ -205,7 +205,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Media.Pipelines
 
             if (noiseUri != null)
             {
-                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay, Placement.Background);
+                return pipeline.Blend(FromTiles(noiseUri, cacheMode: cacheMode), BlendEffectMode.Overlay);
             }
 
             return pipeline;


### PR DESCRIPTION
## Follow up to #3112 and #3298 

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `AcrylicBrush` and the various `PipelineBuilder` APIs to create acrylic brushes are using the incorrect placement for the blend effect adding the noise texture at the end of the pipeline. THis bug was introduced in #3298, as I forgot to update the code there after swapping the way the placement property worked 🤦‍♂️

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Fixed the blend effects for acrylic brushes, now the noise texture will correctly be displayed on top.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [ ] ~~Tests for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Header has been added to all new source files (run *build/UpdateHeaders.bat*)~~
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->
