### PR TITLE
MVVM Toolkit - Make Command classes open for extension

### DIFF
--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
     /// action, and providing an <see cref="ExecutionTask"/> property that notifies changes when
     /// <see cref="ExecuteAsync"/> is invoked and when the returned <see cref="Task"/> completes.
     /// </summary>
-    public sealed class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
+    public class AsyncRelayCommand : ObservableObject, IAsyncRelayCommand
     {
         /// <summary>
         /// The cached <see cref="PropertyChangedEventArgs"/> for <see cref="CanBeCanceled"/>.
@@ -57,7 +57,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
         private CancellationTokenSource? cancellationTokenSource;
 
         /// <inheritdoc/>
-        public event EventHandler? CanExecuteChanged;
+        public virtual event EventHandler? CanExecuteChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncRelayCommand"/> class that can always execute.
@@ -120,6 +120,9 @@ namespace Microsoft.Toolkit.Mvvm.Input
                 }
             }
         }
+
+        /// <inheritdoc/>
+        public bool CanAlwaysExecute => this.canExecute is null;
 
         /// <inheritdoc/>
         public bool CanBeCanceled => !(this.cancelableExecute is null) && IsRunning;

--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
     /// A generic command that provides a more specific version of <see cref="AsyncRelayCommand"/>.
     /// </summary>
     /// <typeparam name="T">The type of parameter being passed as input to the callbacks.</typeparam>
-    public sealed class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<T>
+    public class AsyncRelayCommand<T> : ObservableObject, IAsyncRelayCommand<T>
     {
         /// <summary>
         /// The <see cref="Func{TResult}"/> to invoke when <see cref="Execute(T)"/> is used.
@@ -37,7 +37,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
         private CancellationTokenSource? cancellationTokenSource;
 
         /// <inheritdoc/>
-        public event EventHandler? CanExecuteChanged;
+        public virtual event EventHandler? CanExecuteChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class that can always execute.
@@ -104,6 +104,9 @@ namespace Microsoft.Toolkit.Mvvm.Input
                 }
             }
         }
+
+        /// <inheritdoc/>
+        public bool CanAlwaysExecute => this.canExecute is null;
 
         /// <inheritdoc/>
         public bool CanBeCanceled => !(this.cancelableExecute is null) && IsRunning;

--- a/Microsoft.Toolkit.Mvvm/Input/Interfaces/IRelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/Interfaces/IRelayCommand.cs
@@ -16,5 +16,10 @@ namespace Microsoft.Toolkit.Mvvm.Input
         /// Notifies that the <see cref="ICommand.CanExecute"/> property has changed.
         /// </summary>
         void NotifyCanExecuteChanged();
+
+        /// <summary>
+        /// Gets a value indicating whether this command can always be executed. True if the command was created without execution status logic.
+        /// </summary>
+        bool CanAlwaysExecute { get; }
     }
 }

--- a/Microsoft.Toolkit.Mvvm/Input/RelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/RelayCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
     /// method is <see langword="true"/>. This type does not allow you to accept command parameters
     /// in the <see cref="Execute"/> and <see cref="CanExecute"/> callback methods.
     /// </summary>
-    public sealed class RelayCommand : IRelayCommand
+    public class RelayCommand : IRelayCommand
     {
         /// <summary>
         /// The <see cref="Action"/> to invoke when <see cref="Execute"/> is used.
@@ -31,7 +31,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
         private readonly Func<bool>? canExecute;
 
         /// <inheritdoc/>
-        public event EventHandler? CanExecuteChanged;
+        public virtual event EventHandler? CanExecuteChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RelayCommand"/> class that can always execute.
@@ -52,6 +52,9 @@ namespace Microsoft.Toolkit.Mvvm.Input
             this.execute = execute;
             this.canExecute = canExecute;
         }
+
+        /// <inheritdoc/>
+        public bool CanAlwaysExecute => this.canExecute is null;
 
         /// <inheritdoc/>
         public void NotifyCanExecuteChanged()

--- a/Microsoft.Toolkit.Mvvm/Input/RelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/RelayCommand{T}.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
     /// in the <see cref="Execute(T)"/> and <see cref="CanExecute(T)"/> callback methods.
     /// </summary>
     /// <typeparam name="T">The type of parameter being passed as input to the callbacks.</typeparam>
-    public sealed class RelayCommand<T> : IRelayCommand<T>
+    public class RelayCommand<T> : IRelayCommand<T>
     {
         /// <summary>
         /// The <see cref="Action"/> to invoke when <see cref="Execute(T)"/> is used.
@@ -32,7 +32,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
         private readonly Func<T, bool>? canExecute;
 
         /// <inheritdoc/>
-        public event EventHandler? CanExecuteChanged;
+        public virtual event EventHandler? CanExecuteChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RelayCommand{T}"/> class that can always execute.
@@ -59,6 +59,9 @@ namespace Microsoft.Toolkit.Mvvm.Input
             this.execute = execute;
             this.canExecute = canExecute;
         }
+
+        /// <inheritdoc/>
+        public bool CanAlwaysExecute => this.canExecute is null;
 
         /// <inheritdoc/>
         public void NotifyCanExecuteChanged()


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #
This PR fixes Issue #3609 that helps to make command classes extendable, which is needed to use existing command logic with WPF's CommandManager. 

This change also helps to move issue #3571 forward.

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Feature

## What is the current behavior?
Currently command classes are sealed and cannot be extended


## What is the new behavior?
Command classes can be extended


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


## Other information
