### PR TITLE
Enable light templating in InAppNotification

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -20,11 +20,14 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
+    <x:Double x:Key="SystemControlMSEdgeNotificationDismissButtonSize">40</x:Double>
+    <Thickness x:Key="SystemControlMSEdgeNotificationDismissButtonMargin">24,0,0,0</Thickness>
+
     <Style x:Key="DismissTextBlockButtonStyle" TargetType="ButtonBase">
         <Setter Property="Background" Value="{ThemeResource HyperlinkButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
-        <Setter Property="Width" Value="40" />
-        <Setter Property="Height" Value="40" />
+        <Setter Property="Width" Value="{StaticResource SystemControlMSEdgeNotificationDismissButtonSize}" />
+        <Setter Property="Height" Value="{StaticResource SystemControlMSEdgeNotificationDismissButtonSize}" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="HighContrastAdjustment" Value="None" />
         <Setter Property="Template">
@@ -163,7 +166,7 @@
 
                 <Button x:Name="PART_DismissButton"
                         Grid.Column="1" 
-                        Margin="24,0,0,0"
+                        Margin="{StaticResource SystemControlMSEdgeNotificationDismissButtonMargin}"
                         FontSize="16"
                         Style="{StaticResource DismissTextBlockButtonStyle}"
                         Content="&#xE894;"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -24,6 +24,7 @@
     <Thickness x:Key="SystemControlMSEdgeNotificationDismissButtonMargin">24,0,0,0</Thickness>
     <x:Double x:Key="SystemControlMSEdgeNotificationDismissButtonTranslate">18</x:Double>
     <VerticalAlignment x:Key="SystemControlMSEdgeNotificationDismissButtonVerticalAlignment">Center</VerticalAlignment>
+    <Thickness x:Key="SystemControlMSEdgeNotificationButtonBorderThickness">2</Thickness>
     
     <Style x:Key="DismissTextBlockButtonStyle" TargetType="ButtonBase">
         <Setter Property="Background" Value="{ThemeResource HyperlinkButtonBackground}" />
@@ -36,7 +37,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="ButtonBase">
                     <Grid x:Name="RootGrid" Margin="{TemplateBinding Padding}" Background="{TemplateBinding Background}">
-                        <Border x:Name="TextBorder" BorderThickness="2" BorderBrush="{ThemeResource SystemControlMSEdgeNotificationButtonBorderBrush}">
+                        <Border x:Name="TextBorder" BorderThickness="{StaticResource SystemControlMSEdgeNotificationButtonBorderThickness}" BorderBrush="{ThemeResource SystemControlMSEdgeNotificationButtonBorderBrush}">
                             <ContentPresenter x:Name="Text"
                                               Content="{TemplateBinding Content}"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -22,7 +22,9 @@
 
     <x:Double x:Key="SystemControlMSEdgeNotificationDismissButtonSize">40</x:Double>
     <Thickness x:Key="SystemControlMSEdgeNotificationDismissButtonMargin">24,0,0,0</Thickness>
-
+    <x:Double x:Key="SystemControlMSEdgeNotificationDismissButtonTranslate">18</x:Double>
+    <VerticalAlignment x:Key="SystemControlMSEdgeNotificationDismissButtonVerticalAlignment">Center</VerticalAlignment>
+    
     <Style x:Key="DismissTextBlockButtonStyle" TargetType="ButtonBase">
         <Setter Property="Background" Value="{ThemeResource HyperlinkButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
@@ -170,10 +172,11 @@
                         FontSize="16"
                         Style="{StaticResource DismissTextBlockButtonStyle}"
                         Content="&#xE894;"
+                        VerticalAlignment="{StaticResource SystemControlMSEdgeNotificationDismissButtonVerticalAlignment}"
                         FontFamily="Segoe MDL2 Assets" 
                         AutomationProperties.Name="Dismiss">
                     <Button.RenderTransform>
-                        <TranslateTransform x:Name="DismissButtonTransform" X="18" />
+                        <TranslateTransform x:Name="DismissButtonTransform" X="{StaticResource SystemControlMSEdgeNotificationDismissButtonTranslate}" />
                     </Button.RenderTransform>
                 </Button>
             </Grid>


### PR DESCRIPTION
Adjusting some style properties of `InAppNotification` like the margin between the dismiss button and the content requires a full retemplate. We can avoid this by using named resources and allow a "light" templating by adjusting only the resources we want.

## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
The default style of `InAppNotification` contains fixed values that are not easily customizable like the margin for the dismiss button:

```xaml
<Button x:Name="PART_DismissButton"
    Margin="24,0,0,0" />
```

## What is the new behavior?
`InAppNotification` default style will now use named resources for some key layout properties.
This will allow us to only redefine those property to adjust the layout instead of going through a full retemplate.

```xaml
<Button x:Name="PART_DismissButton"
    Margin="{StaticResource SystemControlMSEdgeNotificationDismissButtonMargin}">
```

We will now be able to customize the following properties:
```xaml
<x:Double x:Key="SystemControlMSEdgeNotificationDismissButtonSize">40</x:Double>
<Thickness x:Key="SystemControlMSEdgeNotificationDismissButtonMargin">24,0,0,0</Thickness>
<x:Double x:Key="SystemControlMSEdgeNotificationDismissButtonTranslate">18</x:Double>
<VerticalAlignment x:Key="SystemControlMSEdgeNotificationDismissButtonVerticalAlignment">Center</VerticalAlignment>
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
