### PR TITLE
GridSplitter accessibility issue fix

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     Foreground = GripperForeground,
                     Text = _resizeDirection == GridResizeDirection.Columns ? GripperBarVertical : GripperBarHorizontal
                 };
+                _gripperDisplay.SetValue(
+                    Windows.UI.Xaml.Automation.AutomationProperties.AccessibilityViewProperty,
+                    Windows.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
             }
         }
 


### PR DESCRIPTION
## Fixes #3399 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

Previously the symbol showing two lines on the GridSplitter was being exposed to the UI Automation Tree with a value outside the valid unicode range.
This removes the textblock containing the symbol from the UIA tree as it's not needed. The whole GridSplitter shows up in the tree. The symbol is just a nice visual extra on the control.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Accessibility Insights for Windows (& Axe.Windows) reports an issue with the GridSplitter when used in any app.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->

No issue now reported.
This is a change to how a symbol is exposed to the UIA Tree. No visual or functional differences are included with this change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
