### PR TITLE
[Feature] EmbeddedResources helper class

### DIFF
--- a/Microsoft.Toolkit/Extensions/AssemblyExtensions.cs
+++ b/Microsoft.Toolkit/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Reflection;
+
+#nullable enable
+
+namespace Microsoft.Toolkit.Extensions
+{
+    /// <summary>
+    /// An extension <see langword="class"/> for the <see cref="Assembly"/> type.
+    /// </summary>
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        /// The sequence of available directory separators for all platforms.
+        /// </summary>
+        private static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        /// <summary>
+        /// Returns a <see cref="Stream"/> instance for a specified manifest file.
+        /// </summary>
+        /// <param name="assembly">The target <see cref="Assembly"/> instance.</param>
+        /// <param name="path">The relative path of the file to open, with respect of the root of the assembly.</param>
+        /// <returns>A <see cref="Stream"/> for the requested file.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> does not represent a valid file.</exception>
+        /// <remarks>
+        /// The relative path should not include the name of the given assembly. For instance, consider an embedded
+        /// resource file that is located at the path <c>/Assets/myfile.txt</c> into the assembly <c>MyAssembly</c>.
+        /// You can then invoke <see cref="GetForManifestFileAsStream"/> with <paramref name="path"/> equal to either
+        /// <c>/Assets/myfile.txt</c>, <c>\Assets\myfile.txt</c>, <c>Assets/myfile.txt</c> or similar combinations.
+        /// This method will reconstruct the full path of the target file (which is <c>MyAssembly.Assets.myfile.txt</c>
+        /// in this case, retrieve the file and return a <see cref="Stream"/> to use to read from it.
+        /// </remarks>
+        [Pure]
+        public static Stream GetForManifestFileAsStream(this Assembly assembly, string path)
+        {
+            string[] parts = path.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries);
+            string filename = $"{assembly.GetName().Name}.{string.Join(".", parts)}";
+
+            using Stream? stream = assembly.GetManifestResourceStream(filename);
+
+            if (stream is null)
+            {
+                static void Throw() => throw new ArgumentException("The input path was not valid or the item didn't exist", nameof(path));
+
+                Throw();
+            }
+
+            return stream!;
+        }
+
+        /// <summary>
+        /// Returns the contents of a specified manifest file, as a <see cref="string"/>.
+        /// </summary>
+        /// <param name="assembly">The target <see cref="Assembly"/> instance.</param>
+        /// <param name="path">The relative path of the file to read, with respect of the root of the assembly.</param>
+        /// <returns>The text contents of the specified manifest file.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> does not represent a valid file.</exception>
+        /// <remarks>See remarks for <see cref="GetForManifestFileAsStream"/> for more info.</remarks>
+        [Pure]
+        public static string GetManifestFileAsString(this Assembly assembly, string path)
+        {
+            using Stream stream = GetForManifestFileAsStream(assembly, path);
+            using StreamReader reader = new StreamReader(stream);
+
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/Microsoft.Toolkit/Helpers/EmbeddedResources.cs
+++ b/Microsoft.Toolkit/Helpers/EmbeddedResources.cs
@@ -1,4 +1,8 @@
-﻿using System;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Reflection;

--- a/Microsoft.Toolkit/Helpers/EmbeddedResources.cs
+++ b/Microsoft.Toolkit/Helpers/EmbeddedResources.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Toolkit.Helpers
             string[] parts = path.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries);
             string filename = $"{assembly.GetName().Name}.{string.Join(".", parts)}";
 
-            using Stream? stream = assembly.GetManifestResourceStream(filename);
+            Stream? stream = assembly.GetManifestResourceStream(filename);
 
             if (stream is null)
             {

--- a/Microsoft.Toolkit/Helpers/EmbeddedResources.cs
+++ b/Microsoft.Toolkit/Helpers/EmbeddedResources.cs
@@ -1,25 +1,37 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Reflection;
 
 #nullable enable
 
-namespace Microsoft.Toolkit.Extensions
+namespace Microsoft.Toolkit.Helpers
 {
     /// <summary>
-    /// An extension <see langword="class"/> for the <see cref="Assembly"/> type.
+    /// A helper class to retrieve embedded resources from the executing assembly.
     /// </summary>
-    public static class AssemblyExtensions
+    public static class EmbeddedResources
     {
         /// <summary>
         /// The sequence of available directory separators for all platforms.
         /// </summary>
         private static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        /// <summary>
+        /// Returns a <see cref="Stream"/> instance for a specified manifest file.
+        /// </summary>
+        /// <param name="path">The relative path of the file to open, with respect of the root of the assembly.</param>
+        /// <returns>A <see cref="Stream"/> for the requested file.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> does not represent a valid file.</exception>
+        /// <remarks>
+        /// This method will automatically get the assembly for the caller to retrieve the target file.
+        /// See remarks for <see cref="GetStream(Assembly,string)"/> for more info.
+        /// </remarks>
+        [Pure]
+        public static Stream GetStream(string path)
+        {
+            return GetStream(Assembly.GetCallingAssembly(), path);
+        }
 
         /// <summary>
         /// Returns a <see cref="Stream"/> instance for a specified manifest file.
@@ -31,13 +43,13 @@ namespace Microsoft.Toolkit.Extensions
         /// <remarks>
         /// The relative path should not include the name of the given assembly. For instance, consider an embedded
         /// resource file that is located at the path <c>/Assets/myfile.txt</c> into the assembly <c>MyAssembly</c>.
-        /// You can then invoke <see cref="GetForManifestFileAsStream"/> with <paramref name="path"/> equal to either
+        /// You can then invoke <see cref="GetStream(Assembly,string)"/> with <paramref name="path"/> equal to either
         /// <c>/Assets/myfile.txt</c>, <c>\Assets\myfile.txt</c>, <c>Assets/myfile.txt</c> or similar combinations.
         /// This method will reconstruct the full path of the target file (which is <c>MyAssembly.Assets.myfile.txt</c>
         /// in this case, retrieve the file and return a <see cref="Stream"/> to use to read from it.
         /// </remarks>
         [Pure]
-        public static Stream GetForManifestFileAsStream(this Assembly assembly, string path)
+        public static Stream GetStream(Assembly assembly, string path)
         {
             string[] parts = path.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries);
             string filename = $"{assembly.GetName().Name}.{string.Join(".", parts)}";
@@ -57,15 +69,34 @@ namespace Microsoft.Toolkit.Extensions
         /// <summary>
         /// Returns the contents of a specified manifest file, as a <see cref="string"/>.
         /// </summary>
+        /// <param name="path">The relative path of the file to read, with respect of the root of the assembly.</param>
+        /// <returns>The text contents of the specified manifest file.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> does not represent a valid file.</exception>
+        /// <remarks>
+        /// This method will automatically get the assembly for the caller to retrieve the target file.
+        /// See remarks for <see cref="GetStream(Assembly,string)"/> for more info.
+        /// </remarks>
+        [Pure]
+        public static string GetString(string path)
+        {
+            return GetString(Assembly.GetCallingAssembly(), path);
+        }
+
+        /// <summary>
+        /// Returns the contents of a specified manifest file, as a <see cref="string"/>.
+        /// </summary>
         /// <param name="assembly">The target <see cref="Assembly"/> instance.</param>
         /// <param name="path">The relative path of the file to read, with respect of the root of the assembly.</param>
         /// <returns>The text contents of the specified manifest file.</returns>
         /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> does not represent a valid file.</exception>
-        /// <remarks>See remarks for <see cref="GetForManifestFileAsStream"/> for more info.</remarks>
+        /// <remarks>
+        /// This method will automatically get the assembly for the caller to retrieve the target file.
+        /// See remarks for <see cref="GetStream(Assembly,string)"/> for more info.
+        /// </remarks>
         [Pure]
-        public static string GetManifestFileAsString(this Assembly assembly, string path)
+        public static string GetString(Assembly assembly, string path)
         {
-            using Stream stream = GetForManifestFileAsStream(assembly, path);
+            using Stream stream = GetStream(assembly, path);
             using StreamReader reader = new StreamReader(stream);
 
             return reader.ReadToEnd();

--- a/UnitTests/UnitTests.NetCore/Assets/SampleFile.txt
+++ b/UnitTests/UnitTests.NetCore/Assets/SampleFile.txt
@@ -1,0 +1,1 @@
+﻿Hello world!

--- a/UnitTests/UnitTests.NetCore/UnitTests.NetCore.csproj
+++ b/UnitTests/UnitTests.NetCore/UnitTests.NetCore.csproj
@@ -6,6 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Assets\SampleFile.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Assets\SampleFile.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />

--- a/UnitTests/UnitTests.Shared/Helpers/Test_EmbeddedResources.cs
+++ b/UnitTests/UnitTests.Shared/Helpers/Test_EmbeddedResources.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Toolkit.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests.Helpers
+{
+    [TestClass]
+    public class Test_EmbeddedResources
+    {
+        private const string SampleText = "Hello world!";
+
+        [TestCategory("EmbeddedResources")]
+        [TestMethod]
+        [DataRow("/Assets/SampleFile.txt")]
+        [DataRow("\\Assets\\SampleFile.txt")]
+        [DataRow("Assets/SampleFile.txt")]
+        [DataRow("Assets\\SampleFile.txt")]
+        [DataRow("/Assets\\SampleFile.txt")]
+        [DataRow("\\Assets/SampleFile.txt")]
+        public void Test_EmbeddedResources_Ok(string path)
+        {
+            Assert.AreEqual(SampleText, EmbeddedResources.GetString(path));
+        }
+
+        [TestCategory("EmbeddedResources")]
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        [DataRow("SampleFile.txt")]
+        [DataRow("/Assets/SampleFile")]
+        public void Test_EmbeddedResources_Fail(string path)
+        {
+            Assert.AreEqual(SampleText, EmbeddedResources.GetString(path));
+        }
+    }
+}

--- a/UnitTests/UnitTests.Shared/UnitTests.Shared.projitems
+++ b/UnitTests/UnitTests.Shared/UnitTests.Shared.projitems
@@ -21,5 +21,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\Test_ArrayExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\Test_TypeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\Test_ValueTypeExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\Test_EmbeddedResources.cs" />
   </ItemGroup>
 </Project>

--- a/UnitTests/UnitTests.UWP/Assets/SampleFile.txt
+++ b/UnitTests/UnitTests.UWP/Assets/SampleFile.txt
@@ -1,0 +1,1 @@
+﻿Hello world!

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -196,6 +196,7 @@
     <None Include=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Assets\SampleFile.txt" />
     <Content Include="Assets\Samples\lorem.txt" />
     <Content Include="Properties\UnitTestApp.rd.xml" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
 - Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Embedded resources are a not-so-common thing to use, especially for many UWP devs, despite the fact they offer one major advantage for eg. apps requiring API keys to work: the assets will go directly into the app binary and will therefore no longer be so easily accessible for users by just opening the app install folder and browsing the `Assets` directory. They're slightly trickier to use though due to the necessary APIs and the fact that paths for manifest files don't use the same separators as folders.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
This PR adds a new `EmbeddedResources` class that makes it easy to retrieve/read embedded resources.
All that's needed now is to add a file to a project, mark it as "Embedded resource", and then do:

```csharp
string text = EmbeddedResources.GetString("/Assets/MyFile.txt");
```

The `EmbeddedResources` class will take care of retrieving the assembly for the caller method, building the right path for the target manifest file, opening a `Stream` and then reading its contents. There are also overloads to directly return a `Stream`, and to also do the same but by manually specifying a target assembly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes