### PR TITLE
Reduced memory usage in HighPerformance tests

### DIFF
--- a/UnitTests/UnitTests.HighPerformance.Shared/Buffers/Internals/UnmanagedSpanOwner.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Buffers/Internals/UnmanagedSpanOwner.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace UnitTests.HighPerformance.Shared.Buffers.Internals
+{
+    /// <summary>
+    /// An owner for a buffer of an unmanaged type, recycling <see cref="byte"/> arrays to save memory.
+    /// </summary>
+    /// <typeparam name="T">The type of items to store in the rented buffers.</typeparam>
+    internal sealed unsafe class UnmanagedSpanOwner<T> : IDisposable
+        where T : unmanaged
+    {
+        /// <summary>
+        /// The size of the current instance
+        /// </summary>
+        private readonly int length;
+
+        /// <summary>
+        /// The pointer to the underlying <see cref="byte"/> array.
+        /// </summary>
+        private IntPtr ptr;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnmanagedSpanOwner{T}"/> class.
+        /// </summary>
+        /// <param name="size">The size of the buffer to rent.</param>
+        public UnmanagedSpanOwner(int size)
+        {
+            this.ptr = Marshal.AllocHGlobal(size * Unsafe.SizeOf<T>());
+            this.length = size;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            IntPtr ptr = this.ptr;
+
+            if (ptr == IntPtr.Zero)
+            {
+                return;
+            }
+
+            this.ptr = IntPtr.Zero;
+
+            Marshal.FreeHGlobal(ptr);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Memory{T}"/> for the current instance.
+        /// </summary>
+        public Span<T> Span => new Span<T>((void*)this.ptr, this.length);
+    }
+}

--- a/UnitTests/UnitTests.HighPerformance.Shared/Buffers/Internals/UnmanagedSpanOwner.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Buffers/Internals/UnmanagedSpanOwner.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -31,6 +35,21 @@ namespace UnitTests.HighPerformance.Shared.Buffers.Internals
             this.length = size;
         }
 
+        /// <summary>
+        /// Gets the length of the buffer in use.
+        /// </summary>
+        public int Length => this.length;
+
+        /// <summary>
+        /// Gets a pointer to the start of the buffer in use.
+        /// </summary>
+        public T* Ptr => (T*)this.ptr;
+
+        /// <summary>
+        /// Gets the <see cref="Memory{T}"/> for the current instance.
+        /// </summary>
+        public Span<T> Span => new Span<T>((void*)this.ptr, this.length);
+
         /// <inheritdoc/>
         public void Dispose()
         {
@@ -45,10 +64,5 @@ namespace UnitTests.HighPerformance.Shared.Buffers.Internals
 
             Marshal.FreeHGlobal(ptr);
         }
-
-        /// <summary>
-        /// Gets the <see cref="Memory{T}"/> for the current instance.
-        /// </summary>
-        public Span<T> Span => new Span<T>((void*)this.ptr, this.length);
     }
 }

--- a/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.Count.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.Count.cs
@@ -178,8 +178,8 @@ namespace UnitTests.HighPerformance.Extensions
             {
                 using UnmanagedSpanOwner<T> data = provider(count, value);
 
-                int result = data.Span.Count(value);
-                int expected = CountWithForeach(data.Span, value);
+                int result = data.GetSpan().Count(value);
+                int expected = CountWithForeach(data.GetSpan(), value);
 
                 Assert.AreEqual(result, expected, $"Failed {typeof(T)} test with count {count}: got {result} instead of {expected}");
             }
@@ -224,7 +224,7 @@ namespace UnitTests.HighPerformance.Extensions
 
             UnmanagedSpanOwner<T> data = new UnmanagedSpanOwner<T>(count);
 
-            foreach (ref byte n in MemoryMarshal.AsBytes(data.Span))
+            foreach (ref byte n in MemoryMarshal.AsBytes(data.GetSpan()))
             {
                 n = (byte)random.Next(0, byte.MaxValue);
             }
@@ -232,7 +232,7 @@ namespace UnitTests.HighPerformance.Extensions
             // Fill at least 20% of the items with a matching value
             int minimum = count / 20;
 
-            Span<T> span = data.Span;
+            Span<T> span = data.GetSpan();
 
             for (int i = 0; i < minimum; i++)
             {
@@ -255,7 +255,7 @@ namespace UnitTests.HighPerformance.Extensions
         {
             UnmanagedSpanOwner<T> data = new UnmanagedSpanOwner<T>(count);
 
-            data.Span.Fill(value);
+            data.GetSpan().Fill(value);
 
             return data;
         }

--- a/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.Count.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.Count.cs
@@ -5,10 +5,10 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Toolkit.HighPerformance.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UnitTests.HighPerformance.Shared.Buffers.Internals;
 
 #nullable enable
 
@@ -258,54 +258,6 @@ namespace UnitTests.HighPerformance.Extensions
             data.Span.Fill(value);
 
             return data;
-        }
-
-        /// <summary>
-        /// An owner for a buffer of an unmanaged type, recycling <see cref="byte"/> arrays to save memory.
-        /// </summary>
-        /// <typeparam name="T">The type of items to store in the rented buffers.</typeparam>
-        private sealed unsafe class UnmanagedSpanOwner<T> : IDisposable
-            where T : unmanaged
-        {
-            /// <summary>
-            /// The size of the current instance
-            /// </summary>
-            private readonly int length;
-
-            /// <summary>
-            /// The pointer to the underlying <see cref="byte"/> array.
-            /// </summary>
-            private IntPtr ptr;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="UnmanagedSpanOwner{T}"/> class.
-            /// </summary>
-            /// <param name="size">The size of the buffer to rent.</param>
-            public UnmanagedSpanOwner(int size)
-            {
-                this.ptr = Marshal.AllocHGlobal(size * Unsafe.SizeOf<T>());
-                this.length = size;
-            }
-
-            /// <inheritdoc/>
-            public void Dispose()
-            {
-                IntPtr ptr = this.ptr;
-
-                if (ptr == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                this.ptr = IntPtr.Zero;
-
-                Marshal.FreeHGlobal(ptr);
-            }
-
-            /// <summary>
-            /// Gets the <see cref="Memory{T}"/> for the current instance.
-            /// </summary>
-            public Span<T> Span => new Span<T>((void*)this.ptr, this.length);
         }
     }
 }

