### PR TITLE
Small fix when Independent loader might throw.

### DIFF
--- a/Microsoft.Toolkit.Uwp/Extensions/StringExtensions.cs
+++ b/Microsoft.Toolkit.Uwp/Extensions/StringExtensions.cs
@@ -14,7 +14,18 @@ namespace Microsoft.Toolkit.Uwp.Extensions
     /// </summary>
     public static class StringExtensions
     {
-        private static readonly ResourceLoader IndependentLoader = ResourceLoader.GetForViewIndependentUse();
+        private static readonly ResourceLoader IndependentLoader;
+
+        static StringExtensions()
+        {
+            try
+            {
+                IndependentLoader = ResourceLoader.GetForViewIndependentUse();
+            }
+            catch
+            {
+            }
+        }
 
         /// <summary>
         /// Retrieves the provided resource for the current view context.
@@ -52,7 +63,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
             }
             else
             {
-                return IndependentLoader.GetString(resourceKey);
+                return IndependentLoader?.GetString(resourceKey);
             }
         }
 
@@ -65,7 +76,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
         public static string GetLocalized(this string resourceKey, string resourcePath)
         {
             // Try and retrieve resource at app level first.
-            var result = IndependentLoader.GetString(resourceKey);
+            var result = IndependentLoader?.GetString(resourceKey);
 
             if (string.IsNullOrEmpty(result))
             {


### PR DESCRIPTION
## Fixes #3480

## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
If you don't override the string resources, like the toolkit sample app, our localization methods throw.


## What is the new behavior?
We check if we have a resources on the current app on the first call. If not, just catch the exception and ignore it, using the built in resources.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [X] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


