### PR TITLE
Remove `lock` statements from `InAppNotification` control

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationCode.bind
@@ -46,6 +46,14 @@ if (isTemplatePresent && inAppNotificationWithButtonsTemplate is DataTemplate)
     ExampleInAppNotification.Show(inAppNotificationWithButtonsTemplate as DataTemplate);
 }
 
+// Show notification using an object
+<controls:InAppNotification
+    x:Name="ExampleInAppNotification"
+    ContentTemplate="{StaticResource MyNotificationDataTemplate}" />
+
+var notificationData = new MyNotificationData("Title", "Message");
+ExampleInAppNotification.Show(notificationData, duration: 2000);
+
 // Dismiss notification
 ExampleInAppNotification.Dismiss();
 
@@ -53,14 +61,14 @@ ExampleInAppNotification.Dismiss();
 
 private void YesButton_Click(object sender, RoutedEventArgs e)
 {
-	// TODO : Do something when user accepted
+    // TODO : Do something when user accepted
 
     ExampleInAppNotification.Dismiss();
 }
 
 private void NoButton_Click(object sender, RoutedEventArgs e)
 {
-	// TODO : Do something when user refused
+    // TODO : Do something when user refused
 
     ExampleInAppNotification.Dismiss();
 }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationPage.xaml.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Windows.Input;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -55,6 +56,15 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _exampleVSCodeInAppNotification?.Dismiss();
                 SetDefaultControlTemplate();
                 _exampleInAppNotification?.Show(GetRandomText(), NotificationDuration);
+            });
+
+            SampleController.Current.RegisterNewCommand("Show notification with object", (sender, args) =>
+            {
+                _exampleVSCodeInAppNotification?.Dismiss();
+                SetDefaultControlTemplate();
+
+                var random = new Random();
+                _exampleInAppNotification?.Show(new KeyValuePair<int, string>(random.Next(1, 10), GetRandomText()), NotificationDuration);
             });
 
             SampleController.Current.RegisterNewCommand("Show notification with buttons (without DataTemplate)", (sender, args) =>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
@@ -153,7 +153,8 @@
                           <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        <ContentPresenter x:Name="PART_Presenter"
+                                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                                           HorizontalContentAlignment="Stretch"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           VerticalContentAlignment="Center"
@@ -333,7 +334,8 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
-                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                <ContentPresenter x:Name="PART_Presenter"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                                                   HorizontalContentAlignment="Stretch"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   VerticalContentAlignment="Center"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationXaml.bind
@@ -378,7 +378,17 @@
                                     AnimationDuration="@[AnimationDuration:TimeSpan:100:0-5000]"
                                     VerticalOffset="@[VerticalOffset:DoubleSlider:100.0:-200.0-200.0]"
                                     HorizontalOffset="@[HorizontalOffset:DoubleSlider:0.0:-200.0-200.0]"
-                                    StackMode="@[StackMode:Enum:StackMode.Replace]" />
+                                    StackMode="@[StackMode:Enum:StackMode.Replace]">
+            <controls:InAppNotification.ContentTemplate>
+               <DataTemplate>
+                    <StackPanel>
+                        <TextBlock Text="{Binding Value}" Margin="0,0,0,8" />
+                        <TextBlock Text="{Binding Key}" Style="{ThemeResource CaptionTextBlockStyle}" Opacity="0.8" />
+                    </StackPanel>
+                </DataTemplate>
+            </controls:InAppNotification.ContentTemplate>
+        </controls:InAppNotification>
+          
 
         <controls:InAppNotification x:Name="ExampleCustomInAppNotification"
                                     Style="{StaticResource MSEdgeNotificationTemplate_NoDismissButton}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Constants.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Constants.cs
@@ -28,5 +28,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Key of the UI Element that dismiss the control
         /// </summary>
         private const string DismissButtonPart = "PART_DismissButton";
+
+        /// <summary>
+        /// Key of the UI Element that will display the notification content.
+        /// </summary>
+        private const string ContentPresenterPart = "PART_Presenter";
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -80,16 +80,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
         public void Show(int duration = 0)
         {
-            _dismissTimer.Stop();
-
-            var eventArgs = new InAppNotificationOpeningEventArgs();
-            Opening?.Invoke(this, eventArgs);
-
-            if (eventArgs.Cancel)
-            {
-                return;
-            }
-
             // We keep our current content
             var notificationOptions = new NotificationOptions
             {
@@ -258,6 +248,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <param name="notificationOptions">Information about the notification to display</param>
         private void Show(NotificationOptions notificationOptions)
         {
+            var eventArgs = new InAppNotificationOpeningEventArgs();
+            Opening?.Invoke(this, eventArgs);
+
+            if (eventArgs.Cancel)
+            {
+                return;
+            }
+
             var shouldDisplayImmediately = true;
             switch (StackMode)
             {
@@ -287,6 +285,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _dismissTimer.Interval = TimeSpan.FromMilliseconds(notificationOptions.Duration);
                     _dismissTimer.Start();
+                }
+                else
+                {
+                    _dismissTimer.Stop();
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Show notification using the current template
+        /// Show notification using the current content.
         /// </summary>
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
         public void Show(int duration = 0)
@@ -131,7 +131,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Show notification using DataTemplate as the content of the notification
+        /// Show notification using <paramref name="dataTemplate"/> as the content of the notification
         /// </summary>
         /// <param name="dataTemplate">DataTemplate used as the content of the notification</param>
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
@@ -141,6 +141,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 Duration = duration,
                 Content = dataTemplate
+            };
+            Show(notificationOptions);
+        }
+
+        /// <summary>
+        /// Show notification using <paramref name="content"/> as the content of the notification.
+        /// The <paramref name="content"/> will be displayed with the current <see cref="ContentControl.ContentTemplate"/>.
+        /// </summary>
+        /// <param name="content">The content of the notification</param>
+        /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
+        public void Show(object content, int duration = 0)
+        {
+            var notificationOptions = new NotificationOptions
+            {
+                Duration = duration,
+                Content = content
             };
             Show(notificationOptions);
         }
@@ -228,6 +244,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 case DataTemplate dataTemplate:
                     _contentProvider.ContentTemplate = dataTemplate;
                     _contentProvider.Content = null;
+                    break;
+                case object content:
+                    _contentProvider.ContentTemplate = ContentTemplate;
+                    _contentProvider.Content = content;
                     break;
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
@@ -1,16 +1,16 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
+                    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml" />
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style TargetType="local:InAppNotification" x:Key="BaseInAppNotificationsStyle">
+    <Style x:Key="BaseInAppNotificationsStyle"
+           TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
@@ -31,11 +31,13 @@
         <Setter Property="Template" Value="{StaticResource MSEdgeNotificationTemplate}" />
     </Style>
 
-    <contract7NotPresent:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+    <contract7NotPresent:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
+                               TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
     </contract7NotPresent:Style>
 
-    <contract7Present:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+    <contract7Present:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
+                            TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />
     </contract7Present:Style>
 </ResourceDictionary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -1,26 +1,34 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <ResourceDictionary.ThemeDictionaries>
-        <!-- Default is a fallback if a more precise theme isn't called
-            out below -->
+        <!--
+            Default is a fallback if a more precise theme isn't called
+            out below
+        -->
         <ResourceDictionary x:Key="Default">
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush" Color="Transparent" />
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush"
+                             Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush"
+                             Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush"
+                             Color="Transparent" />
         </ResourceDictionary>
 
-        <!-- HighContrast is used in all high contrast themes -->
+        <!--  HighContrast is used in all high contrast themes  -->
         <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush" Color="{ThemeResource SystemColorHighlightTextColor}"/>
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush"
+                             Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush"
+                             Color="{ThemeResource SystemColorHighlightTextColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush"
+                             Color="{ThemeResource SystemColorButtonTextColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style x:Key="DismissTextBlockButtonStyle" TargetType="ButtonBase">
+    <Style x:Key="DismissTextBlockButtonStyle"
+           TargetType="ButtonBase">
         <Setter Property="Background" Value="{ThemeResource HyperlinkButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
         <Setter Property="Width" Value="40" />
@@ -30,46 +38,64 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ButtonBase">
-                    <Grid x:Name="RootGrid" Margin="{TemplateBinding Padding}" Background="{TemplateBinding Background}">
-                        <Border x:Name="TextBorder" BorderThickness="2" BorderBrush="{ThemeResource SystemControlMSEdgeNotificationButtonBorderBrush}">
+                    <Grid x:Name="RootGrid"
+                          Margin="{TemplateBinding Padding}"
+                          Background="{TemplateBinding Background}">
+                        <Border x:Name="TextBorder"
+                                BorderBrush="{ThemeResource SystemControlMSEdgeNotificationButtonBorderBrush}"
+                                BorderThickness="2">
                             <ContentPresenter x:Name="Text"
-                                              Content="{TemplateBinding Content}"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Content="{TemplateBinding Content}" />
                         </Border>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
                                 <VisualState x:Name="PointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverForegroundBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text"
+                                                                       Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverForegroundBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverChromeBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
+                                                                       Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverChromeBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverForegroundBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text"
+                                                                       Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverForegroundBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverChromeBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
+                                                                       Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlMSEdgeNotificationPointerOverChromeBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource HyperlinkButtonForegroundDisabled}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text"
+                                                                       Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource HyperlinkButtonForegroundDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource HyperlinkButtonBackgroundDisabled}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text"
+                                                                       Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource HyperlinkButtonBackgroundDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource HyperlinkButtonBorderBrushDisabled}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text"
+                                                                       Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource HyperlinkButtonBorderBrushDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -81,25 +107,67 @@
         </Setter>
     </Style>
 
-    <ControlTemplate x:Key="MSEdgeNotificationTemplate" 
+    <ControlTemplate x:Key="MSEdgeNotificationTemplate"
                      TargetType="local:InAppNotification">
         <Grid>
+            <Grid x:Name="RootGrid"
+                  MaxWidth="{TemplateBinding MaxWidth}"
+                  Margin="{TemplateBinding Margin}"
+                  Padding="{TemplateBinding Padding}"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  RenderTransformOrigin="{TemplateBinding RenderTransformOrigin}"
+                  Visibility="{TemplateBinding Visibility}">
+
+                <Grid.RenderTransform>
+                    <CompositeTransform />
+                </Grid.RenderTransform>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <ContentPresenter x:Name="PART_Presenter"
+                                  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  HorizontalContentAlignment="Stretch"
+                                  VerticalContentAlignment="Center"
+                                  ContentTransitions="{TemplateBinding ContentTransitions}"
+                                  TextWrapping="WrapWholeWords" />
+
+                <Button x:Name="PART_DismissButton"
+                        Grid.Column="1"
+                        Margin="24,0,0,0"
+                        AutomationProperties.Name="Dismiss"
+                        Content="&#xE894;"
+                        FontFamily="Segoe MDL2 Assets"
+                        FontSize="16"
+                        Style="{StaticResource DismissTextBlockButtonStyle}">
+                    <Button.RenderTransform>
+                        <TranslateTransform x:Name="DismissButtonTransform" X="18" />
+                    </Button.RenderTransform>
+                </Button>
+            </Grid>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="State">
                     <VisualState x:Name="Collapsed">
                         <Storyboard>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="0" />
                                 <EasingDoubleKeyFrame local:InAppNotification.KeyFrameDuration="{Binding AnimationDuration, RelativeSource={RelativeSource TemplatedParent}}"
                                                       Value="{Binding HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
                             </DoubleAnimationUsingKeyFrames>
 
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="0" />
-                                <EasingDoubleKeyFrame local:InAppNotification.KeyFrameDuration="{Binding AnimationDuration, RelativeSource={RelativeSource TemplatedParent}}" 
-                                                      Value="{Binding VerticalOffset, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="0" />
+                                <EasingDoubleKeyFrame local:InAppNotification.KeyFrameDuration="{Binding AnimationDuration, RelativeSource={RelativeSource TemplatedParent}}"
+                                                      Value="{Binding VerticalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
                             </DoubleAnimationUsingKeyFrames>
 
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
@@ -120,64 +188,30 @@
 
                     <VisualState x:Name="Visible">
                         <Storyboard>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="{Binding HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
-                                <EasingDoubleKeyFrame local:InAppNotification.KeyFrameDuration="{Binding AnimationDuration, RelativeSource={RelativeSource TemplatedParent}}" Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="{Binding HorizontalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+                                <EasingDoubleKeyFrame local:InAppNotification.KeyFrameDuration="{Binding AnimationDuration, RelativeSource={RelativeSource TemplatedParent}}"
+                                                      Value="0" />
                             </DoubleAnimationUsingKeyFrames>
 
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="{Binding VerticalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
-                                <EasingDoubleKeyFrame local:InAppNotification.KeyFrameDuration="{Binding AnimationDuration, RelativeSource={RelativeSource TemplatedParent}}" Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="{Binding VerticalOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+                                <EasingDoubleKeyFrame local:InAppNotification.KeyFrameDuration="{Binding AnimationDuration, RelativeSource={RelativeSource TemplatedParent}}"
+                                                      Value="0" />
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
-
-            <Grid x:Name="RootGrid" 
-                  RenderTransformOrigin="{TemplateBinding RenderTransformOrigin}"
-                  Margin="{TemplateBinding Margin}"
-                  Padding="{TemplateBinding Padding}"
-                  MaxWidth="{TemplateBinding MaxWidth}"
-                  Visibility="{TemplateBinding Visibility}"
-                  Background="{TemplateBinding Background}" 
-                  BorderBrush="{TemplateBinding BorderBrush}" 
-                  BorderThickness="{TemplateBinding BorderThickness}">
-                
-                <Grid.RenderTransform>
-                    <CompositeTransform />
-                </Grid.RenderTransform>
-
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                                  HorizontalContentAlignment="Stretch"
-                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  VerticalContentAlignment="Center"
-                                  TextWrapping="WrapWholeWords" />
-
-                <Button x:Name="PART_DismissButton"
-                        Grid.Column="1" 
-                        Margin="24,0,0,0"
-                        FontSize="16"
-                        Style="{StaticResource DismissTextBlockButtonStyle}"
-                        Content="&#xE894;"
-                        FontFamily="Segoe MDL2 Assets" 
-                        AutomationProperties.Name="Dismiss">
-                    <Button.RenderTransform>
-                        <TranslateTransform x:Name="DismissButtonTransform" X="18" />
-                    </Button.RenderTransform>
-                </Button>
-            </Grid>
         </Grid>
     </ControlTemplate>
 
-    <Style x:Key="MSEdgeNotificationStyle" TargetType="local:InAppNotification">
+    <Style x:Key="MSEdgeNotificationStyle"
+           TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -8,18 +8,26 @@
             out below
         -->
         <ResourceDictionary x:Key="Default">
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush" Color="Transparent" />
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush" Color="{ThemeResource SystemBaseMediumColor}" />
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerPressedForegroundBrush" Color="{ThemeResource SystemBaseHighColor}" />
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush"
+                             Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush"
+                             Color="{ThemeResource SystemBaseMediumColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerPressedForegroundBrush"
+                             Color="{ThemeResource SystemBaseHighColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush"
+                             Color="Transparent" />
         </ResourceDictionary>
 
         <!--  HighContrast is used in all high contrast themes  -->
         <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush" Color="{ThemeResource SystemBaseHighColor}"/>
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerPressedForegroundBrush" Color="{ThemeResource SystemBaseHighColor}" />
-            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverChromeBrush"
+                             Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerOverForegroundBrush"
+                             Color="{ThemeResource SystemBaseHighColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationPointerPressedForegroundBrush"
+                             Color="{ThemeResource SystemBaseHighColor}" />
+            <SolidColorBrush x:Key="SystemControlMSEdgeNotificationButtonBorderBrush"
+                             Color="{ThemeResource SystemColorButtonTextColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -64,8 +72,10 @@
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlMSEdgeNotificationPointerPressedForegroundBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Text"
+                                                                       Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlMSEdgeNotificationPointerPressedForegroundBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                                        Storyboard.TargetProperty="Background">

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml
@@ -1,39 +1,55 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <ResourceDictionary.ThemeDictionaries>
-        <!-- Default is a fallback if a more precise theme isn't called
-            out below -->
+        <!--
+            Default is a fallback if a more precise theme isn't called
+            out below
+        -->
         <ResourceDictionary x:Key="Default">
-            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBackgroundBrush" Color="#0E639C" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBorderBrush" Color="#0E639C" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationButtonTextBrush" Color="White" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationGridBackgroundBrush" Color="#007ACC" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationBackgroundBrush" Color="#333333" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationForegroundBrush" Color="White" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationPointerOverChromeBrush" Color="#1177BB" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBackgroundBrush"
+                             Color="#0E639C" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBorderBrush"
+                             Color="#0E639C" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonTextBrush"
+                             Color="White" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationGridBackgroundBrush"
+                             Color="#007ACC" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationBackgroundBrush"
+                             Color="#333333" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationForegroundBrush"
+                             Color="White" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationPointerOverChromeBrush"
+                             Color="#1177BB" />
         </ResourceDictionary>
 
-        <!-- HighContrast is used in all high contrast themes -->
+        <!--  HighContrast is used in all high contrast themes  -->
         <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationButtonTextBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationGridBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationForegroundBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
-            <SolidColorBrush x:Key="SystemControlVSNotificationPointerOverChromeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBackgroundBrush"
+                             Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonBorderBrush"
+                             Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationButtonTextBrush"
+                             Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationGridBackgroundBrush"
+                             Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationBackgroundBrush"
+                             Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationForegroundBrush"
+                             Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="SystemControlVSNotificationPointerOverChromeBrush"
+                             Color="{ThemeResource SystemColorHighlightColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style x:Key="VisualStudioCodeNotificationButtonStyle" TargetType="ButtonBase">
+    <Style x:Key="VisualStudioCodeNotificationButtonStyle"
+           TargetType="ButtonBase">
         <Setter Property="Background" Value="{ThemeResource SystemControlVSNotificationButtonBackgroundBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlVSNotificationButtonTextBrush}" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="FontSize" Value="14" />
-        <Setter Property="Padding" Value="10 0" />
+        <Setter Property="Padding" Value="10,0" />
         <Setter Property="Height" Value="35" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlVSNotificationButtonBorderBrush}" />
@@ -41,37 +57,46 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ButtonBase">
-                    <Grid x:Name="RootGrid" 
-                          Padding="{TemplateBinding Padding}" 
-                          Margin="{TemplateBinding Margin}" 
+                    <Grid x:Name="RootGrid"
+                          Margin="{TemplateBinding Margin}"
+                          Padding="{TemplateBinding Padding}"
                           Background="{TemplateBinding Background}"
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}">
-                        <ContentPresenter x:Name="ContentHolder" Content="{TemplateBinding Content}"
+                        <ContentPresenter x:Name="ContentHolder"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
-                                          Foreground="{TemplateBinding Foreground}"/>
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Content}"
+                                          Foreground="{TemplateBinding Foreground}" />
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
                                 <VisualState x:Name="PointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlVSNotificationPointerOverChromeBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
+                                                                       Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlVSNotificationPointerOverChromeBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentHolder" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemColorHighlightTextColor}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentHolder"
+                                                                       Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemColorHighlightTextColor}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlVSNotificationPointerOverChromeBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
+                                                                       Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlVSNotificationPointerOverChromeBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentHolder" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemColorHighlightTextColor}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentHolder"
+                                                                       Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemColorHighlightTextColor}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -84,7 +109,8 @@
         </Setter>
     </Style>
 
-    <Style x:Key="VSCodeNotificationStyle" TargetType="local:InAppNotification">
+    <Style x:Key="VSCodeNotificationStyle"
+           TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlVSNotificationBackgroundBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlVSNotificationForegroundBrush}" />
         <Setter Property="BorderThickness" Value="0" />
@@ -94,28 +120,69 @@
         <Setter Property="FontSize" Value="14" />
         <Setter Property="MinHeight" Value="35" />
         <Setter Property="RenderTransformOrigin" Value="0.5,0" />
-        <Setter Property="Margin" Value="20 0" />
+        <Setter Property="Margin" Value="20,0" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="VerticalOffset" Value="-100" />
         <Setter Property="Template" Value="{StaticResource VSCodeNotificationTemplate}" />
     </Style>
 
-    <ControlTemplate x:Key="VSCodeNotificationTemplate" TargetType="local:InAppNotification">
+    <ControlTemplate x:Key="VSCodeNotificationTemplate"
+                     TargetType="local:InAppNotification">
         <Grid>
+            <Grid x:Name="RootGrid"
+                  MaxWidth="{TemplateBinding MaxWidth}"
+                  Margin="{TemplateBinding Margin}"
+                  Padding="{TemplateBinding Padding}"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  RenderTransformOrigin="{TemplateBinding RenderTransformOrigin}"
+                  Visibility="{TemplateBinding Visibility}">
+                <Grid.RenderTransform>
+                    <CompositeTransform />
+                </Grid.RenderTransform>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+
+                <Grid Height="20"
+                      Margin="10 5"
+                      Background="{ThemeResource SystemControlVSNotificationGridBackgroundBrush}">
+                    <TextBlock Padding="5 0"
+                               VerticalAlignment="Center"
+                               FontWeight="Bold"
+                               Foreground="White"
+                               Text="info" />
+                </Grid>
+
+                <ContentPresenter x:Name="PART_Presenter"
+                                  Grid.Column="1"
+                                  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  HorizontalContentAlignment="Stretch"
+                                  VerticalContentAlignment="Center"
+                                  TextWrapping="NoWrap" />
+            </Grid>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="State">
                     <VisualState x:Name="Collapsed">
                         <Storyboard>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="0" />
-                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0:0:0.1"
+                                                      Value="0" />
                             </DoubleAnimationUsingKeyFrames>
 
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="0" />
-                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="-100" />
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0:0:0.1"
+                                                      Value="-100" />
                             </DoubleAnimationUsingKeyFrames>
 
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
@@ -136,56 +203,25 @@
 
                     <VisualState x:Name="Visible">
                         <Storyboard>
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="0" />
-                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0:0:0.1"
+                                                      Value="0" />
                             </DoubleAnimationUsingKeyFrames>
 
-                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" 
+                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
-                                <EasingDoubleKeyFrame KeyTime="0" Value="-100" />
-                                <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="0"
+                                                      Value="-100" />
+                                <EasingDoubleKeyFrame KeyTime="0:0:0.1"
+                                                      Value="0" />
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
-
-            <Grid x:Name="RootGrid"
-                  RenderTransformOrigin="{TemplateBinding RenderTransformOrigin}"
-                  Margin="{TemplateBinding Margin}"
-                  Padding="{TemplateBinding Padding}"
-                  MaxWidth="{TemplateBinding MaxWidth}"
-                  Visibility="{TemplateBinding Visibility}"
-                  Background="{TemplateBinding Background}" 
-                  BorderBrush="{TemplateBinding BorderBrush}" 
-                  BorderThickness="{TemplateBinding BorderThickness}">
-                <Grid.RenderTransform>
-                    <CompositeTransform />
-                </Grid.RenderTransform>
-                
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition />
-                </Grid.ColumnDefinitions>
-
-                <Grid Margin="10 5" Height="20" Background="{ThemeResource SystemControlVSNotificationGridBackgroundBrush}">
-                    <TextBlock Text="info"
-                               Padding="5 0"
-                               FontWeight="Bold"
-                               VerticalAlignment="Center"
-                               Foreground="White" />
-                </Grid>
-
-                <ContentPresenter Grid.Column="1" 
-                                  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                                  HorizontalContentAlignment="Stretch"
-                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  VerticalContentAlignment="Center"
-                                  TextWrapping="NoWrap" 
-                                  />
-            </Grid>
         </Grid>
     </ControlTemplate>
 


### PR DESCRIPTION
## Fixes
Remove the `lock` statements used in `InAppNotification` as well as all the timers used to detect when the animation ends.

## PR Type
What kind of change does this PR introduce?
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes) 
- Sample app changes

## What is the current behavior?
The current `InAppNotification` implementation is using a lot of `lock` which are not needed since all the code lives in the UI thread. 

## What is the new behavior?
The control is no longer using any `lock`. All the notifications are now pushed to `_stackedNotificationOptions` which will control when the notification is displayed. This change allow us to set the appropriate content on the `ContentPresenter` when the control template is applied.
WE can also now push directly an `object` content as the notification payload. To make it always work, I've simplified the logic between the `InAppNotification` and its template. This is introducing a breaking change in the notification template.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository. Link: [#365](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/365)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

The `ContentPresenter` of the `InAppNotification` template must now be named `PART_Presenter`.

## Other information
The XAML files have been updated by XAML styler and contains a lot of changes unrelated to this PR.