### PR TITLE
Fix InAppNotification  not working show/hide/show sequence

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -43,6 +43,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Dismiss(InAppNotificationDismissKind.Timeout);
         }
 
+        private void OnCurrentStateChanging(object sender, VisualStateChangedEventArgs e)
+        {
+            if (e.NewState.Name == StateContentVisible)
+            {
+                Visibility = Visibility.Visible;
+            }
+        }
+
         private void OnCurrentStateChanged(object sender, VisualStateChangedEventArgs e)
         {
             switch (e.NewState.Name)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_visualStateGroup != null)
             {
+                _visualStateGroup.CurrentStateChanging -= OnCurrentStateChanging;
                 _visualStateGroup.CurrentStateChanged -= OnCurrentStateChanged;
             }
 
@@ -67,7 +68,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_visualStateGroup != null)
             {
-                _visualStateGroup.CurrentStateChanged += OnCurrentStateChanged;
+                _visualStateGroup.CurrentStateChanging += OnCurrentStateChanging;
+                _visualStateGroup.CurrentStateChanged += OnCurrentStateChanged;                
             }
 
             var firstNotification = _stackedNotificationOptions.FirstOrDefault();

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (_visualStateGroup != null)
             {
                 _visualStateGroup.CurrentStateChanging += OnCurrentStateChanging;
-                _visualStateGroup.CurrentStateChanged += OnCurrentStateChanged;                
+                _visualStateGroup.CurrentStateChanged += OnCurrentStateChanged;
             }
 
             var firstNotification = _stackedNotificationOptions.FirstOrDefault();


### PR DESCRIPTION
## Fixes #3451
When using InAppNotification and running the Show()/Dismiss()/Show() sequence "too fast", we never see the last notification.

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When running the following code in the `InAppNotification` sample page, we are not seeing the last notification:
```csharp
 SampleController.Current.RegisterNewCommand("Show hide show", (sender, args) =>
 {
      _exampleInAppNotification?.Show("Notification 1", 0);
      _exampleInAppNotification?.Dismiss();
      _exampleInAppNotification?.Show("Notification 2", 0);
});
```

## What is the new behavior?
The `InAppNotification` content visibility is driven by two `VisualState`s and the control visibility is controlled using its `Visibility` property.

When going "too fast", we have the following sequence:
- show notification 1 is called
-- control visibility set to *visible*
-- request visual state change to "visible"
- dismiss is called
-- request visual state change to "hidden"
- show notification 2 is called
-- request visual state change to "visible"
-- visual state changed to "visible"
-- visual state changed to "hidden"
-- control visibility set to *collapsed* (See `OnNotificationCollapsed()`)
-- visual state changed to "visible"

The *visual states changed* events are raised even if we've never really gone into the state and our event handler for the "hidden" state is forcing the control to be *collapsed*. 
Forcing the control to be displayed when entering the *visible* state is ensuring that the control visibility remains synchronized with its content.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes
