### PR TITLE
Improve accessibility in InAppNotification

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.Toolkit.Uwp.Extensions;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
@@ -51,29 +49,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _openAnimationTimer.Stop();
                 Opened?.Invoke(this, EventArgs.Empty);
-                SetValue(AutomationProperties.NameProperty, StringExtensions.GetLocalized("WindowsCommunityToolkit_InAppNotification_NameProperty", "/Microsoft.Toolkit.Uwp.UI.Controls/Resources"));
-                if (ContentTemplateRoot != null)
-                {
-                    var peer = FrameworkElementAutomationPeer.CreatePeerForElement(ContentTemplateRoot);
-                    if (Content?.GetType() == typeof(string))
-                    {
-                        AutomateTextNotification(peer, Content.ToString());
-                    }
-                }
+                RaiseAutomationNotification();
             }
         }
 
-        private void AutomateTextNotification(AutomationPeer peer, string message)
+        private void RaiseAutomationNotification()
         {
-            if (peer != null)
+            if (!AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
             {
-                peer.SetFocus();
-                peer.RaiseNotificationEvent(
-                    AutomationNotificationKind.Other,
-                    AutomationNotificationProcessing.ImportantMostRecent,
-                    StringExtensions.GetLocalized("WindowsCommunityToolkit_InAppNotification_Events_NewNotificationMessage", "/Microsoft.Toolkit.Uwp.UI.Controls/Resources") + message,
-                    Guid.NewGuid().ToString());
+                return;
             }
+
+            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(this);
+            peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
         }
 
         private void ClosingAnimationTimer_Tick(object sender, object e)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void OnNotificationVisible()
         {
             Opened?.Invoke(this, EventArgs.Empty);
-            RaiseAutomationNotification();
         }
 
         private void OnNotificationCollapsed()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Toolkit.Uwp.Extensions;
+using Microsoft.Toolkit.Uwp.UI.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Toolkit.Uwp.Extensions;
-using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
@@ -246,6 +246,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     _contentProvider.Content = content;
                     break;
             }
+
+            RaiseAutomationNotification();
         }
 
         /// <summary>
@@ -282,10 +284,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (shouldDisplayImmediately)
             {
-                UpdateContent(notificationOptions);
-
                 Visibility = Visibility.Visible;
                 VisualStateManager.GoToState(this, StateContentVisible, true);
+
+                UpdateContent(notificationOptions);
 
                 if (notificationOptions.Duration > 0)
                 {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -5,7 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Toolkit.Uwp.Extensions;
+using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
@@ -41,6 +44,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <inheritdoc />
         protected override void OnApplyTemplate()
         {
+            base.OnApplyTemplate();
+
             if (_dismissButton != null)
             {
                 _dismissButton.Click -= DismissButton_Click;
@@ -53,6 +58,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _dismissButton.Visibility = ShowDismissButton ? Visibility.Visible : Visibility.Collapsed;
                 _dismissButton.Click += DismissButton_Click;
+                AutomationProperties.SetName(_dismissButton, StringExtensions.GetLocalized("WindowsCommunityToolkit_InAppNotification_DismissButton_AutomationName", "Microsoft.Toolkit.Uwp.UI.Controls/Resources"));
             }
 
             if (Visibility == Visibility.Visible)
@@ -64,7 +70,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 VisualStateManager.GoToState(this, StateContentCollapsed, true);
             }
 
-            base.OnApplyTemplate();
+            AutomationProperties.SetLabeledBy(this, VisualTree.FindDescendant<ContentPresenter>(this));
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Toolkit.Uwp.Extensions;
-using Microsoft.Toolkit.Uwp.UI.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Toolkit.Uwp.Extensions;
+using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
@@ -1,16 +1,16 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
+                    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml" />
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style TargetType="local:InAppNotification" x:Key="BaseInAppNotificationsStyle">
+    <Style x:Key="BaseInAppNotificationsStyle"
+           TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
@@ -28,14 +28,20 @@
         <Setter Property="AnimationDuration" Value="0:0:0.100" />
         <Setter Property="VerticalOffset" Value="100" />
         <Setter Property="HorizontalOffset" Value="0" />
+        <Setter Property="AutomationProperties.LandmarkType" Value="Custom" />
+        <!--  The setter value is localized using x:Uid but we still need to set it explicitly to avoid a compiler warning  -->
+        <Setter x:Uid="WindowsCommunityToolkit_InAppNotification_LandmarkProperty" Property="AutomationProperties.LocalizedLandmarkType" Value="Notification" />
+        <Setter Property="AutomationProperties.LiveSetting" Value="Assertive" />
         <Setter Property="Template" Value="{StaticResource MSEdgeNotificationTemplate}" />
     </Style>
 
-    <contract7NotPresent:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+    <contract7NotPresent:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
+                               TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
     </contract7NotPresent:Style>
 
-    <contract7Present:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+    <contract7Present:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
+                            TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlChromeMediumLowAcrylicElementMediumBrush}" />
     </contract7Present:Style>
 </ResourceDictionary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml
@@ -34,6 +34,7 @@
                         <Border x:Name="TextBorder" BorderThickness="2" BorderBrush="{ThemeResource SystemControlMSEdgeNotificationButtonBorderBrush}">
                             <ContentPresenter x:Name="Text"
                                               Content="{TemplateBinding Content}"
+                                              AutomationProperties.AccessibilityView="Raw"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         </Border>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Strings/en-US/Resources.resw
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Strings/en-US/Resources.resw
@@ -205,13 +205,13 @@
     <value>GridSpliter</value>
     <comment>Narrator Resource for GridSplitter control</comment>
   </data>
-  <data name="WindowsCommunityToolkit_InAppNotification_Events_NewNotificationMessage" xml:space="preserve">
-    <value>New notification</value>
-    <comment>Narrator resource for a new notification using the InAppNotification</comment>
+  <data name="WindowsCommunityToolkit_InAppNotification_DismissButton_AutomationName" xml:space="preserve">
+    <value>Dismiss</value>
+    <comment>The automation name for the dismiss button of the InAppNotification control.</comment>
   </data>
-  <data name="WindowsCommunityToolkit_InAppNotification_NameProperty" xml:space="preserve">
+  <data name="WindowsCommunityToolkit_InAppNotification_LandmarkProperty.Value" xml:space="preserve">
     <value>Notification</value>
-    <comment>Name property for InAppNotification</comment>
+    <comment>The landmark name for the InAppNotification control. It is said by the narrator when using landmark navigation.</comment>
   </data>
   <data name="WindowsCommunityToolkit_TabView_CloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Close tab</value>


### PR DESCRIPTION
The `InAppNotification` control is not fully accessible. It sends an automation event only when it contains text content and cannot easily be reached.

## PR Type
What kind of change does this PR introduce?
 - Bugfix

## What is the current behavior?
`InAppNotification` is sending automation notification only when it contains text content.
The generated narrator strings are not properly localizable since they are concatenating a resource string with the content string but this may not be the appropriate way to do it in all cultures.
The code is also forcing the focus on the notification control which may break the user flow.

## What is the new behavior?
I've changed the automation integration:
- The automation event has been changed to `LiveRegionChanged`. It will be sent for any kind of content.
- The control has now a custom landmark so it can easily be reached through landmark navigation (caps lock + page up/down to select the landmark navigation mode then caps lock + left/right to navigate).
- The notification control will be labelled by its presenter. This means that the narrator can automatically read the content accessible string as part of the landmark. This provides a better messaging to the user and reduce the need of custom code in the control itself.
- The `peer.SetFocus()` code has been removed to not break the user flow by changing the focus to something that may only be transient (like a sync complete notification)
- The dismiss button will now use a localized strings instead of its hardcoded one.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

I've removed or updated some resource strings.
