### PR TITLE
TileControl: Remove Animations.Expressions usage

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -466,30 +466,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             expressionX.SetReferenceParameter(pParam, propertySetModulo);
             expressionY.SetReferenceParameter(pParam, propertySetModulo);
 
-            var imageHeightNode = imageHeightParam;
-            var imageWidthNode = imageWidthParam;
-
             string expressionXVal;
             string expressionYVal;
             if (scrollViewer == null)
             {
-                var offsetXNode = "Ceil(" + offsetXParam + ")";
-                var offsetYNode = "Ceil(" + offsetYParam + ")";
+                var xCommon = "Ceil(" + offsetXParam + ")";
+                var yCommon = "Ceil(" + offsetYParam + ")";
 
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset
                 expressionXVal =
-                    $"{offsetXNode} == 0 " +
+                    $"{xCommon} == 0 " +
                     $"? 0 " +
-                    $": {offsetXNode} < 0 " +
-                        $"? -(Abs({offsetXNode} - (Ceil({offsetXNode} / {imageWidthNode}) * {imageWidthNode})) % {imageWidthNode}) " +
-                        $": -({imageWidthNode} - ({offsetXNode} % {imageWidthNode}))";
+                    $": {xCommon} < 0 " +
+                        $"? -(Abs({xCommon} - (Ceil({xCommon} / {imageWidthParam}) * {imageWidthParam})) % {imageWidthParam}) " +
+                        $": -({imageWidthParam} - ({xCommon} % {imageWidthParam}))";
 
                 expressionYVal =
-                    $"{offsetYNode} == 0 " +
+                    $"{yCommon} == 0 " +
                     $"? 0 " +
-                    $": {offsetYNode} < 0 " +
-                        $"? -(Abs({offsetYNode} - (Ceil({offsetYNode} / {imageHeightNode}) * {imageHeightNode})) % {imageHeightNode}) " +
-                        $": -({imageHeightNode} - ({offsetYNode} % {imageHeightNode}))";
+                    $": {yCommon} < 0 " +
+                        $"? -(Abs({yCommon} - (Ceil({yCommon} / {imageHeightParam}) * {imageHeightParam})) % {imageHeightParam}) " +
+                        $": -({imageHeightParam} - ({yCommon} % {imageHeightParam}))";
             }
             else
             {
@@ -498,22 +495,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 expressionX.SetReferenceParameter("s", scrollProperties);
                 expressionY.SetReferenceParameter("s", scrollProperties);
 
-                var speed = speedParam;
-                var xCommon = $"Ceil((s.Translation.X * {speed}) + {offsetXParam})";
+                var xCommon = $"Ceil((s.Translation.X * {speedParam}) + {offsetXParam})";
                 expressionXVal =
                     $"{xCommon} == 0 " +
                     "? 0 " +
                     $": {xCommon} < 0 " +
-                        $"? -(Abs({xCommon} - (Ceil({xCommon} / {imageWidthNode}) * {imageWidthNode})) % {imageWidthNode}) " +
-                        $": -({imageWidthNode} - ({xCommon} % {imageWidthNode}))";
+                        $"? -(Abs({xCommon} - (Ceil({xCommon} / {imageWidthParam}) * {imageWidthParam})) % {imageWidthParam}) " +
+                        $": -({imageWidthParam} - ({xCommon} % {imageWidthParam}))";
 
-                var yCommon = $"Ceil((s.Translation.Y * {speed}) + {offsetYParam})";
+                var yCommon = $"Ceil((s.Translation.Y * {speedParam}) + {offsetYParam})";
                 expressionYVal =
                     $"{yCommon} == 0 " +
                     "? 0 " +
                     $": {yCommon} < 0 " +
-                        $"? -(Abs({yCommon} - (Ceil({yCommon} / {imageHeightNode}) * {imageHeightNode})) % {imageHeightNode}) " +
-                        $": -({imageHeightNode} - ({yCommon} % {imageHeightNode}))";
+                        $"? -(Abs({yCommon} - (Ceil({yCommon} / {imageHeightParam}) * {imageHeightParam})) % {imageHeightParam}) " +
+                        $": -({imageHeightParam} - ({yCommon} % {imageHeightParam}))";
             }
 
             if (scrollOrientation == ScrollOrientation.Horizontal || scrollOrientation == ScrollOrientation.Both)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -461,9 +461,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var expressionY = compositor.CreateExpressionAnimation();
 
             var propertySetModulo = compositor.CreatePropertySet();
-            propertySetModulo.InsertScalar(imageHeightParam, (float)imageWidth);
+            propertySetModulo.InsertScalar(imageWidthParam, (float)imageWidth);
             propertySetModulo.InsertScalar(offsetXParam, (float)OffsetX);
-            propertySetModulo.InsertScalar(imageWidthParam, (float)imageHeight);
+            propertySetModulo.InsertScalar(imageHeightParam, (float)imageHeight);
             propertySetModulo.InsertScalar(offsetYParam, (float)OffsetY);
             propertySetModulo.InsertScalar(speedParam, (float)ParallaxSpeedRatio);
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             expressionX.SetReferenceParameter(propSetParam, propertySetModulo);
             expressionY.SetReferenceParameter(propSetParam, propertySetModulo);
 
-            string Thing(string common, string dimension)
+            string GenerateFormula(string common, string dimension)
                 => string.Format(
                     "{0} == 0 " +
                     "? 0 " +
@@ -485,9 +485,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (scrollViewer == null)
             {
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset
-                expressionXVal = Thing("Ceil(" + qualifiedOffsetXParam + ")", qualifiedImageHeightParam);
+                expressionXVal = GenerateFormula("Ceil(" + qualifiedOffsetXParam + ")", qualifiedImageHeightParam);
 
-                expressionYVal = Thing("Ceil(" + qualifiedOffsetYParam + ")", qualifiedImageWidthParam);
+                expressionYVal = GenerateFormula("Ceil(" + qualifiedOffsetYParam + ")", qualifiedImageWidthParam);
             }
             else
             {
@@ -500,12 +500,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 expressionX.SetReferenceParameter(scrollParam, scrollProperties);
                 expressionY.SetReferenceParameter(scrollParam, scrollProperties);
 
-                string LocalThing(string scrollTranslation, string speed, string offset, string dimension)
-                    => Thing(string.Format("Ceil(({0} * {1}) + {2})", scrollTranslation, speed, offset), dimension);
+                string GenerateParalaxFormula(string scrollTranslation, string speed, string offset, string dimension)
+                    => GenerateFormula(string.Format("Ceil(({0} * {1}) + {2})", scrollTranslation, speed, offset), dimension);
 
-                expressionXVal = LocalThing(translationParam + "." + nameof(scrollViewer.Translation.X), qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
+                expressionXVal = GenerateParalaxFormula(translationParam + "." + nameof(scrollViewer.Translation.X), qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
 
-                expressionYVal = LocalThing(translationParam + "." + nameof(scrollViewer.Translation.Y), qualifiedSpeedParam, qualifiedOffsetYParam, qualifiedImageHeightParam);
+                expressionYVal = GenerateParalaxFormula(translationParam + "." + nameof(scrollViewer.Translation.Y), qualifiedSpeedParam, qualifiedOffsetYParam, qualifiedImageHeightParam);
             }
 
             if (scrollOrientation == ScrollOrientation.Horizontal || scrollOrientation == ScrollOrientation.Both)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -500,8 +500,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 expressionX.SetReferenceParameter(scrollParam, scrollProperties);
                 expressionY.SetReferenceParameter(scrollParam, scrollProperties);
 
-                string LocalThing(string scroll, string speed, string offset, string dimension)
-                    => Thing(string.Format("Ceil(({0} * {1}) + {2})", scroll, speed, offset), dimension);
+                string LocalThing(string scrollTranslation, string speed, string offset, string dimension)
+                    => Thing(string.Format("Ceil(({0} * {1}) + {2})", scrollTranslation, speed, offset), dimension);
 
                 expressionXVal = LocalThing(translationParam + "." + nameof(scrollViewer.Translation.X), qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -466,27 +466,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             expressionX.SetReferenceParameter(pParam, propertySetModulo);
             expressionY.SetReferenceParameter(pParam, propertySetModulo);
 
+            string Thing(string common, string diemtion)
+                => string.Format(
+                    "{0} == 0 " +
+                    "? 0 " +
+                    ": {0} < 0 " +
+                        "? -(Abs({0} - (Ceil({0} / {1}) * {1})) % {1}) " +
+                        ": -({1} - ({0} % {1}))",
+                    common,
+                    diemtion);
+
             string expressionXVal;
             string expressionYVal;
             if (scrollViewer == null)
             {
-                var xCommon = "Ceil(" + offsetXParam + ")";
-                var yCommon = "Ceil(" + offsetYParam + ")";
-
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset
-                expressionXVal =
-                    $"{xCommon} == 0 " +
-                    $"? 0 " +
-                    $": {xCommon} < 0 " +
-                        $"? -(Abs({xCommon} - (Ceil({xCommon} / {imageWidthParam}) * {imageWidthParam})) % {imageWidthParam}) " +
-                        $": -({imageWidthParam} - ({xCommon} % {imageWidthParam}))";
+                expressionXVal = Thing("Ceil(" + offsetXParam + ")", imageHeightParam);
 
-                expressionYVal =
-                    $"{yCommon} == 0 " +
-                    $"? 0 " +
-                    $": {yCommon} < 0 " +
-                        $"? -(Abs({yCommon} - (Ceil({yCommon} / {imageHeightParam}) * {imageHeightParam})) % {imageHeightParam}) " +
-                        $": -({imageHeightParam} - ({yCommon} % {imageHeightParam}))";
+                expressionYVal = Thing("Ceil(" + offsetYParam + ")", imageWidthParam);
             }
             else
             {
@@ -495,21 +492,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 expressionX.SetReferenceParameter("s", scrollProperties);
                 expressionY.SetReferenceParameter("s", scrollProperties);
 
-                var xCommon = $"Ceil((s.Translation.X * {speedParam}) + {offsetXParam})";
-                expressionXVal =
-                    $"{xCommon} == 0 " +
-                    "? 0 " +
-                    $": {xCommon} < 0 " +
-                        $"? -(Abs({xCommon} - (Ceil({xCommon} / {imageWidthParam}) * {imageWidthParam})) % {imageWidthParam}) " +
-                        $": -({imageWidthParam} - ({xCommon} % {imageWidthParam}))";
+                string LocalThing(string scroll, string speed, string offset, string dimention)
+                    => Thing(string.Format("Ceil(({0} * {1}) + {2})", scroll, speed, offset), dimention);
 
-                var yCommon = $"Ceil((s.Translation.Y * {speedParam}) + {offsetYParam})";
-                expressionYVal =
-                    $"{yCommon} == 0 " +
-                    "? 0 " +
-                    $": {yCommon} < 0 " +
-                        $"? -(Abs({yCommon} - (Ceil({yCommon} / {imageHeightParam}) * {imageHeightParam})) % {imageHeightParam}) " +
-                        $": -({imageHeightParam} - ({yCommon} % {imageHeightParam}))";
+                expressionXVal = LocalThing("s.Translation.X", speedParam, offsetXParam, imageWidthParam);
+
+                expressionYVal = LocalThing("s.Translation.Y", speedParam, offsetYParam, imageHeightParam);
             }
 
             if (scrollOrientation == ScrollOrientation.Horizontal || scrollOrientation == ScrollOrientation.Both)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -439,15 +439,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void CreateModuloExpression(ScrollViewer scrollViewer, double imageWidth, double imageHeight, ScrollOrientation scrollOrientation)
         {
             const string propSetParam = "p";
-            const string offsetXParam = "offsetX";
+            const string offsetXParam = nameof(OffsetX);
             const string qualifiedOffsetXParam = propSetParam + "." + offsetXParam;
-            const string offsetYParam = "offsetY";
+            const string offsetYParam = nameof(OffsetY);
             const string qualifiedOffsetYParam = propSetParam + "." + offsetYParam;
-            const string imageWidthParam = "imageWidth";
+            const string imageWidthParam = nameof(imageWidth);
             const string qualifiedImageWidthParam = propSetParam + "." + imageWidthParam;
-            const string imageHeightParam = "imageHeight";
+            const string imageHeightParam = nameof(imageHeight);
             const string qualifiedImageHeightParam = propSetParam + "." + imageHeightParam;
-            const string speedParam = "speed";
+            const string speedParam = nameof(ParallaxSpeedRatio);
 
             if (_containerVisual == null)
             {
@@ -494,6 +494,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset and the ScrollViewer offset (Translation)
                 var scrollProperties = ElementCompositionPreview.GetScrollViewerManipulationPropertySet(scrollViewer);
                 const string scrollParam = "s";
+                const string translationParam = scrollParam + "." + nameof(scrollViewer.Translation);
                 const string qualifiedSpeedParam = propSetParam + "." + speedParam;
 
                 expressionX.SetReferenceParameter(scrollParam, scrollProperties);
@@ -502,9 +503,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 string LocalThing(string scroll, string speed, string offset, string dimension)
                     => Thing(string.Format("Ceil(({0} * {1}) + {2})", scroll, speed, offset), dimension);
 
-                expressionXVal = LocalThing(scrollParam + ".Translation.X", qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
+                expressionXVal = LocalThing(translationParam + "." + nameof(scrollViewer.Translation.X), qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
 
-                expressionYVal = LocalThing(scrollParam + ".Translation.Y", qualifiedSpeedParam, qualifiedOffsetYParam, qualifiedImageHeightParam);
+                expressionYVal = LocalThing(translationParam + "." + nameof(scrollViewer.Translation.Y), qualifiedSpeedParam, qualifiedOffsetYParam, qualifiedImageHeightParam);
             }
 
             if (scrollOrientation == ScrollOrientation.Horizontal || scrollOrientation == ScrollOrientation.Both)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -440,9 +440,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             const string propSetParam = "p";
             const string offsetXParam = "offsetX";
+            const string qualifiedOffsetXParam = propSetParam + "." + offsetXParam;
             const string offsetYParam = "offsetY";
+            const string qualifiedOffsetYParam = propSetParam + "." + offsetYParam;
             const string imageWidthParam = "imageWidth";
+            const string qualifiedImageWidthParam = propSetParam + "." + imageWidthParam;
             const string imageHeightParam = "imageHeight";
+            const string qualifiedImageHeightParam = propSetParam + "." + imageHeightParam;
             const string speedParam = "speed";
 
             if (_containerVisual == null)
@@ -481,24 +485,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (scrollViewer == null)
             {
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset
-                expressionXVal = Thing("Ceil(" + propSetParam + "." + offsetXParam + ")", propSetParam + "." + imageHeightParam);
+                expressionXVal = Thing("Ceil(" + qualifiedOffsetXParam + ")", qualifiedImageHeightParam);
 
-                expressionYVal = Thing("Ceil(" + propSetParam + "." + offsetYParam + ")", propSetParam + "." + imageWidthParam);
+                expressionYVal = Thing("Ceil(" + qualifiedOffsetYParam + ")", qualifiedImageWidthParam);
             }
             else
             {
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset and the ScrollViewer offset (Translation)
                 var scrollProperties = ElementCompositionPreview.GetScrollViewerManipulationPropertySet(scrollViewer);
                 const string scrollParam = "s";
+                const string qualifiedSpeedParam = propSetParam + "." + speedParam;
+
                 expressionX.SetReferenceParameter(scrollParam, scrollProperties);
                 expressionY.SetReferenceParameter(scrollParam, scrollProperties);
 
                 string LocalThing(string scroll, string speed, string offset, string dimention)
                     => Thing(string.Format("Ceil(({0} * {1}) + {2})", scroll, speed, offset), dimention);
 
-                expressionXVal = LocalThing(scrollParam + ".Translation.X", propSetParam + "." + speedParam, propSetParam + "." + offsetXParam, propSetParam + "." + imageWidthParam);
+                expressionXVal = LocalThing(scrollParam + ".Translation.X", qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
 
-                expressionYVal = LocalThing(scrollParam + ".Translation.Y", propSetParam + "." + speedParam, propSetParam + "." + offsetYParam, propSetParam + "." + imageHeightParam);
+                expressionYVal = LocalThing(scrollParam + ".Translation.Y", qualifiedSpeedParam, qualifiedOffsetYParam, qualifiedImageHeightParam);
             }
 
             if (scrollOrientation == ScrollOrientation.Horizontal || scrollOrientation == ScrollOrientation.Both)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             expressionX.SetReferenceParameter(propSetParam, propertySetModulo);
             expressionY.SetReferenceParameter(propSetParam, propertySetModulo);
 
-            string Thing(string common, string diemtion)
+            string Thing(string common, string dimension)
                 => string.Format(
                     "{0} == 0 " +
                     "? 0 " +
@@ -478,7 +478,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         "? -(Abs({0} - (Ceil({0} / {1}) * {1})) % {1}) " +
                         ": -({1} - ({0} % {1}))",
                     common,
-                    diemtion);
+                    dimension);
 
             string expressionXVal;
             string expressionYVal;
@@ -499,8 +499,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 expressionX.SetReferenceParameter(scrollParam, scrollProperties);
                 expressionY.SetReferenceParameter(scrollParam, scrollProperties);
 
-                string LocalThing(string scroll, string speed, string offset, string dimention)
-                    => Thing(string.Format("Ceil(({0} * {1}) + {2})", scroll, speed, offset), dimention);
+                string LocalThing(string scroll, string speed, string offset, string dimension)
+                    => Thing(string.Format("Ceil(({0} * {1}) + {2})", scroll, speed, offset), dimension);
 
                 expressionXVal = LocalThing(scrollParam + ".Translation.X", qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -500,12 +500,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 expressionX.SetReferenceParameter(scrollParam, scrollProperties);
                 expressionY.SetReferenceParameter(scrollParam, scrollProperties);
 
-                string GenerateParalaxFormula(string scrollTranslation, string speed, string offset, string dimension)
+                string GenerateParallaxFormula(string scrollTranslation, string speed, string offset, string dimension)
                     => GenerateFormula(string.Format("Ceil(({0} * {1}) + {2})", scrollTranslation, speed, offset), dimension);
 
-                expressionXVal = GenerateParalaxFormula(translationParam + "." + nameof(scrollViewer.Translation.X), qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
+                expressionXVal = GenerateParallaxFormula(translationParam + "." + nameof(scrollViewer.Translation.X), qualifiedSpeedParam, qualifiedOffsetXParam, qualifiedImageWidthParam);
 
-                expressionYVal = GenerateParalaxFormula(translationParam + "." + nameof(scrollViewer.Translation.Y), qualifiedSpeedParam, qualifiedOffsetYParam, qualifiedImageHeightParam);
+                expressionYVal = GenerateParallaxFormula(translationParam + "." + nameof(scrollViewer.Translation.Y), qualifiedSpeedParam, qualifiedOffsetYParam, qualifiedImageHeightParam);
             }
 
             if (scrollOrientation == ScrollOrientation.Horizontal || scrollOrientation == ScrollOrientation.Both)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -438,12 +438,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <param name="scrollOrientation">The ScrollOrientation</param>
         private void CreateModuloExpression(ScrollViewer scrollViewer, double imageWidth, double imageHeight, ScrollOrientation scrollOrientation)
         {
-            const string pParam = "p";
-            const string offsetXParam = pParam + ".offsetX";
-            const string offsetYParam = pParam + ".offsetY";
-            const string imageWidthParam = pParam + ".imageWidth";
-            const string imageHeightParam = pParam + ".imageHeight";
-            const string speedParam = pParam + ".speed";
+            const string propSetParam = "p";
+            const string offsetXParam = "offsetX";
+            const string offsetYParam = "offsetY";
+            const string imageWidthParam = "imageWidth";
+            const string imageHeightParam = "imageHeight";
+            const string speedParam = "speed";
 
             if (_containerVisual == null)
             {
@@ -457,14 +457,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var expressionY = compositor.CreateExpressionAnimation();
 
             var propertySetModulo = compositor.CreatePropertySet();
-            propertySetModulo.InsertScalar("imageHeight", (float)imageWidth);
-            propertySetModulo.InsertScalar("offsetX", (float)OffsetX);
-            propertySetModulo.InsertScalar("imageWidth", (float)imageHeight);
-            propertySetModulo.InsertScalar("offsetY", (float)OffsetY);
-            propertySetModulo.InsertScalar("speed", (float)ParallaxSpeedRatio);
+            propertySetModulo.InsertScalar(imageHeightParam, (float)imageWidth);
+            propertySetModulo.InsertScalar(offsetXParam, (float)OffsetX);
+            propertySetModulo.InsertScalar(imageWidthParam, (float)imageHeight);
+            propertySetModulo.InsertScalar(offsetYParam, (float)OffsetY);
+            propertySetModulo.InsertScalar(speedParam, (float)ParallaxSpeedRatio);
 
-            expressionX.SetReferenceParameter(pParam, propertySetModulo);
-            expressionY.SetReferenceParameter(pParam, propertySetModulo);
+            expressionX.SetReferenceParameter(propSetParam, propertySetModulo);
+            expressionY.SetReferenceParameter(propSetParam, propertySetModulo);
 
             string Thing(string common, string diemtion)
                 => string.Format(
@@ -481,23 +481,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (scrollViewer == null)
             {
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset
-                expressionXVal = Thing("Ceil(" + offsetXParam + ")", imageHeightParam);
+                expressionXVal = Thing("Ceil(" + propSetParam + "." + offsetXParam + ")", propSetParam + "." + imageHeightParam);
 
-                expressionYVal = Thing("Ceil(" + offsetYParam + ")", imageWidthParam);
+                expressionYVal = Thing("Ceil(" + propSetParam + "." + offsetYParam + ")", propSetParam + "." + imageWidthParam);
             }
             else
             {
                 // expressions are created to simulate a positive and negative modulo with the size of the image and the offset and the ScrollViewer offset (Translation)
                 var scrollProperties = ElementCompositionPreview.GetScrollViewerManipulationPropertySet(scrollViewer);
-                expressionX.SetReferenceParameter("s", scrollProperties);
-                expressionY.SetReferenceParameter("s", scrollProperties);
+                const string scrollParam = "s";
+                expressionX.SetReferenceParameter(scrollParam, scrollProperties);
+                expressionY.SetReferenceParameter(scrollParam, scrollProperties);
 
                 string LocalThing(string scroll, string speed, string offset, string dimention)
                     => Thing(string.Format("Ceil(({0} * {1}) + {2})", scroll, speed, offset), dimention);
 
-                expressionXVal = LocalThing("s.Translation.X", speedParam, offsetXParam, imageWidthParam);
+                expressionXVal = LocalThing(scrollParam + ".Translation.X", propSetParam + "." + speedParam, propSetParam + "." + offsetXParam, propSetParam + "." + imageWidthParam);
 
-                expressionYVal = LocalThing("s.Translation.Y", speedParam, offsetYParam, imageHeightParam);
+                expressionYVal = LocalThing(scrollParam + ".Translation.Y", propSetParam + "." + speedParam, propSetParam + "." + offsetYParam, propSetParam + "." + imageHeightParam);
             }
 
             if (scrollOrientation == ScrollOrientation.Horizontal || scrollOrientation == ScrollOrientation.Both)


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

<!-- Add a brief overview here of the feature/bug & fix. -->
Sept towards #3578.

Remove the `TileControl`'s usage of the `Animations.Expressions` ns and thus the animations package.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`TileControl`'s uses `Animations.Expressions` to build expression animation.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
`TileControl`'s uses strings to build expression animation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
