### PR TITLE
Fixes #3673 and resolves issues with some samples not working correctly

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
@@ -195,8 +195,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 {
                     try
                     {
-                        var pageInstance = Activator.CreateInstance(CurrentSample.PageType);
-                        SampleContent.Content = pageInstance;
+                        SamplePage = Activator.CreateInstance(CurrentSample.PageType) as Page;
+                        SampleContent.Content = SamplePage;
 
                         // Some samples use the OnNavigatedTo and OnNavigatedFrom
                         // Can't use Frame here because some samples depend on the current Frame
@@ -206,7 +206,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
                         if (method != null)
                         {
-                            method.Invoke(pageInstance, new object[] { e });
+                            method.Invoke(SamplePage, new object[] { e });
                         }
                     }
                     catch
@@ -348,6 +348,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
         private void SamplePage_Loaded(object sender, RoutedEventArgs e)
         {
+            SamplePage.Loaded -= SamplePage_Loaded;
+
             if (CurrentSample != null && CurrentSample.HasXAMLCode)
             {
                 _lastRenderedProperties = true;
@@ -516,17 +518,23 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 if (CurrentSample.HasType)
                 {
                     root = SamplePage?.FindDescendantByName("XamlRoot");
-                }
 
-                if (root is Panel)
-                {
-                    // If we've defined a 'XamlRoot' element to host us as a panel, use that.
-                    (root as Panel).Children.Clear();
-                    (root as Panel).Children.Add(element);
+                    if (root is Panel)
+                    {
+                        // If we've defined a 'XamlRoot' element to host us as a panel, use that.
+                        (root as Panel).Children.Clear();
+                        (root as Panel).Children.Add(element);
+                    }
+                    else
+                    {
+                        // if we didn't find a XamlRoot host, then we replace the entire content of
+                        // the provided sample page with the XAML.
+                        SamplePage.Content = element;
+                    }
                 }
                 else
                 {
-                    // Otherwise, just replace the entire page's content
+                    // Otherwise, just replace our entire presenter's content
                     SampleContent.Content = element;
                 }
 
@@ -675,7 +683,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             }
         }
 
-        private Page SamplePage => SampleContent.Content as Page;
+        // The Loaded Instance of the backing .xaml.cs Page (if any)
+        private Page SamplePage { get; set; }
 
         private bool CanChangePaneState => !_onlyDocumentation;
 


### PR DESCRIPTION
## Fixes #3673

Forgot to check some scenarios in the original update to #3648 and broke scenarios of pages with code-behind. This PR resolves that and forward-fixes all sample types (XAML only, code-behind, code-behind + XamlRoot).

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
If a sample page didn't have a `XamlRoot` defined in it's page it was getting obliterated in the `UpdateXamlRender` call.


## What is the new behavior?
Clearly defined what a `SamplePage` was (to be the backing instance of a sample (if one)). Then used that to instead overwrite it's content as intended if there is no `XamlRoot` instead of the entire page itself.

i.e. the bug was that we were replacing the entire page with the rendered XAML and therefore no longer held an instance to call `IXamlRenderListener` on. This fix now checks for that condition and only updates the inner page content vs. our entire hosted content within the Sample.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

FYI @RosarioPulella, @Kyaa-dost 