### PR TITLE
Fixed ImageEx.CornerRadius property

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
@@ -9,7 +9,10 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:ImageEx">
-                    <Grid Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding CornerRadius}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                    <Grid Background="{TemplateBinding Background}"
+                          CornerRadius="{TemplateBinding CornerRadius}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}">
                         <Image Name="PlaceholderImage"
                                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                                VerticalAlignment="{TemplateBinding VerticalAlignment}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.Members.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.Members.cs
@@ -21,11 +21,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty StretchProperty = DependencyProperty.Register(nameof(Stretch), typeof(Stretch), typeof(ImageExBase), new PropertyMetadata(Stretch.Uniform));
 
         /// <summary>
-        /// Identifies the <see cref="CornerRadius"/> dependency property.
-        /// </summary>
-        public static new readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(nameof(CornerRadius), typeof(CornerRadius), typeof(ImageExBase), new PropertyMetadata(new CornerRadius(0)));
-
-        /// <summary>
         /// Identifies the <see cref="DecodePixelHeight"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty DecodePixelHeightProperty = DependencyProperty.Register(nameof(DecodePixelHeight), typeof(int), typeof(ImageExBase), new PropertyMetadata(0));
@@ -80,16 +75,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Gets a value indicating whether control has been initialized.
         /// </summary>
         public bool IsInitialized { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the CornerRadius for underlying image. <para/>
-        /// Used to created rounded/circular images.
-        /// </summary>
-        public new CornerRadius CornerRadius
-        {
-            get { return (CornerRadius)GetValue(CornerRadiusProperty); }
-            set { SetValue(CornerRadiusProperty, value); }
-        }
 
         /// <summary>
         /// Gets or sets DecodePixelHeight for underlying bitmap


### PR DESCRIPTION
## Fixes #3528 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `ImageEx.CornerRadius` property isn't working anymore.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Modifying `ImageEx.CornerRadius` works correctly.

## Additional detail
With #3440, we bumped the minimum SDK to 1809 (build 17763), which is the first one with the `CornerRadius` being available in the `Control` class. I suspect building the controls package with that minimum SDK caused an issue with `ImageEx` defining the `CornerRadius` property again (using `new`), so that the XAML `TemplateBinding` ended up failing to find the correct property to bind to. It might also be because setting the property in XAML ended up setting the value for the incorrect duplicate one, so that binding was never update. Regardless, with that minimum version available there's no reason to duplicate that property in the first place, we can just use the built-in one and bind to that. This PR removes that duplicate property, fixing the issue.

> **NOTE:** this is _technically_ a breaking change as we're removing a public property, but users should effectively not really notice any difference, unless they were for some reason setting that very specific property through reflection, which is highly unlikely. Adding the tag for correctness, since this is still in fact a breaking change. Not likely to be noticed though 😄

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes