### PR TITLE
Test TextBox with a TextBoxMask.Mask and x:Bind

### DIFF
--- a/UITests/UITests.App/MainPage.xaml
+++ b/UITests/UITests.App/MainPage.xaml
@@ -9,11 +9,16 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
         <testhelpers:TestAutomationHelpersPanel />
 
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-            <Button Content="Click Me" Click="Button_Click"/>
-            <TextBlock x:Name="textBlock"/>
+        <Frame x:Name="navigationFrame" />
+        
+        <StackPanel Orientation="Horizontal" Grid.Row="1" >
+            <Button Content="Simple" Click="btnSimple_Click" />
         </StackPanel>
     </Grid>
 </Page>

--- a/UITests/UITests.App/MainPage.xaml
+++ b/UITests/UITests.App/MainPage.xaml
@@ -19,6 +19,7 @@
         
         <StackPanel Orientation="Horizontal" Grid.Row="1" >
             <Button Content="Simple" Click="btnSimple_Click" />
+            <Button Content="TextBox Mask" Click="btnTextBoxMask_Click" />
         </StackPanel>
     </Grid>
 </Page>

--- a/UITests/UITests.App/MainPage.xaml.cs
+++ b/UITests/UITests.App/MainPage.xaml.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using UITests.App.Pages;
+using Windows.UI.Xaml;
+
 namespace UITests.App
 {
     public sealed partial class MainPage
@@ -11,9 +14,9 @@ namespace UITests.App
             InitializeComponent();
         }
 
-        private void Button_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private void btnSimple_Click(object sender, RoutedEventArgs e)
         {
-            textBlock.Text = "Clicked";
+            navigationFrame.Navigate(typeof(SimpleTest));
         }
     }
 }

--- a/UITests/UITests.App/MainPage.xaml.cs
+++ b/UITests/UITests.App/MainPage.xaml.cs
@@ -18,5 +18,10 @@ namespace UITests.App
         {
             navigationFrame.Navigate(typeof(SimpleTest));
         }
+        
+        private void btnTextBoxMask_Click(object sender, RoutedEventArgs e)
+        {
+            navigationFrame.Navigate(typeof(TextBoxMask));
+        }
     }
 }

--- a/UITests/UITests.App/Pages/SimpleTest.xaml
+++ b/UITests/UITests.App/Pages/SimpleTest.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="UITests.App.Pages.SimpleTest"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.App.Pages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button Content="Click Me" Click="Button_Click"/>
+        <TextBlock x:Name="textBlock"/>
+    </StackPanel>
+</Page>

--- a/UITests/UITests.App/Pages/SimpleTest.xaml.cs
+++ b/UITests/UITests.App/Pages/SimpleTest.xaml.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.App.Pages
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class SimpleTest : Page
+    {
+        public SimpleTest()
+        {
+            this.InitializeComponent();
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            textBlock.Text = "Clicked";
+        }
+    }
+}

--- a/UITests/UITests.App/Pages/TextBoxMask.xaml
+++ b/UITests/UITests.App/Pages/TextBoxMask.xaml
@@ -1,0 +1,52 @@
+﻿<Page
+    x:Class="UITests.App.Pages.TextBoxMask"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.App.Pages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:extensions="using:Microsoft.Toolkit.Uwp.UI.Extensions"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="10"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="10"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <Button 
+            x:Name="ChangeButton" 
+            Content="Change Target Value"
+            Click="ChangeButton_Click"
+            Grid.Column="0" Grid.Row="0"
+            />
+        <TextBox 
+            x:Name="TextBox"
+            Width="120"
+	        Padding="0,4,0,0"
+            VerticalAlignment="Center"
+            extensions:TextBoxMask.CustomMask="5:[0-5]"
+            extensions:TextBoxMask.Mask="99:59:59"
+            TextAlignment="Center"
+            Text="{x:Bind Value, Mode=OneWay}"
+            Grid.Column="2" Grid.Row="0"
+            />
+        <TextBlock 
+            x:Name="InitialValueTextBlock"
+            Text="{x:Bind InitialValue}"
+            HorizontalAlignment="Center"
+            Grid.Column="0" Grid.Row="2"
+            />
+        <TextBlock
+            x:Name="NewValueTextBlock"
+            Text="{x:Bind NewValue}"
+            HorizontalAlignment="Center"
+            Grid.Column="2" Grid.Row="2"
+            />
+    </Grid>
+</Page>

--- a/UITests/UITests.App/Pages/TextBoxMask.xaml.cs
+++ b/UITests/UITests.App/Pages/TextBoxMask.xaml.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Windows.Input;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.App.Pages
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class TextBoxMask : Page, INotifyPropertyChanged
+    {
+        private const string INITIAL_VALUE = "12:50:59";
+        private const string NEW_VALUE = "00:00:00";
+
+        private string _value = INITIAL_VALUE;
+
+        public string InitialValue => INITIAL_VALUE;
+
+        public string NewValue => NEW_VALUE;
+
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+
+        public TextBoxMask()
+        {
+            this.InitializeComponent();
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void ChangeButton_Click(object sender, RoutedEventArgs e)
+        {
+            Value = NEW_VALUE;
+        }
+    }
+}

--- a/UITests/UITests.App/UITests.App.csproj
+++ b/UITests/UITests.App/UITests.App.csproj
@@ -136,6 +136,9 @@
     <Compile Include="Pages\SimpleTest.xaml.cs">
       <DependentUpon>SimpleTest.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\TextBoxMask.xaml.cs">
+      <DependentUpon>TextBoxMask.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -163,6 +166,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Pages\SimpleTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Pages\TextBoxMask.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/UITests/UITests.App/UITests.App.csproj
+++ b/UITests/UITests.App/UITests.App.csproj
@@ -133,6 +133,9 @@
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\SimpleTest.xaml.cs">
+      <DependentUpon>SimpleTest.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -158,6 +161,10 @@
     <Page Include="MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Pages\SimpleTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/UITests/UITests.Tests.Shared/Tests.cs
+++ b/UITests/UITests.Tests.Shared/Tests.cs
@@ -98,8 +98,10 @@ namespace UITests.Tests
         }
 
         [TestMethod]
-        public void SimpleLaunchTest()
+        public void SimpleTest()
         {
+            OpenTest("Simple");
+
             var button = new Button(FindElement.ByName("Click Me"));
             var textBlock = new TextBlock(FindElement.ById("textBlock"));
 
@@ -112,6 +114,14 @@ namespace UITests.Tests
             Wait.ForIdle();
 
             Verify.AreEqual("Clicked", textBlock.GetText());
+        }
+
+        private static void OpenTest(string name)
+        {
+            var btn = new Button(FindElement.ByName(name));
+            Verify.IsNotNull(btn);
+            btn.Click();
+            Wait.ForIdle();
         }
     }
 }

--- a/UITests/UITests.Tests.Shared/Tests.cs
+++ b/UITests/UITests.Tests.Shared/Tests.cs
@@ -116,6 +116,26 @@ namespace UITests.Tests
             Verify.AreEqual("Clicked", textBlock.GetText());
         }
 
+        [TestMethod]
+        public void TestTextBoxMaskBinding_Property()
+        {
+            OpenTest("TextBox Mask");
+
+            var initialValue = FindElement.ById<TextBlock>("InitialValueTextBlock").GetText();
+            var textBox = FindElement.ById<Edit>("TextBox");
+
+            Verify.AreEqual(initialValue, textBox.GetText());
+
+            var changeButton = FindElement.ById<Button>("ChangeButton");
+
+            changeButton.Click();
+            Wait.ForIdle();
+
+            var newValue = FindElement.ById<TextBlock>("NewValueTextBlock").GetText();
+
+            Verify.AreEqual(newValue, textBox.GetText());
+        }
+
         private static void OpenTest(string name)
         {
             var btn = new Button(FindElement.ByName(name));


### PR DESCRIPTION
Add UI tests for `TextBox` with a `TextBoxMask.Mask` and `x:Bind`
Uses WinUI Test Infrasttcure from #3482 to test the fix from #3338 for #3335.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
No UI Tests for TextBoxMask


## What is the new behavior?
Given a `TextBox` with a `Mask` set and its `Text` bound to a C# property using `x:Bind`. It tests if the text in the `TextBox` updates when that property is updated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- ~~[ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- ~~[ ] Sample in sample app has been added / updated (for bug fixes / features) ~~
    - ~~[ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets) ~~
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->

## Other information
Does not test #3514