### PR TITLE
Temp - Remove 'native' target for Notifications package to unblock CI

### DIFF
--- a/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
+++ b/Microsoft.Toolkit.Uwp.Notifications/Microsoft.Toolkit.Uwp.Notifications.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;uap10.0;native;net461;netcoreapp3.1</TargetFrameworks>
+    <!--<TargetFrameworks>netstandard1.4;uap10.0;native;net461;netcoreapp3.1</TargetFrameworks>-->
+    <!-- Removed 'native' target to unblock CI on VS 16.8, tied to changes breaking workaround for https://github.com/NuGet/Home/issues/5154 -->
+    <TargetFrameworks>netstandard1.4;uap10.0;net461;netcoreapp3.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETFX_CORE</DefineConstants>
     <Title>Windows Community Toolkit Notifications</Title>
     <Description>

--- a/Windows Community Toolkit.sln
+++ b/Windows Community Toolkit.sln
@@ -43,11 +43,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Toolkit.Uwp.Notif
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTests.Notifications.NetCore", "UnitTests\UnitTests.Notifications.NetCore\UnitTests.Notifications.NetCore.csproj", "{94994424-5F60-4CD8-ABA2-101779066208}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests.Notifications.WinRT", "UnitTests\UnitTests.Notifications.WinRT\UnitTests.Notifications.WinRT.csproj", "{EFA96B3C-857E-4659-B942-6BEF7719F4CA}"
-	ProjectSection(ProjectDependencies) = postProject
-		{97EE849B-403C-490E-80ED-D19D7CC153FD} = {97EE849B-403C-490E-80ED-D19D7CC153FD}
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CFA75BE0-5A44-45DE-8114-426A605B062B}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -148,7 +143,6 @@ Global
 		UnitTests\UnitTests.Shared\UnitTests.Shared.projitems*{a139968e-ad78-4e8c-93b8-9a5523bcac89}*SharedItemsImports = 4
 		UnitTests\UnitTests.Notifications.Shared\UnitTests.Notifications.Shared.projitems*{bab1caf4-c400-4a7f-a987-c576de63cffd}*SharedItemsImports = 4
 		UnitTests\UnitTests.HighPerformance.Shared\UnitTests.HighPerformance.Shared.projitems*{d9bdbc68-3d0a-47fc-9c88-0bf769101644}*SharedItemsImports = 5
-		UnitTests\UnitTests.Notifications.Shared\UnitTests.Notifications.Shared.projitems*{efa96b3c-857e-4659-b942-6bef7719f4ca}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -486,34 +480,6 @@ Global
 		{94994424-5F60-4CD8-ABA2-101779066208}.Release|x64.Build.0 = Release|Any CPU
 		{94994424-5F60-4CD8-ABA2-101779066208}.Release|x86.ActiveCfg = Release|Any CPU
 		{94994424-5F60-4CD8-ABA2-101779066208}.Release|x86.Build.0 = Release|Any CPU
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|Any CPU.Build.0 = Debug|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|ARM.ActiveCfg = Debug|ARM
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|ARM.Build.0 = Debug|ARM
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|ARM.Deploy.0 = Debug|ARM
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|ARM64.Build.0 = Debug|ARM64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|ARM64.Deploy.0 = Debug|ARM64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|x64.ActiveCfg = Debug|x64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|x64.Build.0 = Debug|x64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|x64.Deploy.0 = Debug|x64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|x86.ActiveCfg = Debug|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|x86.Build.0 = Debug|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Debug|x86.Deploy.0 = Debug|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|Any CPU.ActiveCfg = Release|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|Any CPU.Build.0 = Release|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|ARM.ActiveCfg = Release|ARM
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|ARM.Build.0 = Release|ARM
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|ARM.Deploy.0 = Release|ARM
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|ARM64.ActiveCfg = Release|ARM64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|ARM64.Build.0 = Release|ARM64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|ARM64.Deploy.0 = Release|ARM64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|x64.ActiveCfg = Release|x64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|x64.Build.0 = Release|x64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|x64.Deploy.0 = Release|x64
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|x86.ActiveCfg = Release|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|x86.Build.0 = Release|x86
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA}.Release|x86.Deploy.0 = Release|x86
 		{7AEFC959-ED7C-4D96-9E92-72609B40FBE0}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{7AEFC959-ED7C-4D96-9E92-72609B40FBE0}.Debug|Any CPU.Build.0 = Debug|x86
 		{7AEFC959-ED7C-4D96-9E92-72609B40FBE0}.Debug|ARM.ActiveCfg = Debug|x86
@@ -1026,7 +992,6 @@ Global
 		{BAB1CAF4-C400-4A7F-A987-C576DE63CFFD} = {9333C63A-F64F-4797-82B3-017422668A5D}
 		{1AE2CB5C-58A0-4F12-8E6F-2CD4AAADB34C} = {9AD30620-667D-433C-9961-8D885EE7B762}
 		{94994424-5F60-4CD8-ABA2-101779066208} = {9333C63A-F64F-4797-82B3-017422668A5D}
-		{EFA96B3C-857E-4659-B942-6BEF7719F4CA} = {9333C63A-F64F-4797-82B3-017422668A5D}
 		{7AEFC959-ED7C-4D96-9E92-72609B40FBE0} = {F1AFFFA7-28FE-4770-BA48-10D76F3E59BC}
 		{6BD0BA4A-DE6D-3E87-8F83-63518C31ECD1} = {F1AFFFA7-28FE-4770-BA48-10D76F3E59BC}
 		{A122EA02-4DE7-413D-BFBF-AF7DFC668DD6} = {B30036C4-D514-4E5B-A323-587A061772CE}


### PR DESCRIPTION
## Fixes #3564 

Remove the 'native' target framework that is causing issues on VS 16.8 for now until a long-term solution can be found.

Current theory is 16.8 broke the workaround we were using to address this issue: https://github.com/NuGet/Home/issues/5154

FYI @andrewleader @azchohfi 