### PR TITLE
Adding .NET Framework 4.6.1 as tartget framework for Toolkit.Mvvm

### DIFF
--- a/Microsoft.Toolkit.Mvvm/Microsoft.Toolkit.Mvvm.csproj
+++ b/Microsoft.Toolkit.Mvvm/Microsoft.Toolkit.Mvvm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -26,6 +26,12 @@
   <!-- .NET Standard 2.1 doesn't have the Unsafe type -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/UnitTests.Net461/UnitTests.Net461.csproj
+++ b/UnitTests/UnitTests.Net461/UnitTests.Net461.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Toolkit.Mvvm\Microsoft.Toolkit.Mvvm.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Toolkit\Microsoft.Toolkit.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\UnitTests.Shared\UnitTests.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/UnitTests/UnitTests.Shared/Diagnostics/Test_Guard.cs
+++ b/UnitTests/UnitTests.Shared/Diagnostics/Test_Guard.cs
@@ -11,6 +11,8 @@ namespace UnitTests.Diagnostics
     [TestClass]
     public partial class Test_Guard
     {
+        private const float PI = 3.14159274f;
+
         [TestCategory("Guard")]
         [TestMethod]
         public void Test_Guard_IsNull_Ok()
@@ -156,7 +158,7 @@ namespace UnitTests.Diagnostics
         public void Test_Guard_IsBitwiseEqualTo_Ok()
         {
             Guard.IsBitwiseEqualTo(byte.MaxValue, byte.MaxValue, nameof(Test_Guard_IsBitwiseEqualTo_Ok));
-            Guard.IsBitwiseEqualTo(MathF.PI, MathF.PI, nameof(Test_Guard_IsBitwiseEqualTo_Ok));
+            Guard.IsBitwiseEqualTo(PI, PI, nameof(Test_Guard_IsBitwiseEqualTo_Ok));
             Guard.IsBitwiseEqualTo(double.Epsilon, double.Epsilon, nameof(Test_Guard_IsBitwiseEqualTo_Ok));
 
             var guid = Guid.NewGuid();
@@ -326,7 +328,7 @@ namespace UnitTests.Diagnostics
         public void Test_Guard_IsLessThan_Ok()
         {
             Guard.IsLessThan(1, 2, nameof(Test_Guard_IsLessThan_Ok));
-            Guard.IsLessThan(1.2f, 3.14f, nameof(Test_Guard_IsLessThan_Ok));
+            Guard.IsLessThan(1.2f, PI, nameof(Test_Guard_IsLessThan_Ok));
             Guard.IsLessThan(DateTime.Now, DateTime.MaxValue, nameof(Test_Guard_IsLessThan_Ok));
         }
 
@@ -352,8 +354,8 @@ namespace UnitTests.Diagnostics
         {
             Guard.IsLessThanOrEqualTo(1, 2, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
             Guard.IsLessThanOrEqualTo(1, 1, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
-            Guard.IsLessThanOrEqualTo(0.1f, MathF.PI, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
-            Guard.IsLessThanOrEqualTo(MathF.PI, MathF.PI, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
+            Guard.IsLessThanOrEqualTo(0.1f, PI, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
+            Guard.IsLessThanOrEqualTo(PI, PI, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
             Guard.IsLessThanOrEqualTo(DateTime.Today, DateTime.MaxValue, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
             Guard.IsLessThanOrEqualTo(DateTime.MaxValue, DateTime.MaxValue, nameof(Test_Guard_IsLessThanOrEqualTo_Ok));
         }
@@ -371,7 +373,7 @@ namespace UnitTests.Diagnostics
         public void Test_Guard_IsGreaterThan_Ok()
         {
             Guard.IsGreaterThan(2, 1, nameof(Test_Guard_IsGreaterThan_Ok));
-            Guard.IsGreaterThan(3.14f, 2.1f, nameof(Test_Guard_IsGreaterThan_Ok));
+            Guard.IsGreaterThan(PI, 2.1f, nameof(Test_Guard_IsGreaterThan_Ok));
             Guard.IsGreaterThan(DateTime.MaxValue, DateTime.Today, nameof(Test_Guard_IsGreaterThan_Ok));
         }
 
@@ -397,8 +399,8 @@ namespace UnitTests.Diagnostics
         {
             Guard.IsGreaterThanOrEqualTo(2, 1, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
             Guard.IsGreaterThanOrEqualTo(1, 1, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
-            Guard.IsGreaterThanOrEqualTo(MathF.PI, 1, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
-            Guard.IsGreaterThanOrEqualTo(MathF.PI, MathF.PI, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
+            Guard.IsGreaterThanOrEqualTo(PI, 1, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
+            Guard.IsGreaterThanOrEqualTo(PI, PI, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
             Guard.IsGreaterThanOrEqualTo(DateTime.MaxValue, DateTime.Today, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
             Guard.IsGreaterThanOrEqualTo(DateTime.MaxValue, DateTime.MaxValue, nameof(Test_Guard_IsGreaterThanOrEqualTo_Ok));
         }
@@ -417,11 +419,11 @@ namespace UnitTests.Diagnostics
         {
             Guard.IsInRange(1, 0, 4, nameof(Test_Guard_IsInRange_Ok));
             Guard.IsInRange(0, 0, 2, nameof(Test_Guard_IsInRange_Ok));
-            Guard.IsInRange(3.14f, 0, 10, nameof(Test_Guard_IsInRange_Ok));
-            Guard.IsInRange(1, 0, 3.14f, nameof(Test_Guard_IsInRange_Ok));
+            Guard.IsInRange(PI, 0, 10, nameof(Test_Guard_IsInRange_Ok));
+            Guard.IsInRange(1, 0, PI, nameof(Test_Guard_IsInRange_Ok));
             Guard.IsInRange(1, -50, 2, nameof(Test_Guard_IsInRange_Ok));
             Guard.IsInRange(-44, -44, 0, nameof(Test_Guard_IsInRange_Ok));
-            Guard.IsInRange(3.14f, -float.Epsilon, 22, nameof(Test_Guard_IsInRange_Ok));
+            Guard.IsInRange(PI, -float.Epsilon, 22, nameof(Test_Guard_IsInRange_Ok));
             Guard.IsInRange(1, int.MinValue, int.MaxValue, nameof(Test_Guard_IsInRange_Ok));
         }
 
@@ -456,7 +458,7 @@ namespace UnitTests.Diagnostics
             Guard.IsNotInRange(0, 4, 10, nameof(Test_Guard_IsNotInRange_Ok));
             Guard.IsNotInRange(-4, 0, 2, nameof(Test_Guard_IsNotInRange_Ok));
             Guard.IsNotInRange(12f, 0, 10, nameof(Test_Guard_IsNotInRange_Ok));
-            Guard.IsNotInRange(-1, 0, 3.14f, nameof(Test_Guard_IsNotInRange_Ok));
+            Guard.IsNotInRange(-1, 0, PI, nameof(Test_Guard_IsNotInRange_Ok));
         }
 
         [TestCategory("Guard")]
@@ -552,7 +554,7 @@ namespace UnitTests.Diagnostics
         public void Test_Guard_IsBetween_Ok()
         {
             Guard.IsBetween(1, 0, 4, nameof(Test_Guard_IsBetween_Ok));
-            Guard.IsBetween(3.14f, 0, 10, nameof(Test_Guard_IsBetween_Ok));
+            Guard.IsBetween(PI, 0, 10, nameof(Test_Guard_IsBetween_Ok));
             Guard.IsBetween(1, 0, 3.14, nameof(Test_Guard_IsBetween_Ok));
         }
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- Add a brief overview here of the feature/bug & fix. -->

This pull request adds .NET Framework 4.6.1 as TargetFramework to Micorsoft.Toolkit.Mvvm.
This is because  .NET Framework 4.6.1 is not fully compatible with .Net Standard 2.0. It can be use with  .Net Standard 2.0, yes, but it produces many System.*.dll in the ouptut directory. A better solution is to multitarget also  .NET Framework 4.6.1. That is what many libraries do.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you create e.g. a WPF application that targets 4.6.1 (yes that is still used) and you references the Microsoft.Toolkit.Mvvm package, your output directory is filled with many System dlls which are needed because net4.6.1 is not fully compatible with netstandard2.0.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
The Microsoft.Toolkit.Mvvm also targets net4.6.1 which prevents that.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*) **Not applicable, no new .cs files**
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
I added also a unit test project for net4.6.1. Since there is no dedicated unit test project but it is mixed with the whole Toolkit version (maybe it would be good to separate them), this test the same things like the UnitTests.NetCore project. Since MathF is not available in net4.6.1 I replaced the calls to MathF.PI with a constant in code of the test.
I didn't add the unit test project to the solution because it changed too much in the solution file. (removed "Native" Plattforms)