### PR TITLE
Fixed rendering of markdown links with inline code

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.xaml
@@ -44,15 +44,16 @@
         <Setter Property="CodeBackground" Value="{ThemeResource MarkdownBackgroundBrush}" />
         <Setter Property="CodeBorderBrush" Value="{ThemeResource MarkdownBorderBrush}" />
         <Setter Property="CodeBorderThickness" Value="0" />
+        <Setter Property="CodeFontFamily" Value="Consolas" />
+        <Setter Property="CodeMargin" Value="0, 7, 0, 7" />
+        <Setter Property="CodePadding" Value="10, 6, 10, 6" />
         <Setter Property="InlineCodeBorderThickness" Value="0" />
         <Setter Property="InlineCodePadding" Value="4, 2, 4, 2" />
         <Setter Property="InlineCodeMargin" Value="2,0,2,-4"/>
         <Setter Property="InlineCodeBackground" Value="{ThemeResource MarkdownInlineCodeBackgroundBrush}" />
         <Setter Property="InlineCodeBorderBrush" Value="{ThemeResource MarkdownBorderBrush}" />
         <Setter Property="InlineCodeForeground" Value="{ThemeResource MarkdownInlineCodeForegroundBrush}" />
-        <Setter Property="CodeFontFamily" Value="Consolas" />
-        <Setter Property="CodeMargin" Value="0, 7, 0, 7" />
-        <Setter Property="CodePadding" Value="10, 6, 10, 6" />
+        <Setter Property="InlineCodeFontFamily" Value="Consolas" />
         <Setter Property="EmojiFontFamily" Value="Segoe UI Emoji" />
         <Setter Property="Header1FontWeight" Value="Bold" />
         <Setter Property="Header1FontSize" Value="20" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Inlines.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Inlines.cs
@@ -539,47 +539,70 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
                 throw new RenderContextIncorrectException();
             }
 
-            var text = CreateTextBlock(localContext);
-            text.Text = CollapseWhitespace(context, element.Text);
-            text.FontFamily = InlineCodeFontFamily ?? FontFamily;
-            text.Foreground = InlineCodeForeground ?? Foreground;
+            var text = CollapseWhitespace(context, element.Text);
 
-            if (localContext.WithinItalics)
+            // Avoid a crash if the current inline is inside an hyperline.
+            // This happens when using inline code blocks like [`SomeCode`](https://www.foo.bar).
+            if (localContext.Parent is Hyperlink)
             {
-                text.FontStyle = FontStyle.Italic;
+                // Fallback span
+                Run run = new Run
+                {
+                    Text = text,
+                    FontFamily = InlineCodeFontFamily ?? FontFamily,
+                    Foreground = InlineCodeForeground ?? Foreground
+                };
+
+                // Additional formatting
+                if (localContext.WithinItalics)
+                {
+                    run.FontStyle = FontStyle.Italic;
+                }
+
+                if (localContext.WithinBold)
+                {
+                    run.FontWeight = FontWeights.Bold;
+                }
+
+                // Add the fallback block
+                localContext.InlineCollection.Add(run);
             }
-
-            if (localContext.WithinBold)
+            else
             {
-                text.FontWeight = FontWeights.Bold;
+                var textBlock = CreateTextBlock(localContext);
+                textBlock.Text = text;
+                textBlock.FontFamily = InlineCodeFontFamily ?? FontFamily;
+                textBlock.Foreground = InlineCodeForeground ?? Foreground;
+
+                if (localContext.WithinItalics)
+                {
+                    textBlock.FontStyle = FontStyle.Italic;
+                }
+
+                if (localContext.WithinBold)
+                {
+                    textBlock.FontWeight = FontWeights.Bold;
+                }
+
+                var inlineUIContainer = new InlineUIContainer
+                {
+                    Child = new Border
+                    {
+                        BorderThickness = InlineCodeBorderThickness,
+                        BorderBrush = InlineCodeBorderBrush,
+                        Background = InlineCodeBackground,
+                        Child = textBlock,
+                        Padding = InlineCodePadding,
+                        Margin = InlineCodeMargin,
+
+                        // Aligns content in InlineUI, see https://social.msdn.microsoft.com/Forums/silverlight/en-US/48b5e91e-efc5-4768-8eaf-f897849fcf0b/richtextbox-inlineuicontainer-vertical-alignment-issue?forum=silverlightarchieve
+                        RenderTransform = new TranslateTransform { Y = 4 }
+                    }
+                };
+
+                // Add it to the current inlines
+                localContext.InlineCollection.Add(inlineUIContainer);
             }
-
-            var borderthickness = InlineCodeBorderThickness;
-            var padding = InlineCodePadding;
-
-            var border = new Border
-            {
-                BorderThickness = borderthickness,
-                BorderBrush = InlineCodeBorderBrush,
-                Background = InlineCodeBackground,
-                Child = text,
-                Padding = padding,
-                Margin = InlineCodeMargin
-            };
-
-            // Aligns content in InlineUI, see https://social.msdn.microsoft.com/Forums/silverlight/en-US/48b5e91e-efc5-4768-8eaf-f897849fcf0b/richtextbox-inlineuicontainer-vertical-alignment-issue?forum=silverlightarchieve
-            border.RenderTransform = new TranslateTransform
-            {
-                Y = 4
-            };
-
-            var inlineUIContainer = new InlineUIContainer
-            {
-                Child = border,
-            };
-
-            // Add it to the current inlines
-            localContext.InlineCollection.Add(inlineUIContainer);
         }
     }
 }


### PR DESCRIPTION
## Fixes #3123
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `MarkdownTextBlock` fails to render text when a link contains inline code.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Links with inline code work fine, and use the same foreground color as inline code blocks.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [ ] ~~Tests for the changes have been added (for bug fixes / features) (if applicable)~~
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes