### PR TITLE
Removed leftover DispatcherQueue usages

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherQueueHelper/DispatcherQueueHelperPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherQueueHelper/DispatcherQueueHelperPage.xaml.cs
@@ -3,10 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Uwp.Helpers;
+using Microsoft.Toolkit.Uwp.Extensions;
 using Windows.System;
 using Windows.UI.Xaml;
-using Microsoft.Toolkit.Uwp.Extensions;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 {

--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.SamplePicker.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.SamplePicker.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.Extensions;
 using Microsoft.Toolkit.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp.SampleApp.Pages;
 using Microsoft.Toolkit.Uwp.UI.Animations;
@@ -147,7 +148,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                     ShowSamplePicker(category.Samples, true);
 
                     // Then Focus on Picker
-                    DispatcherHelper.ExecuteOnUIThreadAsync(() => SamplePickerGridView.Focus(FocusState.Keyboard));
+                    dispatcherQueue.EnqueueAsync(() => SamplePickerGridView.Focus(FocusState.Keyboard));
                 }
             }
             else if (args.IsSettingsInvoked)

--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.Search.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.Search.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using Microsoft.Toolkit.Uwp.Extensions;
 using Microsoft.Toolkit.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.UI.Xaml;
@@ -76,7 +77,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             if (e.Key == Windows.System.VirtualKey.Down && SamplePickerGrid.Visibility == Windows.UI.Xaml.Visibility.Visible)
             {
                 // If we try and navigate down out of the textbox (and there's search results), go to the search results.
-                DispatcherHelper.ExecuteOnUIThreadAsync(() => SamplePickerGridView.Focus(FocusState.Keyboard));
+                dispatcherQueue.EnqueueAsync(() => SamplePickerGridView.Focus(FocusState.Keyboard));
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
@@ -7,7 +7,6 @@ using Microsoft.Toolkit.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp.SampleApp.Pages;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.System;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
@@ -16,6 +15,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 {
     public sealed partial class Shell
     {
+        private readonly DispatcherQueue dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
         public static Shell Current { get; private set; }
 
         public Shell()

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Light.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Light.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Effects;
-using Microsoft.Toolkit.Uwp.Helpers;
+using Microsoft.Toolkit.Uwp.Extensions;
 using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Composition.Effects;
@@ -102,7 +102,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             var task = new AnimationTask();
             task.AnimationSet = animationSet;
 
-            task.Task = DispatcherHelper.ExecuteOnUIThreadAsync(
+            task.Task = visual.DispatcherQueue.EnqueueAsync(
                 () =>
             {
                 const string sceneName = "PointLightScene";
@@ -184,7 +184,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                 }
 
                 pointLights[visual] = pointLight;
-            }, Windows.UI.Core.CoreDispatcherPriority.Normal);
+            });
 
             animationSet.AddAnimationThroughTask(task);
             return animationSet;

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ScrollViewer/ScrollViewerExtensions.MiddleClickScrolling.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ScrollViewer/ScrollViewerExtensions.MiddleClickScrolling.cs
@@ -162,10 +162,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                 offsetX = offsetX > _maxSpeed ? _maxSpeed : offsetX;
                 offsetY = offsetY > _maxSpeed ? _maxSpeed : offsetY;
 
-                RunInUIThread(dispatcherQueue, () =>
-                {
-                    _scrollViewer?.ChangeView(_scrollViewer.HorizontalOffset + offsetX, _scrollViewer.VerticalOffset + offsetY, null, true);
-                });
+                dispatcherQueue.EnqueueAsync(() => _scrollViewer?.ChangeView(_scrollViewer.HorizontalOffset + offsetX, _scrollViewer.VerticalOffset + offsetY, null, true));
             }
         }
 
@@ -326,10 +323,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
             if (_oldCursorID != cursorID)
             {
-                RunInUIThread(dispatcherQueue, () =>
-                {
-                    Window.Current.CoreWindow.PointerCursor = new CoreCursor(CoreCursorType.Custom, cursorID);
-                });
+                dispatcherQueue.EnqueueAsync(() => Window.Current.CoreWindow.PointerCursor = new CoreCursor(CoreCursorType.Custom, cursorID));
 
                 _oldCursorID = cursorID;
             }
@@ -365,11 +359,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
 
             return isCursorAvailable;
-        }
-
-        private static async void RunInUIThread(DispatcherQueue dispatcherQueue, Action action)
-        {
-            await dispatcherQueue.EnqueueAsync(action, DispatcherQueuePriority.Normal);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp/Extensions/DispatcherQueueExtensions.cs
+++ b/Microsoft.Toolkit.Uwp/Extensions/DispatcherQueueExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Windows.Foundation.Metadata;
 using Windows.System;
@@ -67,7 +68,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                     }
                 }))
                 {
-                    taskCompletionSource.SetException(new InvalidOperationException("Failed to enqueue the operation"));
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
                 }
 
                 return taskCompletionSource.Task;
@@ -116,7 +117,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                     }
                 }))
                 {
-                    taskCompletionSource.SetException(new InvalidOperationException("Failed to enqueue the operation"));
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
                 }
 
                 return taskCompletionSource.Task;
@@ -149,7 +150,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                         return awaitableResult;
                     }
 
-                    return Task.FromException(new InvalidOperationException("The Task returned by function cannot be null."));
+                    return Task.FromException(GetEnqueueException("The Task returned by function cannot be null."));
                 }
                 catch (Exception e)
                 {
@@ -173,7 +174,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                         }
                         else
                         {
-                            taskCompletionSource.SetException(new InvalidOperationException("The Task returned by function cannot be null."));
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
                         }
                     }
                     catch (Exception e)
@@ -182,7 +183,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                     }
                 }))
                 {
-                    taskCompletionSource.SetException(new InvalidOperationException("Failed to enqueue the operation"));
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
                 }
 
                 return taskCompletionSource.Task;
@@ -212,7 +213,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                         return awaitableResult;
                     }
 
-                    return Task.FromException<T>(new InvalidOperationException("The Task returned by function cannot be null."));
+                    return Task.FromException<T>(GetEnqueueException("The Task returned by function cannot be null."));
                 }
                 catch (Exception e)
                 {
@@ -236,7 +237,7 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                         }
                         else
                         {
-                            taskCompletionSource.SetException(new InvalidOperationException("The Task returned by function cannot be null."));
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
                         }
                     }
                     catch (Exception e)
@@ -245,13 +246,24 @@ namespace Microsoft.Toolkit.Uwp.Extensions
                     }
                 }))
                 {
-                    taskCompletionSource.SetException(new InvalidOperationException("Failed to enqueue the operation"));
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
                 }
 
                 return taskCompletionSource.Task;
             }
 
             return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="InvalidOperationException"/> to return when an enqueue operation fails.
+        /// </summary>
+        /// <param name="message">The message of the exception.</param>
+        /// <returns>An <see cref="InvalidOperationException"/> with a specified message.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetEnqueueException(string message)
+        {
+            return new InvalidOperationException(message);
         }
     }
 }

--- a/UnitTests/UnitTests.XamlIslands.UWPApp/XamlIslandsTest_Gaze.cs
+++ b/UnitTests/UnitTests.XamlIslands.UWPApp/XamlIslandsTest_Gaze.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.Extensions;
 using Microsoft.Toolkit.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp.Input.GazeInteraction;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,7 +22,7 @@ namespace UnitTests.XamlIslands.UWPApp
         [TestInitialize]
         public async Task Init()
         {
-            await App.Dispatcher.ExecuteOnUIThreadAsync(() =>
+            await App.Dispatcher.EnqueueAsync(() =>
             {
                 var xamlItemsPanelTemplate = @"<Grid xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' 
                                                  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
@@ -65,7 +66,7 @@ namespace UnitTests.XamlIslands.UWPApp
         [TestCleanup]
         public async Task Cleanup()
         {
-            await App.Dispatcher.ExecuteOnUIThreadAsync(() =>
+            await App.Dispatcher.EnqueueAsync(() =>
             {
                 GazeInput.SetInteraction(_grid, Interaction.Disabled);
             });
@@ -76,7 +77,7 @@ namespace UnitTests.XamlIslands.UWPApp
         [Ignore]
         public async Task Gaze_DoesNotCrashOnIslands()
         {
-            await App.Dispatcher.ExecuteOnUIThreadAsync(async () =>
+            await App.Dispatcher.EnqueueAsync(async () =>
             {
                 await Task.Delay(10000);
 


### PR DESCRIPTION
## Follow up for #3498 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
- Refactoring
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Some leftover `DispatcherQueue` usages (some causing a build error).

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
All code is now using `DispatcherQueue` instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes