### PR TITLE
remove redundant namespaces

### DIFF
--- a/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableObject.cs
+++ b/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableObject.cs
@@ -15,7 +15,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace Microsoft.Toolkit.Mvvm.ComponentModel
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A base class for objects of which the properties must be observable.

--- a/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableRecipient.cs
+++ b/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableRecipient.cs
@@ -10,8 +10,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Microsoft.Toolkit.Mvvm.Messaging;
-using Microsoft.Toolkit.Mvvm.Messaging.Messages;
 
 namespace Microsoft.Toolkit.Mvvm
 {
@@ -25,11 +23,11 @@ namespace Microsoft.Toolkit.Mvvm
         /// Initializes a new instance of the <see cref="ObservableRecipient"/> class.
         /// </summary>
         /// <remarks>
-        /// This constructor will produce an instance that will use the <see cref="Messaging.Messenger.Default"/> instance
+        /// This constructor will produce an instance that will use the <see cref="Mvvm.Messenger.Default"/> instance
         /// to perform requested operations. It will also be available locally through the <see cref="Messenger"/> property.
         /// </remarks>
         protected ObservableRecipient()
-            : this(Messaging.Messenger.Default)
+            : this(Mvvm.Messenger.Default)
         {
         }
 

--- a/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableRecipient.cs
+++ b/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableRecipient.cs
@@ -13,7 +13,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.Toolkit.Mvvm.Messaging;
 using Microsoft.Toolkit.Mvvm.Messaging.Messages;
 
-namespace Microsoft.Toolkit.Mvvm.ComponentModel
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A base class for observable objects that also acts as recipients for messages. This class is an extension of

--- a/Microsoft.Toolkit.Mvvm/DependencyInjection/Ioc.cs
+++ b/Microsoft.Toolkit.Mvvm/DependencyInjection/Ioc.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 #nullable enable
 
-namespace Microsoft.Toolkit.Mvvm.DependencyInjection
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A type that facilitates the use of the <see cref="IServiceProvider"/> type.

--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -5,9 +5,8 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Mvvm.ComponentModel;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A command that mirrors the functionality of <see cref="RelayCommand"/>, with the addition of

--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -5,9 +5,8 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Mvvm.ComponentModel;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A generic command that provides a more specific version of <see cref="AsyncRelayCommand"/>.

--- a/Microsoft.Toolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand.cs
@@ -5,7 +5,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// An interface expanding <see cref="IRelayCommand"/> to support asynchronous operations.

--- a/Microsoft.Toolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/Interfaces/IAsyncRelayCommand{T}.cs
@@ -4,7 +4,7 @@
 
 using System.Threading.Tasks;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A generic interface representing a more specific version of <see cref="IAsyncRelayCommand"/>.

--- a/Microsoft.Toolkit.Mvvm/Input/Interfaces/IRelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/Interfaces/IRelayCommand.cs
@@ -4,7 +4,7 @@
 
 using System.Windows.Input;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// An interface expanding <see cref="ICommand"/> with the ability to raise

--- a/Microsoft.Toolkit.Mvvm/Input/Interfaces/IRelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/Interfaces/IRelayCommand{T}.cs
@@ -4,7 +4,7 @@
 
 using System.Windows.Input;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A generic interface representing a more specific version of <see cref="IRelayCommand"/>.

--- a/Microsoft.Toolkit.Mvvm/Input/RelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/RelayCommand.cs
@@ -10,7 +10,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A command whose sole purpose is to relay its functionality to other

--- a/Microsoft.Toolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -10,7 +10,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.Toolkit.Mvvm.Input
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A generic command whose sole purpose is to relay its functionality to other

--- a/Microsoft.Toolkit.Mvvm/Messaging/IMessenger.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/IMessenger.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Toolkit.Mvvm.Messaging
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// An interface for a type providing the ability to exchange messages between different objects.

--- a/Microsoft.Toolkit.Mvvm/Messaging/IRecipient{TMessage}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/IRecipient{TMessage}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.Toolkit.Mvvm.Messaging
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// An interface for a recipient that declares a registration for a specific message type.

--- a/Microsoft.Toolkit.Mvvm/Messaging/Messages/AsyncCollectionRequestMessage{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messages/AsyncCollectionRequestMessage{T}.cs
@@ -9,7 +9,7 @@ using System.Diagnostics.Contracts;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Toolkit.Mvvm.Messaging.Messages
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A <see langword="class"/> for request messages that can receive multiple replies, which can either be used directly or through derived classes.

--- a/Microsoft.Toolkit.Mvvm/Messaging/Messages/AsyncRequestMessage{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messages/AsyncRequestMessage{T}.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace Microsoft.Toolkit.Mvvm.Messaging.Messages
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A <see langword="class"/> for async request messages, which can either be used directly or through derived classes.

--- a/Microsoft.Toolkit.Mvvm/Messaging/Messages/CollectionRequestMessage{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messages/CollectionRequestMessage{T}.cs
@@ -8,7 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.Toolkit.Mvvm.Messaging.Messages
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A <see langword="class"/> for request messages that can receive multiple replies, which can either be used directly or through derived classes.

--- a/Microsoft.Toolkit.Mvvm/Messaging/Messages/PropertyChangedMessage{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messages/PropertyChangedMessage{T}.cs
@@ -7,7 +7,7 @@
 // This file is inspired from the MvvmLight libray (lbugnion/mvvmlight),
 // more info in ThirdPartyNotices.txt in the root of the project.
 
-namespace Microsoft.Toolkit.Mvvm.Messaging.Messages
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A message used to broadcast property changes in observable objects.

--- a/Microsoft.Toolkit.Mvvm/Messaging/Messages/RequestMessage{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messages/RequestMessage{T}.cs
@@ -6,7 +6,7 @@ using System;
 
 #pragma warning disable CS8618
 
-namespace Microsoft.Toolkit.Mvvm.Messaging.Messages
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A <see langword="class"/> for request messages, which can either be used directly or through derived classes.

--- a/Microsoft.Toolkit.Mvvm/Messaging/Messages/ValueChangedMessage{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messages/ValueChangedMessage{T}.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.Toolkit.Mvvm.Messaging.Messages
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A base message that signals whenever a specific value has changed.

--- a/Microsoft.Toolkit.Mvvm/Messaging/Messenger.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messenger.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Collections.Extensions;
 
-namespace Microsoft.Toolkit.Mvvm.Messaging
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// A type that can be used to exchange messages between different objects.

--- a/Microsoft.Toolkit.Mvvm/Messaging/MessengerExtensions.Unit.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/MessengerExtensions.Unit.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.Toolkit.Mvvm.Messaging
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// Extensions for the <see cref="IMessenger"/> type.

--- a/Microsoft.Toolkit.Mvvm/Messaging/MessengerExtensions.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/MessengerExtensions.cs
@@ -9,7 +9,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.Toolkit.Mvvm.Messaging
+namespace Microsoft.Toolkit.Mvvm
 {
     /// <summary>
     /// Extensions for the <see cref="IMessenger"/> type.

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_AsyncRelayCommand.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_AsyncRelayCommand.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Mvvm.Input;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_Ioc.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_Ioc.cs
@@ -4,9 +4,7 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Toolkit.Mvvm.ComponentModel;
-using Microsoft.Toolkit.Mvvm.DependencyInjection;
-using Microsoft.Toolkit.Mvvm.Messaging;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.Request.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.Request.cs
@@ -5,8 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Mvvm.Messaging;
-using Microsoft.Toolkit.Mvvm.Messaging.Messages;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.Toolkit.Mvvm.Messaging;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableObject.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableObject.cs
@@ -5,7 +5,7 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Mvvm.ComponentModel;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableRecipient.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableRecipient.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Toolkit.Mvvm.ComponentModel;
-using Microsoft.Toolkit.Mvvm.Messaging;
-using Microsoft.Toolkit.Mvvm.Messaging.Messages;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_RelayCommand.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_RelayCommand.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.Toolkit.Mvvm.Input;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_RelayCommand{T}.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_RelayCommand{T}.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Toolkit.Mvvm.Input;
+using Microsoft.Toolkit.Mvvm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests.Mvvm


### PR DESCRIPTION
There is no value in making the internal directory structure be reflected in the public API namespaces. it actually adds more noise since it often request consumers to add more using in file headers. it obscures apis from intellisense for no value.