### PR TITLE
Fixed MemoryStream seek to end validation

### DIFF
--- a/Microsoft.Toolkit.HighPerformance/Streams/MemoryStream.Validate.cs
+++ b/Microsoft.Toolkit.HighPerformance/Streams/MemoryStream.Validate.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Toolkit.HighPerformance.Streams
     internal static partial class MemoryStream
     {
         /// <summary>
-        /// Validates the <see cref="Stream.Position"/> argument.
+        /// Validates the <see cref="Stream.Position"/> argument (it needs to be in the [0, length]) range.
         /// </summary>
         /// <param name="position">The new <see cref="Stream.Position"/> value being set.</param>
         /// <param name="length">The maximum length of the target <see cref="Stream"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ValidatePosition(long position, int length)
         {
-            if ((ulong)position >= (ulong)length)
+            if ((ulong)position > (ulong)length)
             {
                 ThrowArgumentOutOfRangeExceptionForPosition();
             }

--- a/UnitTests/UnitTests.HighPerformance.Shared/Streams/Test_MemoryStream.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Streams/Test_MemoryStream.cs
@@ -78,6 +78,42 @@ namespace UnitTests.HighPerformance.Streams
             Assert.AreEqual(stream.Position, 32);
         }
 
+        // See https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3536
+        [TestCategory("MemoryStream")]
+        [TestMethod]
+        public void Test_MemoryStream_WriteToEndAndRefreshPosition()
+        {
+            byte[]
+                array = new byte[10],
+                temp = new byte[1];
+            ReadOnlyMemory<byte> memory = array;
+
+            using var stream = memory.AsStream();
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                int read = stream.Read(temp, 0, 1);
+
+                Assert.AreEqual(read, 1);
+                Assert.AreEqual(stream.Position, i + 1);
+            }
+
+            Assert.AreEqual(stream.Position, array.Length);
+
+            // These should not throw, seeking to the end is valid
+            stream.Position = stream.Position;
+            Assert.AreEqual(stream.Position, array.Length);
+
+            stream.Seek(array.Length, SeekOrigin.Begin);
+            Assert.AreEqual(stream.Position, array.Length);
+
+            stream.Seek(0, SeekOrigin.Current);
+            Assert.AreEqual(stream.Position, array.Length);
+
+            stream.Seek(0, SeekOrigin.End);
+            Assert.AreEqual(stream.Position, array.Length);
+        }
+
         [TestCategory("MemoryStream")]
         [TestMethod]
         public void Test_MemoryStream_ReadWrite_Array()


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

## Fixes https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3536
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Seeking to the end of a `Stream` from a `Memory<T>` or other types in the `HighPerformance` package throws an exception.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Seeking to the end of the stream is now allowed. This is consistent to other `Stream` types in the BCL.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes