### PR TITLE
Add barebones support for IsIndeterminate to RadialProgressBar

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RadialProgressBar/RadialProgressBarCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RadialProgressBar/RadialProgressBarCode.bind
@@ -23,7 +23,8 @@
           Maximum="100"
           Width="@[Width:Slider:100:100-200]"
           Height="@[Height:Slider:100:100-200]"
-          Outline="@[Outline:Brush:LightGray]" />
+          Outline="@[Outline:Brush:LightGray]" 
+          IsIndeterminate="@[IsIndeterminate:Bool:False]"/>
     </Grid>
   </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.cs
@@ -122,12 +122,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             // Register a callback to re-render segments when IsIndeterminate is changed
             var token = RegisterPropertyChangedCallback(IsIndeterminateProperty, OnIsIndeterminateChanged);
-            Unloaded += (s,e) => UnregisterPropertyChangedCallback(IsIndeterminateProperty, token);
-        }
-
-        private void OnIsIndeterminateChanged(DependencyObject sender, DependencyProperty dp)
-        {
-            RenderSegment();
+            Unloaded += (s, e) => UnregisterPropertyChangedCallback(IsIndeterminateProperty, token);
         }
 
         // Render outline and progress segment when thickness is changed
@@ -135,6 +130,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             var sender = d as RadialProgressBar;
             sender.RenderAll();
+        }
+
+        private void OnIsIndeterminateChanged(DependencyObject sender, DependencyProperty dp)
+        {
+            RenderSegment();
         }
 
         // Render outline and progress segment when control is resized.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.cs
@@ -157,9 +157,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private Size ComputeEllipseSize()
         {
             var safeThickness = Math.Max(Thickness, 0.0);
-            var width = Math.Max((ActualWidth - safeThickness) / 2.0, 0.0);
-            var height = Math.Max((ActualHeight - safeThickness) / 2.0, 0.0);
-            return new Size(width, height);
+            var safeWidthHeight = Math.Min(ActualWidth, ActualHeight);
+            var size = Math.Max((safeWidthHeight - safeThickness) / 2.0, 0.0);
+            return new Size(size, size);
         }
 
         // Render the segment representing progress ratio.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.cs
@@ -119,6 +119,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             DefaultStyleKey = typeof(RadialProgressBar);
             SizeChanged += SizeChangedHandler;
+
+            // Register a callback to re-render segments when IsIndeterminate is changed
+            var token = RegisterPropertyChangedCallback(IsIndeterminateProperty, OnIsIndeterminateChanged);
+            Unloaded += (s,e) => UnregisterPropertyChangedCallback(IsIndeterminateProperty, token);
+        }
+
+        private void OnIsIndeterminateChanged(DependencyObject sender, DependencyProperty dp)
+        {
+            RenderSegment();
         }
 
         // Render outline and progress segment when thickness is changed
@@ -161,7 +170,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            var normalizedRange = ComputeNormalizedRange();
+            // Set the segment to a fixed size in case of indeterminate progress
+            var normalizedRange = IsIndeterminate ? 0.25 : ComputeNormalizedRange();
 
             var angle = 2 * Math.PI * normalizedRange;
             var size = ComputeEllipseSize();

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.xaml
@@ -12,10 +12,12 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:RadialProgressBar">
 
-                    <Grid x:Name="LayoutRoot"  Background="{TemplateBinding Background}" RenderTransformOrigin="0.5,0.5">
+
+                    <Grid x:Name="LayoutRoot"  Background="{TemplateBinding Background}" RenderTransformOrigin="0.5,0.5"
+                          Width="{Binding Outline.Width}" Height="{Binding Outline.Height}" HorizontalAlignment="Center" VerticalAlignment="Center">
 
                         <Grid.RenderTransform>
-                            <RotateTransform/>
+                            <RotateTransform Angle="0"/>
                         </Grid.RenderTransform>
 
                         <VisualStateManager.VisualStateGroups>
@@ -42,9 +44,9 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                            
+
                         <!-- Gray outline of progress bar -->
-                        <Path Fill="Transparent" Stroke="{TemplateBinding Outline}" StrokeThickness="{TemplateBinding Thickness}" StrokeDashCap="Flat">
+                        <Path x:Name="Outline" Fill="Transparent" Stroke="{TemplateBinding Outline}" StrokeThickness="{TemplateBinding Thickness}" StrokeDashCap="Flat">
                             <Path.Data>
                                 <PathGeometry>
                                     <PathGeometry.Figures>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialProgressBar/RadialProgressBar.xaml
@@ -11,7 +11,38 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:RadialProgressBar">
-                    <Grid Background="{TemplateBinding Background}">
+
+                    <Grid x:Name="LayoutRoot"  Background="{TemplateBinding Background}" RenderTransformOrigin="0.5,0.5">
+
+                        <Grid.RenderTransform>
+                            <RotateTransform/>
+                        </Grid.RenderTransform>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="Indeterminate" To="Determinate">
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)" To="0"/>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Determinate" />
+                                <VisualState x:Name="Updating" />
+                                <VisualState x:Name="Indeterminate">
+                                    <Storyboard RepeatBehavior="Forever">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="(Grid.RenderTransform).(RotateTransform.Angle)">
+                                            <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+                                            <EasingDoubleKeyFrame KeyTime="0:0:0.8" Value="360"/>
+                                            <EasingDoubleKeyFrame KeyTime="0:0:1.4" Value="720"/>
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                            
                         <!-- Gray outline of progress bar -->
                         <Path Fill="Transparent" Stroke="{TemplateBinding Outline}" StrokeThickness="{TemplateBinding Thickness}" StrokeDashCap="Flat">
                             <Path.Data>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

## Fixes #1236  
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
👋 I needed a ProgressRing with both determinate and indeterminate states and couldn't use the new WinUI one for reasons, so I've added very simple support for indeterminate progress to the toolkit's `RadialProgressBar`.  

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `RadialProgressBar` doesn't take into account the `IsIndeterminate` property of the `ProgressBar` it inherits from.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Setting `IsIndeterminate` now triggers a simple rotating animation through `RenderTransform`.  
If the property is true, during rendering a hard value of 0.25 is used instead of whichever progress value exists. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/407
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
