### PR TITLE
Fix Sticky ScrollHeader causing unwanted scrolling with Popups on ListItems

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
@@ -11,6 +11,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
 {
@@ -238,7 +239,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 focusedElement = FocusManager.GetFocusedElement();
             }
 
-            if (focusedElement is UIElement element)
+            // To prevent Popups (Flyouts...) from triggering the autoscroll, we check if the focused element has a valid parent.
+            // Popups have no parents, whereas a normal Item would have the ListView as a parent.
+            if (focusedElement is UIElement element && VisualTreeHelper.GetParent(element) != null)
             {
                 FrameworkElement header = (FrameworkElement)HeaderElement;
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

## Fixes #3415
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
I took a quick look at the ScrollHeader bug and it was simple enough so:   

The Scrollheader's `StickyHeaderBehavior` adjusts scrolling when focusing an element of the ScrollViewer if it's slightly hidden by the header. This imitates standard ScrollViewer behavior.
However, `ScrollViewer.GotFocus` also triggers if we open a Flyout on a ListItem, but since the scrolling calculation didn't plan for that, it ends up scrolling the list by the height of the Flyout.  

An easy fix for this is to check if the focused element is really part of the list and not just a popup, which can be done by checking if the element has a parent or not.  

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If a Popup/Flyout of any kind is assigned to either the ListView or its items, opening it by right-click will scroll the ListView by the height of the Flyout if a Sticky ScrollHeader is used.  

The bug can be easily repro'd in the sample app's ScrollHeader page by adding a Flyout to its ListView:  
```
<ListView.ContextFlyout>
         <Flyout>
            <Button Content="Hello!" />
        </Flyout>
</ListView.ContextFlyout>
```

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Showing the Flyout no longer scrolls the ListView.  

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
