### PR TITLE
Shameful rename of [IsNullOr]WhiteSpace Guard APIs

### DIFF
--- a/Microsoft.Toolkit/Diagnostics/Guard.String.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.String.cs
@@ -43,13 +43,13 @@ namespace Microsoft.Toolkit.Diagnostics
         {
             if (!string.IsNullOrEmpty(text))
             {
+#pragma warning disable CS8777 // Does not return when text is null
                 return;
+#pragma warning restore CS8777
             }
 
             ThrowHelper.ThrowArgumentExceptionForIsNotNullOrEmpty(text, name);
-#pragma warning disable CS8777 // Does not return when text is null (.NET Standard 2.0 string.IsNullOrEmpty lacks flow attribute)
         }
-#pragma warning restore CS8777
 
         /// <summary>
         /// Asserts that the input <see cref="string"/> instance must be <see langword="null"/> or whitespace.
@@ -97,13 +97,13 @@ namespace Microsoft.Toolkit.Diagnostics
         {
             if (!string.IsNullOrWhiteSpace(text))
             {
+#pragma warning disable CS8777 // Does not return when text is null
                 return;
+#pragma warning restore CS8777
             }
 
             ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhiteSpace(text, name);
-#pragma warning disable CS8777 // Does not return when text is null
         }
-#pragma warning restore CS8777
 
         /// <summary>
         /// Asserts that the input <see cref="string"/> instance must not be <see langword="null"/> or whitespace.
@@ -117,13 +117,13 @@ namespace Microsoft.Toolkit.Diagnostics
         {
             if (!string.IsNullOrWhiteSpace(text))
             {
+#pragma warning disable CS8777 // Does not return when text is null
                 return;
+#pragma warning restore CS8777
             }
 
             ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhiteSpace(text, name);
-#pragma warning disable CS8777 // Does not return when text is null
         }
-#pragma warning restore CS8777
 
         /// <summary>
         /// Asserts that the input <see cref="string"/> instance must be empty.

--- a/Microsoft.Toolkit/Diagnostics/Guard.String.cs
+++ b/Microsoft.Toolkit/Diagnostics/Guard.String.cs
@@ -58,6 +58,24 @@ namespace Microsoft.Toolkit.Diagnostics
         /// <param name="name">The name of the input parameter being tested.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is neither <see langword="null"/> nor whitespace.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IsNullOrWhiteSpace(string? text, string name)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNullOrWhiteSpace(text, name);
+        }
+
+        /// <summary>
+        /// Asserts that the input <see cref="string"/> instance must be <see langword="null"/> or whitespace.
+        /// </summary>
+        /// <param name="text">The input <see cref="string"/> instance to test.</param>
+        /// <param name="name">The name of the input parameter being tested.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is neither <see langword="null"/> nor whitespace.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use " + nameof(IsNullOrWhiteSpace))]
         public static void IsNullOrWhitespace(string? text, string name)
         {
             if (string.IsNullOrWhiteSpace(text))
@@ -65,7 +83,7 @@ namespace Microsoft.Toolkit.Diagnostics
                 return;
             }
 
-            ThrowHelper.ThrowArgumentExceptionForIsNullOrWhitespace(text, name);
+            ThrowHelper.ThrowArgumentExceptionForIsNullOrWhiteSpace(text, name);
         }
 
         /// <summary>
@@ -75,6 +93,26 @@ namespace Microsoft.Toolkit.Diagnostics
         /// <param name="name">The name of the input parameter being tested.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is <see langword="null"/> or whitespace.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IsNotNullOrWhiteSpace([NotNull] string? text, string name)
+        {
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhiteSpace(text, name);
+#pragma warning disable CS8777 // Does not return when text is null
+        }
+#pragma warning restore CS8777
+
+        /// <summary>
+        /// Asserts that the input <see cref="string"/> instance must not be <see langword="null"/> or whitespace.
+        /// </summary>
+        /// <param name="text">The input <see cref="string"/> instance to test.</param>
+        /// <param name="name">The name of the input parameter being tested.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is <see langword="null"/> or whitespace.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use " + nameof(IsNotNullOrWhiteSpace))]
         public static void IsNotNullOrWhitespace([NotNull] string? text, string name)
         {
             if (!string.IsNullOrWhiteSpace(text))
@@ -82,7 +120,7 @@ namespace Microsoft.Toolkit.Diagnostics
                 return;
             }
 
-            ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhitespace(text, name);
+            ThrowHelper.ThrowArgumentExceptionForIsNotNullOrWhiteSpace(text, name);
 #pragma warning disable CS8777 // Does not return when text is null
         }
 #pragma warning restore CS8777
@@ -128,6 +166,24 @@ namespace Microsoft.Toolkit.Diagnostics
         /// <param name="name">The name of the input parameter being tested.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is neither <see langword="null"/> nor whitespace.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IsWhiteSpace(string text, string name)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            ThrowHelper.ThrowArgumentExceptionForIsWhiteSpace(text, name);
+        }
+
+        /// <summary>
+        /// Asserts that the input <see cref="string"/> instance must be whitespace.
+        /// </summary>
+        /// <param name="text">The input <see cref="string"/> instance to test.</param>
+        /// <param name="name">The name of the input parameter being tested.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is neither <see langword="null"/> nor whitespace.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use " + nameof(IsWhiteSpace))]
         public static void IsWhitespace(string text, string name)
         {
             if (string.IsNullOrWhiteSpace(text))
@@ -135,7 +191,7 @@ namespace Microsoft.Toolkit.Diagnostics
                 return;
             }
 
-            ThrowHelper.ThrowArgumentExceptionForIsWhitespace(text, name);
+            ThrowHelper.ThrowArgumentExceptionForIsWhiteSpace(text, name);
         }
 
         /// <summary>
@@ -145,6 +201,24 @@ namespace Microsoft.Toolkit.Diagnostics
         /// <param name="name">The name of the input parameter being tested.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is <see langword="null"/> or whitespace.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IsNotWhiteSpace(string text, string name)
+        {
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            ThrowHelper.ThrowArgumentExceptionForIsNotWhiteSpace(text, name);
+        }
+
+        /// <summary>
+        /// Asserts that the input <see cref="string"/> instance must not be <see langword="null"/> or whitespace.
+        /// </summary>
+        /// <param name="text">The input <see cref="string"/> instance to test.</param>
+        /// <param name="name">The name of the input parameter being tested.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is <see langword="null"/> or whitespace.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use " + nameof(IsNotWhiteSpace))]
         public static void IsNotWhitespace(string text, string name)
         {
             if (!string.IsNullOrWhiteSpace(text))
@@ -152,7 +226,7 @@ namespace Microsoft.Toolkit.Diagnostics
                 return;
             }
 
-            ThrowHelper.ThrowArgumentExceptionForIsNotWhitespace(text, name);
+            ThrowHelper.ThrowArgumentExceptionForIsNotWhiteSpace(text, name);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit/Diagnostics/Internals/ThrowHelper.Guard.String.cs
+++ b/Microsoft.Toolkit/Diagnostics/Internals/ThrowHelper.Guard.String.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Toolkit.Diagnostics
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DoesNotReturn]
-        internal static void ThrowArgumentExceptionForIsNullOrWhitespace(string? text, string name)
+        internal static void ThrowArgumentExceptionForIsNullOrWhiteSpace(string? text, string name)
         {
             ThrowArgumentException(name, $"Parameter {name.ToAssertString()} (string) must be null or whitespace, was {text.ToAssertString()}");
         }
@@ -50,7 +50,7 @@ namespace Microsoft.Toolkit.Diagnostics
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DoesNotReturn]
-        internal static void ThrowArgumentExceptionForIsNotNullOrWhitespace(string? text, string name)
+        internal static void ThrowArgumentExceptionForIsNotNullOrWhiteSpace(string? text, string name)
         {
             ThrowArgumentException(name, $"Parameter {name.ToAssertString()} (string) must not be null or whitespace, was {(text is null ? "null" : "whitespace")}");
         }
@@ -80,7 +80,7 @@ namespace Microsoft.Toolkit.Diagnostics
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DoesNotReturn]
-        internal static void ThrowArgumentExceptionForIsWhitespace(string text, string name)
+        internal static void ThrowArgumentExceptionForIsWhiteSpace(string text, string name)
         {
             ThrowArgumentException(name, $"Parameter {name.ToAssertString()} (string) must be whitespace, was {text.ToAssertString()}");
         }
@@ -90,7 +90,7 @@ namespace Microsoft.Toolkit.Diagnostics
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DoesNotReturn]
-        internal static void ThrowArgumentExceptionForIsNotWhitespace(string text, string name)
+        internal static void ThrowArgumentExceptionForIsNotWhiteSpace(string text, string name)
         {
             ThrowArgumentException(name, $"Parameter {name.ToAssertString()} (string) must not be whitespace, was {text.ToAssertString()}");
         }


### PR DESCRIPTION
## Overview
Some `Guard` APIs were incorrectly using the wrong capitalization for the `WhiteSpace` part, not following the same structure of the actual APIs in the BCL (eg. `string.IsNullOrWhiteSpace`). This PR deprecates them and adds new APIs with the right name.

...I'm sorry 😅

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- API rename
- API deprecation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [ ] ~~Tests for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Header has been added to all new source files (run *build/UpdateHeaders.bat*)~~
- [X] Contains **NO** breaking changes