### PR TITLE
Reduce memory pressure in CI tests for HP package

### DIFF
--- a/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.Count.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.Count.cs
@@ -62,7 +62,12 @@ namespace UnitTests.HighPerformance.Extensions
         {
             var value = new Int(37438941);
 
-            foreach (var count in TestCounts)
+            // We can skip the most expensive test in this case, as we're not testing
+            // a SIMD enabled path. The last test requires a very high memory usage which
+            // sometimes causes the CI test runner to fail with an out of memory exception.
+            // Since we don't need to double check overflows in the managed case, which is
+            // just a classic linear loop with some optimizations, omitting this case is fine.
+            foreach (var count in TestCounts.Slice(0, TestCounts.Length - 1))
             {
                 var random = new Random(count);
 


### PR DESCRIPTION
## Fixes OOM error in CI for `HighPerformance` tests

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
 - Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`UnitTests.HighPerformance.Extensions.Test_ReadOnlySpanExtensions.Test_ReadOnlySpanExtensions_RandomCountManaged` is sometimes failing with an out of memory exception.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Disabled the most expensive test case there (see comments) to try to avoid this issue.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [ ] ~~Tests for the changes have been added (for bug fixes / features) (if applicable)~~
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->