--- a/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.cs
@@ -18,7 +18,9 @@ namespace UnitTests.HighPerformance.Extensions
         [TestMethod]
         public void Test_ReadOnlySpanExtensions_DangerousGetReference()
         {
-            ReadOnlySpan<int> data = CreateRandomData<int>(12, default).AsSpan();
+            using var owner = CreateRandomData<int>(12, default);
+
+            ReadOnlySpan<int> data = owner.Span;
 
             ref int r0 = ref data.DangerousGetReference();
             ref int r1 = ref Unsafe.AsRef(data[0]);
@@ -30,7 +32,9 @@ namespace UnitTests.HighPerformance.Extensions
         [TestMethod]
         public void Test_ReadOnlySpanExtensions_DangerousGetReferenceAt_Zero()
         {
-            ReadOnlySpan<int> data = CreateRandomData<int>(12, default).AsSpan();
+            using var owner = CreateRandomData<int>(12, default);
+
+            ReadOnlySpan<int> data = owner.Span;
 
             ref int r0 = ref data.DangerousGetReference();
             ref int r1 = ref data.DangerousGetReferenceAt(0);
@@ -42,7 +46,9 @@ namespace UnitTests.HighPerformance.Extensions
         [TestMethod]
         public void Test_ReadOnlySpanExtensions_DangerousGetReferenceAt_Index()
         {
-            ReadOnlySpan<int> data = CreateRandomData<int>(12, default).AsSpan();
+            using var owner = CreateRandomData<int>(12, default);
+
+            ReadOnlySpan<int> data = owner.Span;
 
             ref int r0 = ref data.DangerousGetReferenceAt(5);
             ref int r1 = ref Unsafe.AsRef(data[5]);

--- a/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Extensions/Test_ReadOnlySpanExtensions.cs
@@ -20,7 +20,7 @@ namespace UnitTests.HighPerformance.Extensions
         {
             using var owner = CreateRandomData<int>(12, default);
 
-            ReadOnlySpan<int> data = owner.Span;
+            ReadOnlySpan<int> data = owner.GetSpan();
 
             ref int r0 = ref data.DangerousGetReference();
             ref int r1 = ref Unsafe.AsRef(data[0]);
@@ -34,7 +34,7 @@ namespace UnitTests.HighPerformance.Extensions
         {
             using var owner = CreateRandomData<int>(12, default);
 
-            ReadOnlySpan<int> data = owner.Span;
+            ReadOnlySpan<int> data = owner.GetSpan();
 
             ref int r0 = ref data.DangerousGetReference();
             ref int r1 = ref data.DangerousGetReferenceAt(0);
@@ -48,7 +48,7 @@ namespace UnitTests.HighPerformance.Extensions
         {
             using var owner = CreateRandomData<int>(12, default);
 
-            ReadOnlySpan<int> data = owner.Span;
+            ReadOnlySpan<int> data = owner.GetSpan();
 
             ref int r0 = ref data.DangerousGetReferenceAt(5);
             ref int r1 = ref Unsafe.AsRef(data[5]);

--- a/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_HashCode{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_HashCode{T}.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using Microsoft.Toolkit.HighPerformance.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UnitTests.HighPerformance.Shared.Buffers.Internals;
 
 namespace UnitTests.HighPerformance.Helpers
 {
@@ -67,19 +68,23 @@ namespace UnitTests.HighPerformance.Helpers
         [TestMethod]
         public void Test_HashCodeOfT_ManagedType_TestRepeat()
         {
+            var localTestCounts = TestCounts.Slice(0, 8);
+
+            // Only rent a single array of the maximum necessary size, to save space
+            string[] data = new string[localTestCounts[localTestCounts.Length - 1]];
+
             var random = new Random();
-
-            foreach (var count in TestCounts.Slice(0, 8))
+            foreach (ref string text in data.AsSpan())
             {
-                string[] data = new string[count];
+                text = random.NextDouble().ToString("E");
+            }
 
-                foreach (ref string text in data.AsSpan())
-                {
-                    text = random.NextDouble().ToString("E");
-                }
+            foreach (var count in localTestCounts)
+            {
+                Span<string> iterationData = data.AsSpan().Slice(0, count);
 
-                int hash1 = HashCode<string>.Combine(data);
-                int hash2 = HashCode<string>.Combine(data);
+                int hash1 = HashCode<string>.Combine(iterationData);
+                int hash2 = HashCode<string>.Combine(iterationData);
 
                 Assert.AreEqual(hash1, hash2, $"Failed {typeof(string)} test with count {count}: got {hash1} and then {hash2}");
             }
@@ -95,10 +100,10 @@ namespace UnitTests.HighPerformance.Helpers
         {
             foreach (var count in TestCounts)
             {
-                T[] data = CreateRandomData<T>(count);
+                using UnmanagedSpanOwner<T> data = CreateRandomData<T>(count);
 
-                int hash1 = HashCode<T>.Combine(data);
-                int hash2 = HashCode<T>.Combine(data);
+                int hash1 = HashCode<T>.Combine(data.Span);
+                int hash2 = HashCode<T>.Combine(data.Span);
 
                 Assert.AreEqual(hash1, hash2, $"Failed {typeof(T)} test with count {count}: got {hash1} and then {hash2}");
             }
@@ -111,14 +116,14 @@ namespace UnitTests.HighPerformance.Helpers
         /// <param name="count">The number of array items to create.</param>
         /// <returns>An array of random <typeparamref name="T"/> elements.</returns>
         [Pure]
-        private static T[] CreateRandomData<T>(int count)
+        private static UnmanagedSpanOwner<T> CreateRandomData<T>(int count)
             where T : unmanaged
         {
             var random = new Random(count);
 
-            T[] data = new T[count];
+            UnmanagedSpanOwner<T> data = new UnmanagedSpanOwner<T>(count);
 
-            foreach (ref byte n in MemoryMarshal.AsBytes(data.AsSpan()))
+            foreach (ref byte n in MemoryMarshal.AsBytes(data.Span))
             {
                 n = (byte)random.Next(0, byte.MaxValue);
             }

--- a/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_HashCode{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_HashCode{T}.cs
@@ -102,8 +102,8 @@ namespace UnitTests.HighPerformance.Helpers
             {
                 using UnmanagedSpanOwner<T> data = CreateRandomData<T>(count);
 
-                int hash1 = HashCode<T>.Combine(data.Span);
-                int hash2 = HashCode<T>.Combine(data.Span);
+                int hash1 = HashCode<T>.Combine(data.GetSpan());
+                int hash2 = HashCode<T>.Combine(data.GetSpan());
 
                 Assert.AreEqual(hash1, hash2, $"Failed {typeof(T)} test with count {count}: got {hash1} and then {hash2}");
             }
@@ -123,7 +123,7 @@ namespace UnitTests.HighPerformance.Helpers
 
             UnmanagedSpanOwner<T> data = new UnmanagedSpanOwner<T>(count);
 
-            foreach (ref byte n in MemoryMarshal.AsBytes(data.Span))
+            foreach (ref byte n in MemoryMarshal.AsBytes(data.GetSpan()))
             {
                 n = (byte)random.Next(0, byte.MaxValue);
             }

--- a/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_ParallelHelper.ForEach.In.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_ParallelHelper.ForEach.In.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Toolkit.HighPerformance.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UnitTests.HighPerformance.Shared.Buffers.Internals;
 
 namespace UnitTests.HighPerformance.Helpers
 {
@@ -19,15 +20,15 @@ namespace UnitTests.HighPerformance.Helpers
         {
             foreach (int count in TestForCounts)
             {
-                int[] data = CreateRandomData(count);
+                using UnmanagedSpanOwner<int> data = CreateRandomData(count);
 
                 int sum = 0;
 
-                ParallelHelper.ForEach<int, Summer>(data.AsMemory(), new Summer(&sum));
+                ParallelHelper.ForEach<int, Summer>(data.Memory, new Summer(&sum));
 
                 int expected = 0;
 
-                foreach (int n in data)
+                foreach (int n in data.GetSpan())
                 {
                     expected += n;
                 }
@@ -55,13 +56,13 @@ namespace UnitTests.HighPerformance.Helpers
         /// <param name="count">The number of array items to create.</param>
         /// <returns>An array of random <see cref="int"/> elements.</returns>
         [Pure]
-        private static int[] CreateRandomData(int count)
+        private static UnmanagedSpanOwner<int> CreateRandomData(int count)
         {
             var random = new Random(count);
 
-            int[] data = new int[count];
+            UnmanagedSpanOwner<int> data = new UnmanagedSpanOwner<int>(count);
 
-            foreach (ref int n in data.AsSpan())
+            foreach (ref int n in data.GetSpan())
             {
                 n = random.Next(0, byte.MaxValue);
             }

--- a/UnitTests/UnitTests.HighPerformance.Shared/UnitTests.HighPerformance.Shared.projitems
+++ b/UnitTests/UnitTests.HighPerformance.Shared/UnitTests.HighPerformance.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>UnitTests.HighPerformance.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Buffers\Internals\UnmanagedSpanOwner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Buffers\Test_MemoryBufferWriter{T}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Buffers\Test_ArrayPoolBufferWriter{T}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Buffers\Test_MemoryOwner{T}.cs" />


### PR DESCRIPTION
## Fixes random CI `SystemOutOfMemoryException`-s
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
 - Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The CI will randomly fail with an out of memory error.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
The error should be gone now. All the `Count` tests for the `HighPerformance` package are now reusing arrays from the same `ArrayPool<byte>` instance (since they use unmanaged types, so they can just be reinterpret-cast-ed to the necessary type every time). This should greatly reduce the total number of allocated arrays.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes