### PR TITLE
Updated TFM of Notifications package from netcoreapp3.0 to netcoreapp3.1.

### DIFF
--- a/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
+++ b/Microsoft.Toolkit.Services/Microsoft.Toolkit.Services.csproj
@@ -19,6 +19,11 @@
     <DefineConstants Condition="'$(DisableImplicitFrameworkDefines)' != 'true'">$(DefineConstants);WINRT</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+    <UseWpf>true</UseWpf>
+    <EnableDefaultPageItems>false</EnableDefaultPageItems>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj" />
     <ProjectReference Include="..\Microsoft.Toolkit\Microsoft.Toolkit.csproj" />
@@ -40,28 +45,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">
-    <Reference Include="System.Data" />
-    <Reference Include="System.ComponentModel" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
     <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView" Version="[5.0.0-preview.gb86cb1c4cb,)" />
     <PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView" Version="[5.0.0-preview.gb86cb1c4cb,)" />
-    <Page Update="PlatformSpecific\NetFramework\PopupWPF.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Update="PlatformSpecific\NetFramework\PopupWPF.xaml.cs">
-      <DependentUpon>PlatformSpecific\NetFramework\PopupWPF.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
   </ItemGroup>
 
   <ItemGroup Condition="!('$(TargetFramework)'=='uap10.0.16299')">

--- a/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
+++ b/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;uap10.0;native;net461;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;uap10.0;native;net461;netcoreapp3.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETFX_CORE</DefineConstants>
     <Title>Windows Community Toolkit Notifications</Title>
     <Description>

--- a/UnitTests/UnitTests.UWP/Helpers/Test_StorageFileHelper.cs
+++ b/UnitTests/UnitTests.UWP/Helpers/Test_StorageFileHelper.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Helpers
     public class Test_StorageFileHelper
     {
         private const string Sampletext = "Lorem ipsum dolor sit amet";
-        private const string Filename = "filename.txt";
+        private const string Filename = "Test_StorageFileHelper_file.txt";
         private const string PackagedFilePath = @"Assets\Samples\lorem.txt";
 
         [TestCategory("Helpers")]

--- a/UnitTests/UnitTests.UWP/Helpers/Test_StreamHelper.cs
+++ b/UnitTests/UnitTests.UWP/Helpers/Test_StreamHelper.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Helpers
     public class Test_StreamHelper
     {
         private const string SampleText = "Lorem ipsum dolor sit amet";
-        private const string Filename = "filename.txt";
+        private const string Filename = "Test_StreamHelper_file.txt";
         private const string PackagedFilePath = @"Assets\Samples\lorem.txt";
 
         [TestCategory("Helpers")]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,16 +21,9 @@ steps:
   displayName: Setup Environment Variables
   
 - task: NuGetToolInstaller@0
-  displayName: Use NuGet 5.0.0
+  displayName: Use NuGet 5.6.0
   inputs:
-    versionSpec: 5.0.0
-
-- task: UseDotNet@2
-  inputs:
-    packageType: 'sdk'
-    version: '3.1.200'
-    performMultiLevelLookup: true
-  displayName: Use .NET Core sdk 3
+    versionSpec: 5.6.0
 
 - task: DotNetCoreCLI@2  
   inputs:


### PR DESCRIPTION
## Fixes #3382

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Microsoft.Toolkit.Uwp.Notifications targets an end of life SDK (netcoreapp3.0). We should upgrade it to netcoreapp3.1.

## What is the new behavior?
Microsoft.Toolkit.Uwp.Notifications targets netcoreapp3.1.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

## Other information
I've also fixed a small race condition on the tests, since they run on parallel, per class, and two classes/tests were writing to the same file, which would eventually fail.