### PR TITLE
Fix SmokeTest Projects to Use Version from CI

### DIFF
--- a/SmokeTests/SmokeTest.csproj
+++ b/SmokeTests/SmokeTest.csproj
@@ -6,6 +6,9 @@
     <!-- When writting the SmokeTests, change this to whichever Toolkit project you want to build a test to, then reload the project -->
     <CurrentProject>Microsoft.Toolkit.Uwp.UI.Controls</CurrentProject>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(NuGetPackageVersion)' == ''">
+    <NuGetPackageVersion>To Fill In With Local Version Number</NuGetPackageVersion>
+  </PropertyGroup>
   <!-- - - - - - Don't check-in changes in between this lines. Used for development. - - - - - -->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -112,8 +115,8 @@
       <Version>2.4.3</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(CurrentProject)' != '' and '$(CurrentProject)' != 'UWPBaseline'">
-    <PackageReference Include="$(CurrentProject)" Version="7.*-*" />
+  <ItemGroup Condition="'$(CurrentProject)' != '' and '$(CurrentProject)' != 'UWPBaseline' and '$(NuGetPackageVersion)' != 'To Fill In With Local Version Number'">
+    <PackageReference Include="$(CurrentProject)" Version="$(NuGetPackageVersion)" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
@@ -125,5 +128,6 @@
       <ToolkitNuget Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Identity)', `$(CurrentProject).([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?.nupkg`))" Include="@(ToolkitNugets)"/>
     </ItemGroup>
     <Error Condition="'@(ToolkitNuget)' == '' and $(CurrentProject) != 'UWPBaseline'" Text="NuGet $(CurrentProject).[SEMVER].nupkg doesn't exist!"/>
+    <Error Condition="'$(CurrentProject)' != 'UWPBaseline' and '$(NuGetPackageVersion)' == 'To Fill In With Local Version Number'" Text="Please set NuGetPackageVersion at the top of SmokeTest.csproj with the version to smoke test locally."/>
   </Target>
 </Project>

--- a/SmokeTests/SmokeTest.sln
+++ b/SmokeTests/SmokeTest.sln
@@ -5,6 +5,13 @@ VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmokeTest", "SmokeTest.csproj", "{A6E4CB52-1025-4BBA-9C65-BB871D1FB53F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configuration", "{86F3F991-6DDA-442D-A610-9309D6559522}"
+	ProjectSection(SolutionItems) = preProject
+		nuget.config = nuget.config
+		SmokeTestAnalysis.ps1 = SmokeTestAnalysis.ps1
+		SmokeTests.proj = SmokeTests.proj
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM

--- a/SmokeTests/SmokeTests.proj
+++ b/SmokeTests/SmokeTests.proj
@@ -7,8 +7,18 @@
     <ToolkitPackages>UWPBaseline;Microsoft.Toolkit;Microsoft.Toolkit.HighPerformance;Microsoft.Toolkit.Parsers;Microsoft.Toolkit.Mvvm;Microsoft.Toolkit.Services;Microsoft.Toolkit.Uwp;Microsoft.Toolkit.Uwp.Connectivity;Microsoft.Toolkit.Uwp.DeveloperTools;Microsoft.Toolkit.Uwp.Input.GazeInteraction;Microsoft.Toolkit.Uwp.Notifications;Microsoft.Toolkit.Uwp.UI;Microsoft.Toolkit.Uwp.UI.Animations;Microsoft.Toolkit.Uwp.UI.Controls;Microsoft.Toolkit.Uwp.UI.Controls.DataGrid;Microsoft.Toolkit.Uwp.UI.Controls.Layout;Microsoft.Toolkit.Uwp.UI.Media;Microsoft.Toolkit.Uwp.UI.Controls.Markdown</ToolkitPackages>
   </PropertyGroup>
 
+  <Target Name="GetNuGetVersion">
+    <Exec Command="powershell -Command &quot;&amp; { .\&quot;$(ProjectDir)..\build\tools\Nerdbank.GitVersioning\tools\Get-Version.ps1\&quot; | Select -ExpandProperty NuGetPackageVersion }&quot;"
+          ConsoleToMSBuild="true"
+          EchoOff="true"
+          Condition="'$(NuGetPackageVersion)' == ''">
+      <Output TaskParameter="ConsoleOutput" PropertyName="NuGetPackageVersion" />
+    </Exec>
+    <Message Text="Got GitBank Version... $(NuGetPackageVersion)" Importance="High" />
+  </Target>
+
   <Target Name="Build" 
-          DependsOnTargets="ChooseProjectsToBuild"
+          DependsOnTargets="ChooseProjectsToBuild;GetNuGetVersion"
           Inputs="@(ProjectsToBuild)"
           Outputs="%(Filename)">
 
@@ -16,7 +26,7 @@
 
     <MSBuild Projects="SmokeTest.csproj"
               Targets="restore;build"
-              Properties="CurrentProject=%(ProjectsToBuild.Identity);Configuration=%(ProjectsToBuild.Configuration);Platform=%(ProjectsToBuild.Platform)"/>
+              Properties="CurrentProject=%(ProjectsToBuild.Identity);Configuration=%(ProjectsToBuild.Configuration);Platform=%(ProjectsToBuild.Platform);NuGetPackageVersion=$(NuGetPackageVersion)"/>
   </Target>
 
   <Target Name="ChooseProjectsToBuild" DependsOnTargets="CheckNugets">


### PR DESCRIPTION
## Fixes #3657
Adjusts SmokeTest project and Cake script to pass in the Version of the Toolkit being built to ensure NuGet restores the proper version when building the SmokeTest projects (and used for analysis later).

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
SmokeTests will grab latest from NuGet

## What is the new behavior?
SmokeTests will grab version from CI

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
