### PR TITLE
DataGrid fixes for WinUI 3 usage

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
@@ -5653,7 +5653,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             ShowScrollBars();
 
             // If the DataGrid itself got focus, we actually want the automation focus to be on the current element
-            if (e.OriginalSource == this && AutomationPeer.ListenerExists(AutomationEvents.AutomationFocusChanged))
+            if (e.OriginalSource as Control == this && AutomationPeer.ListenerExists(AutomationEvents.AutomationFocusChanged))
             {
                 DataGridAutomationPeer peer = DataGridAutomationPeer.FromElement(this) as DataGridAutomationPeer;
                 if (peer != null)
@@ -5684,7 +5684,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void DataGrid_KeyUp(object sender, KeyRoutedEventArgs e)
         {
-            if (e.Key == VirtualKey.Tab && e.OriginalSource == this)
+            if (e.Key == VirtualKey.Tab && e.OriginalSource as Control == this)
             {
                 if (this.CurrentColumnIndex == -1)
                 {
@@ -6239,7 +6239,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 // If the DataGrid itself has focus, we want to move automation focus to the new current element
                 object focusedObject = FocusManager.GetFocusedElement();
-                if (focusedObject == this && AutomationPeer.ListenerExists(AutomationEvents.AutomationFocusChanged))
+                if (focusedObject as Control == this && AutomationPeer.ListenerExists(AutomationEvents.AutomationFocusChanged))
                 {
                     peer.RaiseAutomationFocusChangedEvent(this.CurrentSlot, this.CurrentColumnIndex);
                 }
@@ -6716,7 +6716,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (_editingColumnIndex == -1 ||
                 this.CurrentColumnIndex == -1 ||
-                this.EditingRow.Cells[this.CurrentColumnIndex].Content != editingElement)
+                this.EditingRow.Cells[this.CurrentColumnIndex].Content as FrameworkElement != editingElement)
             {
                 // The current cell has changed since the call to BeginCellEdit, so the fact
                 // that this element has loaded is no longer relevant

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridCell.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridCell.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 if (this.OwningRow != null)
                 {
                     Debug.Assert(sender is DataGridCell, "Expected sender is DataGridCell.");
-                    Debug.Assert(sender == this, "Expected sender is this.");
+                    Debug.Assert(sender as ContentControl == this, "Expected sender is this.");
                     e.Handled = this.OwningGrid.UpdateStateOnTapped(e, this.ColumnIndex, this.OwningRow.Slot, !e.Handled /*allowEdit*/);
                     this.OwningGrid.UpdatedStateOnTapped = true;
                 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumnHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumnHeader.cs
@@ -1065,10 +1065,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
             {
                 Debug.Assert(interactionInfo.OriginalCursor != null, "Expected non-null interactionInfo.OriginalCursor.");
 
-                if (Window.Current != null)
-                {
-                    Window.Current.CoreWindow.PointerCursor = interactionInfo.OriginalCursor;
-                }
+                CoreWindow.GetForCurrentThread().PointerCursor = interactionInfo.OriginalCursor;
 
                 interactionInfo.ResizePointerId = 0;
             }
@@ -1103,14 +1100,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
 
             if (this.OwningGrid.IsEnabled && (nearCurrentResizableColumnRightEdge || nearPreviousResizableColumnLeftEdge))
             {
-                if (Window.Current != null)
+                CoreCursor currentCursor = CoreWindow.GetForCurrentThread().PointerCursor;
+                if (currentCursor != null && currentCursor.Type != CoreCursorType.SizeWestEast)
                 {
-                    if (Window.Current.CoreWindow.PointerCursor != null && Window.Current.CoreWindow.PointerCursor.Type != CoreCursorType.SizeWestEast)
-                    {
-                        interactionInfo.OriginalCursor = Window.Current.CoreWindow.PointerCursor;
-                        interactionInfo.ResizePointerId = pointer.PointerId;
-                        Window.Current.CoreWindow.PointerCursor = new CoreCursor(CoreCursorType.SizeWestEast, 0);
-                    }
+                    interactionInfo.OriginalCursor = currentCursor;
+                    interactionInfo.ResizePointerId = pointer.PointerId;
+                    CoreWindow.GetForCurrentThread().PointerCursor = new CoreCursor(CoreCursorType.SizeWestEast, 0);
                 }
             }
             else if (interactionInfo.ResizePointerId == pointer.PointerId)

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridRowHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridRowHeader.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
                 if (this.OwningRow != null)
                 {
                     Debug.Assert(sender is DataGridRowHeader, "Expected sender is DataGridRowHeader.");
-                    Debug.Assert(sender == this, "Expected sender is this.");
+                    Debug.Assert(sender as ContentControl == this, "Expected sender is this.");
 
                     e.Handled = this.OwningGrid.UpdateStateOnTapped(e, -1, this.Slot, false /*allowEdit*/);
                     this.OwningGrid.UpdatedStateOnTapped = true;

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/Utilities/KeyboardHelper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/Utilities/KeyboardHelper.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Toolkit.Uwp.Utilities
     {
         public static void GetMetaKeyState(out bool ctrl, out bool shift)
         {
-            ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            shift = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            ctrl = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            shift = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
         }
 
         public static void GetMetaKeyState(out bool ctrl, out bool shift, out bool alt)
         {
             GetMetaKeyState(out ctrl, out shift);
-            alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+            alt = CoreWindow.GetForCurrentThread().GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
         }
     }
 }


### PR DESCRIPTION
A few changes for the WinUI branch so that the DataGrid control can be used in a WinUI 3 app:

- addressed some compilation warnings (casting event args to Control/ContentControl/FrameworkElement as recommended by compiler)
- removed all usages of Window.Current which is null in WinUI3:
* replaced usage of Window.Current.CoreWindow.PointerCursor with CoreWindow.GetForCurrentThread().PointerCursor
* replaced usage of Window.Current.CoreWindow.GetKeyState with CoreWindow.GetForCurrentThread().GetKeyState

## PR Type
- Bugfix

## What is the current behavior?
Application crashes because Window.Current == null causes null ref exceptions as soon as user tries to interact with the DataGrid.

## What is the new behavior?
No more exception, as in regular UWP.

## PR Checklist

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes