### PR TITLE
[Visual|Logical]Tree extensions revamp

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
@@ -517,7 +517,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
                 if (CurrentSample.HasType)
                 {
-                    root = SamplePage?.FindDescendantByName("XamlRoot");
+                    root = SamplePage?.FindDescendant("XamlRoot");
 
                     if (root is Panel)
                     {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public async void OnXamlRendered(FrameworkElement control)
         {
-            _adaptiveGridViewControl = control.FindDescendantByName("AdaptiveGridViewControl") as AdaptiveGridView;
+            _adaptiveGridViewControl = control.FindDescendant("AdaptiveGridViewControl") as AdaptiveGridView;
             if (_adaptiveGridViewControl != null)
             {
                 var allPhotos = await new Data.PhotosDataSource().GetItemsAsync();

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/BladeView/BladePage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/BladeView/BladePage.xaml.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            bladeView = control.FindChildByName("BladeView") as BladeView;
-            addBlade = control.FindChildByName("AddBlade") as Button;
+            bladeView = control.FindChild("BladeView") as BladeView;
+            addBlade = control.FindChild("AddBlade") as Button;
 
             if (addBlade != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/CameraPreview/CameraPreviewPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/CameraPreview/CameraPreviewPage.xaml.cs
@@ -54,14 +54,14 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _cameraPreviewControl.CameraHelper.FrameArrived += CameraPreviewControl_FrameArrived;
             }
 
-            _imageControl = control.FindDescendantByName("CurrentFrameImage") as Image;
+            _imageControl = control.FindDescendant("CurrentFrameImage") as Image;
             if (_imageControl != null)
             {
                 _softwareBitmapSource = new SoftwareBitmapSource();
                 _imageControl.Source = _softwareBitmapSource;
             }
 
-            _errorMessageText = control.FindDescendantByName("ErrorMessage") as TextBlock;
+            _errorMessageText = control.FindDescendant("ErrorMessage") as TextBlock;
 
             semaphoreSlim.Release();
         }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Carousel/CarouselPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Carousel/CarouselPage.xaml.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public async void OnXamlRendered(FrameworkElement control)
         {
-            carouselControl = control.FindDescendantByName("CarouselControl") as Carousel;
+            carouselControl = control.FindDescendant("CarouselControl") as Carousel;
             carouselControl.ItemsSource = await new Data.PhotosDataSource().GetItemsAsync();
         }
     }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DataGrid/DataGridPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DataGrid/DataGridPage.xaml.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 dataGrid.LoadingRowGroup -= DataGrid_LoadingRowGroup;
             }
 
-            dataGrid = control.FindDescendantByName("dataGrid") as DataGrid;
+            dataGrid = control.FindDescendant("dataGrid") as DataGrid;
             if (dataGrid != null)
             {
                 dataGrid.Sorting += DataGrid_Sorting;
@@ -54,7 +54,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 groupButton.Click -= GroupButton_Click;
             }
 
-            groupButton = control.FindDescendantByName("groupButton") as AppBarButton;
+            groupButton = control.FindDescendant("groupButton") as AppBarButton;
             if (groupButton != null)
             {
                 groupButton.Click += GroupButton_Click;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DockPanel/DockPanelPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DockPanel/DockPanelPage.xaml.cs
@@ -9,7 +9,6 @@ using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 {
@@ -29,7 +28,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            _sampleDockPanel = control.FindChildByName("SampleDockPanel") as DockPanel;
+            _sampleDockPanel = control.FindChild("SampleDockPanel") as DockPanel;
         }
 
         private void Load()

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/FadeHeader/FadeHeaderBehaviorPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/FadeHeader/FadeHeaderBehaviorPage.xaml.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            myListView = control.FindChildByName("MyListView") as ListView;
+            myListView = control.FindChild("MyListView") as ListView;
 
             // Load the ListView with Sample Data
             if (myListView != null)

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GazeInteraction/GazeInteractionPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GazeInteraction/GazeInteractionPage.xaml.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.Toolkit.Uwp.Input.GazeInteraction;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Shapes;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 {
@@ -33,7 +31,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
             WarnUserToPlugInDevice();
 
-            var buttonControl = control.FindChildByName("TargetButton") as Button;
+            var buttonControl = control.FindChild("TargetButton") as Button;
 
             if (buttonControl != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GazeTracing/GazeTracingPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GazeTracing/GazeTracingPage.xaml.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            if (control.FindChildByName("Points") is ItemsControl itemsControl)
+            if (control.FindChild("Points") is ItemsControl itemsControl)
             {
                 itemsControl.ItemsSource = GazeHistory;
             }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/HeaderedItemsControl/HeaderedItemsControlPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/HeaderedItemsControl/HeaderedItemsControlPage.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.UI.Xaml;
@@ -26,7 +27,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement element)
         {
-            foreach (var control in element.FindChildren<HeaderedItemsControl>())
+            foreach (var control in element.FindChildren().OfType<HeaderedItemsControl>())
             {
                 control.DataContext = this;
             }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageCache/ImageCachePage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageCache/ImageCachePage.xaml.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            photoList = control.FindChildByName("PhotoList") as ListView;
+            photoList = control.FindChild("PhotoList") as ListView;
         }
 
         private async void Load()

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageCropper/ImageCropperPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageCropper/ImageCropperPage.xaml.cs
@@ -4,12 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
-using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.UI.Xaml;
@@ -35,7 +32,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public async void OnXamlRendered(FrameworkElement control)
         {
-            _imageCropper = control.FindChildByName("ImageCropper") as ImageCropper;
+            _imageCropper = control.FindChild("ImageCropper") as ImageCropper;
             if (_imageCropper != null)
             {
                 var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/Photos/Owl.jpg"));

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public void OnXamlRendered(FrameworkElement control)
         {
             // Need to use logical tree here as scrollviewer hasn't initialized yet even with dispatch.
-            container = control.FindChildByName("Container") as StackPanel;
+            container = control.FindChild("Container") as StackPanel;
             resources = control.Resources;
-            lazyLoadingControlHost = control.FindChildByName("LazyLoadingControlHost") as Border;
+            lazyLoadingControlHost = control.FindChild("LazyLoadingControlHost") as Border;
         }
 
         private async void Load()

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Implicit Animations/ImplicitAnimationsPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Implicit Animations/ImplicitAnimationsPage.xaml.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            _element = control.FindChildByName("Element");
+            _element = control.FindChild("Element");
         }
 
         private void Load()

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationPage.xaml.cs
@@ -35,14 +35,14 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             NotificationDuration = 0;
 
-            _exampleInAppNotification = control.FindChildByName("ExampleInAppNotification") as InAppNotification;
+            _exampleInAppNotification = control.FindChild("ExampleInAppNotification") as InAppNotification;
             _defaultInAppNotificationControlTemplate = _exampleInAppNotification?.Template;
-            _exampleCustomInAppNotification = control.FindChildByName("ExampleCustomInAppNotification") as InAppNotification;
+            _exampleCustomInAppNotification = control.FindChild("ExampleCustomInAppNotification") as InAppNotification;
             _customInAppNotificationControlTemplate = _exampleCustomInAppNotification?.Template;
-            _exampleVSCodeInAppNotification = control.FindChildByName("ExampleVSCodeInAppNotification") as InAppNotification;
+            _exampleVSCodeInAppNotification = control.FindChild("ExampleVSCodeInAppNotification") as InAppNotification;
             _resources = control.Resources;
 
-            var notificationDurationTextBox = control.FindChildByName("NotificationDurationTextBox") as TextBox;
+            var notificationDurationTextBox = control.FindChild("NotificationDurationTextBox") as TextBox;
             if (notificationDurationTextBox != null)
             {
                 notificationDurationTextBox.TextChanged += NotificationDurationTextBox_TextChanged;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InfiniteCanvas/InfiniteCanvasPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InfiniteCanvas/InfiniteCanvasPage.xaml.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            _infiniteCanvas = control.FindChildByName("canvas") as InfiniteCanvas;
+            _infiniteCanvas = control.FindChild("canvas") as InfiniteCanvas;
         }
 
         private void Load()

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ItemsReorderAnimation/ItemsReorderAnimationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ItemsReorderAnimation/ItemsReorderAnimationPage.xaml.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public async void OnXamlRendered(FrameworkElement control)
         {
-            imageView = control.FindChildByName("ImageView") as GridView;
+            imageView = control.FindChild("ImageView") as GridView;
 
             if (imageView != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListViewExtensions/ListViewExtensionsPage.xaml.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public async void OnXamlRendered(FrameworkElement control)
         {
-            var sampleListView = control.FindChildByName("SampleListView") as ListView;
+            var sampleListView = control.FindChild("SampleListView") as ListView;
 
             if (sampleListView != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Loading/LoadingPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Loading/LoadingPage.xaml.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public async void OnXamlRendered(FrameworkElement control)
         {
-            loadingControl = control.FindDescendantByName("LoadingControl") as Loading;
+            loadingControl = control.FindDescendant("LoadingControl") as Loading;
             loadingContentControl = control.FindChildByName("LoadingContentControl") as ContentControl;
             resources = control.Resources;
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Loading/LoadingPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Loading/LoadingPage.xaml.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public async void OnXamlRendered(FrameworkElement control)
         {
             loadingControl = control.FindDescendant("LoadingControl") as Loading;
-            loadingContentControl = control.FindChildByName("LoadingContentControl") as ContentControl;
+            loadingContentControl = control.FindChild("LoadingContentControl") as ContentControl;
             resources = control.Resources;
 
-            if (control.FindChildByName("AdaptiveGridViewControl") is AdaptiveGridView gridView)
+            if (control.FindChild("AdaptiveGridViewControl") is AdaptiveGridView gridView)
             {
                 gridView.ItemsSource = await new Data.PhotosDataSource().GetItemsAsync();
             }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MarkdownTextBlock/MarkdownTextBlockPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MarkdownTextBlock/MarkdownTextBlockPage.xaml.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            unformattedText = control.FindChildByName("UnformattedText") as TextBox;
+            unformattedText = control.FindChild("UnformattedText") as TextBox;
 
-            markdownText = control.FindChildByName("MarkdownText") as MarkdownTextBlock;
+            markdownText = control.FindChild("MarkdownText") as MarkdownTextBlock;
 
             if (markdownText != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Menu/MenuPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Menu/MenuPage.xaml.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            fileMenu = control.FindChildByName("FileMenu") as MenuItem;
+            fileMenu = control.FindChild("FileMenu") as MenuItem;
         }
         #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/OrbitView/OrbitViewPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/OrbitView/OrbitViewPage.xaml.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var people = control.FindChildByName("People") as OrbitView;
+            var people = control.FindChild("People") as OrbitView;
             if (people != null)
             {
                 people.ItemClick += People_ItemClick;
             }
 
-            var devices = control.FindChildByName("Devices") as OrbitView;
+            var devices = control.FindChild("Devices") as OrbitView;
             if (devices != null)
             {
                 devices.ItemsSource = DeviceList;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml.cs
@@ -10,7 +10,6 @@ using Windows.Graphics.Printing;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 {
@@ -40,7 +39,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var listView = control.FindChildByName("PrintSampleListView") as ListView;
+            var listView = control.FindChild("PrintSampleListView") as ListView;
             if (listView == null)
             {
                 customPrintTemplate = null;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RotatorTile/RotatorTilePage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RotatorTile/RotatorTilePage.xaml.cs
@@ -22,28 +22,28 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var tile1 = control.FindChildByName("Tile1") as RotatorTile;
+            var tile1 = control.FindChild("Tile1") as RotatorTile;
 
             if (tile1 != null)
             {
                 tile1.ItemsSource = _pictures;
             }
 
-            var tile2 = control.FindChildByName("Tile2") as RotatorTile;
+            var tile2 = control.FindChild("Tile2") as RotatorTile;
 
             if (tile2 != null)
             {
                 tile2.ItemsSource = _pictures;
             }
 
-            var tile3 = control.FindChildByName("Tile3") as RotatorTile;
+            var tile3 = control.FindChild("Tile3") as RotatorTile;
 
             if (tile3 != null)
             {
                 tile3.ItemsSource = _pictures;
             }
 
-            var tile4 = control.FindChildByName("Tile4") as RotatorTile;
+            var tile4 = control.FindChild("Tile4") as RotatorTile;
 
             if (tile4 != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ScrollHeader/ScrollHeaderPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ScrollHeader/ScrollHeaderPage.xaml.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var listView = control.FindChildByName("listView") as ListView;
+            var listView = control.FindChild("listView") as ListView;
             if (listView != null)
             {
                 listView.ItemsSource = _items;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ScrollViewerExtensions/ScrollViewerExtensionsPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ScrollViewerExtensions/ScrollViewerExtensionsPage.xaml.cs
@@ -30,12 +30,12 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var listView = control.FindChildByName("listView") as ListView;
+            var listView = control.FindChild("listView") as ListView;
             if (listView != null)
             {
                 listView.ItemsSource = _items;
 
-                var shapesPanel = control.FindChildByName("shapesPanel") as StackPanel;
+                var shapesPanel = control.FindChild("shapesPanel") as StackPanel;
                 if (shapesPanel != null)
                 {
                     var listScrollViewer = listView.FindDescendant<ScrollViewer>();

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/StaggeredLayout/StaggeredLayoutPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/StaggeredLayout/StaggeredLayoutPage.xaml.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var repeater = control.FindDescendantByName("StaggeredRepeater") as ItemsRepeater;
+            var repeater = control.FindDescendant("StaggeredRepeater") as ItemsRepeater;
 
             if (repeater != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/StaggeredPanel/StaggeredPanelPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/StaggeredPanel/StaggeredPanelPage.xaml.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public async void OnXamlRendered(FrameworkElement control)
         {
-            var gridView = control.FindChildByName("GridView") as ItemsControl;
+            var gridView = control.FindChild("GridView") as ItemsControl;
 
             if (gridView == null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMaskPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMaskPage.xaml.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            alphaTextBox = control.FindChildByName("AlphaTextBox") as TextBox;
+            alphaTextBox = control.FindChild("AlphaTextBox") as TextBox;
         }
 
         private void Load()

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextToolbar/TextToolbarPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextToolbar/TextToolbarPage.xaml.cs
@@ -28,14 +28,14 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            _toolbar = control.FindChildByName("Toolbar") as TextToolbar;
+            _toolbar = control.FindChild("Toolbar") as TextToolbar;
 
-            if (control.FindChildByName("EditZone") is RichEditBox editZone)
+            if (control.FindChild("EditZone") is RichEditBox editZone)
             {
                 editZone.TextChanged += EditZone_TextChanged;
             }
 
-            if (control.FindChildByName("Previewer") is MarkdownTextBlock previewer)
+            if (control.FindChild("Previewer") is MarkdownTextBlock previewer)
             {
                 _previewer = previewer;
                 _previewer.LinkClicked += Previewer_LinkClicked;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TokenizingTextBox/TokenizingTextBoxPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TokenizingTextBox/TokenizingTextBoxPage.xaml.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _ttb.TokenItemAdding -= TokenItemCreating;
             }
 
-            if (control.FindChildByName("TokenBox") is TokenizingTextBox ttb)
+            if (control.FindChild("TokenBox") is TokenizingTextBox ttb)
             {
                 _ttb = ttb;
                 _ttb.TokenItemAdded += TokenItemAdded;
@@ -147,7 +147,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _ttbEmail.PreviewKeyDown -= EmailPreviewKeyDown;
             }
 
-            if (control.FindChildByName("TokenBoxEmail") is TokenizingTextBox ttbEmail)
+            if (control.FindChild("TokenBoxEmail") is TokenizingTextBox ttbEmail)
             {
                 _ttbEmail = ttbEmail;
 
@@ -168,7 +168,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _ttbEmailSuggestions.PreviewKeyDown -= EmailList_PreviewKeyDown;
             }
 
-            if (control.FindChildByName("EmailList") is ListView ttbList)
+            if (control.FindChild("EmailList") is ListView ttbList)
             {
                 _ttbEmailSuggestions = ttbList;
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Triggers/IsNullOrEmptyStateTriggerPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Triggers/IsNullOrEmptyStateTriggerPage.xaml.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _addButton.Click -= this.AddButton_Click;
             }
 
-            if (control.FindDescendantByName("AddButton") is Button btn)
+            if (control.FindDescendant("AddButton") is Button btn)
             {
                 _addButton = btn;
 
@@ -44,14 +44,14 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _removeButton.Click -= this.RemoveButton_Click;
             }
 
-            if (control.FindDescendantByName("RemoveButton") is Button btn2)
+            if (control.FindDescendant("RemoveButton") is Button btn2)
             {
                 _removeButton = btn2;
 
                 _removeButton.Click += this.RemoveButton_Click;
             }
 
-            _listBox = control.FindDescendantByName("OurList") as ListBox;
+            _listBox = control.FindDescendant("OurList") as ListBox;
         }
 
         private void AddButton_Click(object sender, RoutedEventArgs e)

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ViewportBehavior/ViewportBehaviorPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ViewportBehavior/ViewportBehaviorPage.xaml.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            if (control.FindChildByName("EffectElement") is Image effectElement)
+            if (control.FindChild("EffectElement") is Image effectElement)
             {
                 _effectElement = effectElement;
                 ////TODO: _effectElement.Blur(value: 10, duration: 0).Start();
             }
 
-            if (control.FindChildByName("EffectElementHost") is FrameworkElement effectElementHost)
+            if (control.FindChild("EffectElementHost") is FrameworkElement effectElementHost)
             {
                 var behaviors = Interaction.GetBehaviors(effectElementHost);
                 var viewportBehavior = behaviors.OfType<ViewportBehavior>().FirstOrDefault();

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapLayout/WrapLayoutPage.xaml.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            var repeater = control.FindDescendantByName("WrapRepeater") as ItemsRepeater;
+            var repeater = control.FindDescendant("WrapRepeater") as ItemsRepeater;
 
             if (repeater != null)
             {
@@ -48,7 +48,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 _wrapLayout = repeater.Layout as WrapLayout;
             }
 
-            _wrapScrollParent = control.FindDescendantByName("WrapScrollParent") as ScrollViewer;
+            _wrapScrollParent = control.FindDescendant("WrapScrollParent") as ScrollViewer;
         }
 
         private class Item

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapPanel/WrapPanelPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WrapPanel/WrapPanelPage.xaml.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         public void OnXamlRendered(FrameworkElement control)
         {
-            _itemControl = control.FindChildByName("WrapPanelContainer") as ListView;
+            _itemControl = control.FindChild("WrapPanelContainer") as ListView;
 
             if (_itemControl != null)
             {

--- a/Microsoft.Toolkit.Uwp.SampleApp/readme.md
+++ b/Microsoft.Toolkit.Uwp.SampleApp/readme.md
@@ -95,7 +95,7 @@ Therefore, for any new control/extension, you should still have a simplified sni
 This gets called whenever the template gets parsed (due to loading or user modification).   Here you can use the [LogicalTree](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs) extensions to grab named controls in the template and register their events.  **Check for null first** as the developer may have removed the name from the element.
 
 ```csharp
-var markdownText = control.FindChildByName("MarkdownText") as MarkdownTextBlock;
+var markdownText = control.FindChild("MarkdownText") as MarkdownTextBlock;
 if (markdownText != null)
 {
     markdownText.LinkClicked += MarkdownText_LinkClicked;

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             //
             // To combat this issue:
             //   We toggle the visibility of the Placeholder ContentControl in order to force it's layout to update properly
-            var placeholder = ContainerFromItem(_lastTextEdit).FindDescendant("PlaceholderTextContentPresenter");
+            var placeholder = ContainerFromItem(_lastTextEdit)?.FindDescendant("PlaceholderTextContentPresenter");
 
             if (placeholder?.Visibility == Visibility.Visible)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBox.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             //
             // To combat this issue:
             //   We toggle the visibility of the Placeholder ContentControl in order to force it's layout to update properly
-            var placeholder = ContainerFromItem(_lastTextEdit).FindDescendantByName("PlaceholderTextContentPresenter");
+            var placeholder = ContainerFromItem(_lastTextEdit).FindDescendant("PlaceholderTextContentPresenter");
 
             if (placeholder?.Visibility == Visibility.Visible)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
@@ -105,15 +105,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     {
                         // This can be expensive, could we optimize?
                         // Also, this is changing the FontSize on the IconSource (which could be shared?)
-                        if (Owner.TryFindResource("TokenizingTextBoxIconFontSize", out object resource) &&
-                            resource is double fontSize)
-                        {
-                            fis.FontSize = fontSize;
-                        }
-                        else
-                        {
-                            fis.FontSize = 16;
-                        }
+                        fis.FontSize = Owner.TryFindResource("TokenizingTextBoxIconFontSize") as double? ?? 16;
                     }
 
                     var iconBinding = new Binding()

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/TokenizingTextBox/TokenizingTextBoxItem.AutoSuggestBox.cs
@@ -5,10 +5,8 @@
 using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.Foundation;
 using Windows.System;
-using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 
@@ -107,7 +105,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     {
                         // This can be expensive, could we optimize?
                         // Also, this is changing the FontSize on the IconSource (which could be shared?)
-                        fis.FontSize = Owner.TryFindResource("TokenizingTextBoxIconFontSize") as double? ?? 16;
+                        if (Owner.TryFindResource("TokenizingTextBoxIconFontSize", out object resource) &&
+                            resource is double fontSize)
+                        {
+                            fis.FontSize = fontSize;
+                        }
+                        else
+                        {
+                            fis.FontSize = 16;
+                        }
                     }
 
                     var iconBinding = new Binding()

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ScrollViewer/ScrollViewerExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ScrollViewer/ScrollViewerExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             var scrollViewer = sender as ScrollViewer ?? sender.FindDescendant<ScrollViewer>();
 
             // Last scrollbar with "HorizontalScrollBar" as name is our target to set its margin and avoid it overlapping the header
-            var scrollBar = scrollViewer?.FindDescendants<ScrollBar>().LastOrDefault(bar => bar.Name == "HorizontalScrollBar");
+            var scrollBar = scrollViewer?.FindDescendants().OfType<ScrollBar>().LastOrDefault(bar => bar.Name == "HorizontalScrollBar");
 
             if (scrollBar == null)
             {
@@ -99,7 +99,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             var scrollViewer = sender as ScrollViewer ?? sender.FindDescendant<ScrollViewer>();
 
             // Last scrollbar with "HorizontalScrollBar" as name is our target to set its margin and avoid it overlapping the header
-            var scrollBar = scrollViewer?.FindDescendants<ScrollBar>().LastOrDefault(bar => bar.Name == "VerticalScrollBar");
+            var scrollBar = scrollViewer?.FindDescendants().OfType<ScrollBar>().LastOrDefault(bar => bar.Name == "VerticalScrollBar");
 
             if (scrollBar == null)
             {

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -153,20 +153,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     }
                 }
             }
-            else if (element is UserControl userControl)
-            {
-                if (userControl.Content is T result && predicate.Match(result))
-                {
-                    return result;
-                }
-
-                if (userControl.Content is FrameworkElement content)
-                {
-                    element = content;
-
-                    goto Start;
-                }
-            }
             else if (element is ContentControl contentControl)
             {
                 if (contentControl.Content is T result && predicate.Match(result))
@@ -191,6 +177,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                 if (border.Child is FrameworkElement child)
                 {
                     element = child;
+
+                    goto Start;
+                }
+            }
+            else if (element is UserControl userControl)
+            {
+                // We put UserControl right before the slower reflection fallback path as
+                // this type is less likely to be used compared to the other ones above.
+                if (userControl.Content is T result && predicate.Match(result))
+                {
+                    return result;
+                }
+
+                if (userControl.Content is FrameworkElement content)
+                {
+                    element = content;
 
                     goto Start;
                 }
@@ -348,17 +350,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     }
                 }
             }
-            else if (element is UserControl userControl)
-            {
-                if (userControl.Content is FrameworkElement content)
-                {
-                    yield return content;
-
-                    element = content;
-
-                    goto Start;
-                }
-            }
             else if (element is ContentControl contentControl)
             {
                 if (contentControl.Content is FrameworkElement content)
@@ -377,6 +368,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     yield return child;
 
                     element = child;
+
+                    goto Start;
+                }
+            }
+            else if (element is UserControl userControl)
+            {
+                if (userControl.Content is FrameworkElement content)
+                {
+                    yield return content;
+
+                    element = content;
 
                     goto Start;
                 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -194,6 +194,94 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         }
 
         /// <summary>
+        /// Find the first child (or self) of type <see cref="FrameworkElement"/> with a given name, using a depth-first search.
+        /// </summary>
+        /// <param name="element">The root element.</param>
+        /// <param name="name">The name of the element to look for.</param>
+        /// <param name="comparisonType">The comparison type to use to match <paramref name="name"/>.</param>
+        /// <returns>The child (or self) that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindChildOrSelf(this FrameworkElement element, string name, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            if (name.Equals(element.Name, comparisonType))
+            {
+                return element;
+            }
+
+            return FindChild(element, name, comparisonType);
+        }
+
+        /// <summary>
+        /// Find the first child (or self) element of a given type, using a depth-first search.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The root element.</param>
+        /// <returns>The child (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindChildOrSelf<T>(this FrameworkElement element)
+            where T : notnull, FrameworkElement
+        {
+            if (element is T result)
+            {
+                return result;
+            }
+
+            return FindChild<T>(element);
+        }
+
+        /// <summary>
+        /// Find the first child (or self) element of a given type, using a depth-first search.
+        /// </summary>
+        /// <param name="element">The root element.</param>
+        /// <param name="type">The type of element to match.</param>
+        /// <returns>The child (or self) that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindChildOrSelf(this FrameworkElement element, Type type)
+        {
+            if (element.GetType() == type)
+            {
+                return element;
+            }
+
+            return FindChild(element, type);
+        }
+
+        /// <summary>
+        /// Find the first child (or self) element matching a given predicate, using a depth-first search.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The root element.</param>
+        /// <param name="predicate">The predicatee to use to match the child nodes.</param>
+        /// <returns>The child (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindChildOrSelf<T>(this FrameworkElement element, Func<T, bool> predicate)
+            where T : notnull, FrameworkElement
+        {
+            if (element is T result && predicate(result))
+            {
+                return result;
+            }
+
+            return FindChild(element, predicate);
+        }
+
+        /// <summary>
+        /// Find the first child (or self) element matching a given predicate, using a depth-first search.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <typeparam name="TState">The type of state to use when matching nodes.</typeparam>
+        /// <param name="element">The root element.</param>
+        /// <param name="state">The state to give as input to <paramref name="predicate"/>.</param>
+        /// <param name="predicate">The predicatee to use to match the child nodes.</param>
+        /// <returns>The child (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindChildOrSelf<T, TState>(this FrameworkElement element, TState state, Func<T, TState, bool> predicate)
+            where T : notnull, FrameworkElement
+        {
+            if (element is T result && predicate(result, state))
+            {
+                return result;
+            }
+
+            return FindChild(element, state, predicate);
+        }
+
+        /// <summary>
         /// Find all logical child controls of the specified type.
         /// </summary>
         /// <typeparam name="T">Type to search for.</typeparam>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -110,14 +110,50 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     }
                 }
             }
-            else if (element.GetContentControl() is FrameworkElement contentControl)
+            else if (element is UserControl userControl)
             {
-                if (contentControl is T result && predicate(result))
+                if (userControl.Content is T result && predicate(result))
                 {
                     return result;
                 }
 
-                return FindChild(contentControl, predicate);
+                if (userControl.Content is FrameworkElement content)
+                {
+                    return FindChild(content, predicate);
+                }
+            }
+            else if (element is ContentControl contentControl)
+            {
+                if (contentControl.Content is T result && predicate(result))
+                {
+                    return result;
+                }
+
+                if (contentControl.Content is FrameworkElement content)
+                {
+                    return FindChild(content, predicate);
+                }
+            }
+            else if (element is Border border)
+            {
+                if (border.Child is T result && predicate(result))
+                {
+                    return result;
+                }
+
+                if (border.Child is FrameworkElement child)
+                {
+                    return FindChild(child, predicate);
+                }
+            }
+            else if (element.GetContentControl() is FrameworkElement containedControl)
+            {
+                if (containedControl is T result && predicate(result))
+                {
+                    return result;
+                }
+
+                return FindChild(containedControl, predicate);
             }
 
             return null;
@@ -179,14 +215,50 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     }
                 }
             }
-            else if (element.GetContentControl() is FrameworkElement contentControl)
+            else if (element is UserControl userControl)
             {
-                if (contentControl is T result && predicate(result, state))
+                if (userControl.Content is T result && predicate(result, state))
                 {
                     return result;
                 }
 
-                return FindChild(contentControl, state, predicate);
+                if (userControl.Content is FrameworkElement content)
+                {
+                    return FindChild(content, state, predicate);
+                }
+            }
+            else if (element is ContentControl contentControl)
+            {
+                if (contentControl.Content is T result && predicate(result, state))
+                {
+                    return result;
+                }
+
+                if (contentControl.Content is FrameworkElement content)
+                {
+                    return FindChild(content, state, predicate);
+                }
+            }
+            else if (element is Border border)
+            {
+                if (border.Child is T result && predicate(result, state))
+                {
+                    return result;
+                }
+
+                if (border.Child is FrameworkElement child)
+                {
+                    return FindChild(child, state, predicate);
+                }
+            }
+            else if (element.GetContentControl() is FrameworkElement containedControl)
+            {
+                if (containedControl is T result && predicate(result, state))
+                {
+                    return result;
+                }
+
+                return FindChild(containedControl, state, predicate);
             }
 
             return null;
@@ -328,11 +400,47 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     }
                 }
             }
-            else if (element.GetContentControl() is FrameworkElement contentControl)
+            else if (element is UserControl userControl)
             {
-                yield return contentControl;
+                if (userControl.Content is FrameworkElement content)
+                {
+                    yield return content;
 
-                foreach (FrameworkElement childOfChild in FindChildren(contentControl))
+                    foreach (FrameworkElement childOfContent in FindChildren(content))
+                    {
+                        yield return childOfContent;
+                    }
+                }
+            }
+            else if (element is ContentControl contentControl)
+            {
+                if (contentControl.Content is FrameworkElement content)
+                {
+                    yield return content;
+
+                    foreach (FrameworkElement childOfContent in FindChildren(content))
+                    {
+                        yield return childOfContent;
+                    }
+                }
+            }
+            else if (element is Border border)
+            {
+                if (border.Child is FrameworkElement child)
+                {
+                    yield return child;
+
+                    foreach (FrameworkElement childOfChild in FindChildren(child))
+                    {
+                        yield return childOfChild;
+                    }
+                }
+            }
+            else if (element.GetContentControl() is FrameworkElement containedControl)
+            {
+                yield return containedControl;
+
+                foreach (FrameworkElement childOfChild in FindChildren(containedControl))
                 {
                     yield return childOfChild;
                 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -355,5 +355,93 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                 element = parent;
             }
         }
+
+        /// <summary>
+        /// Find the first parent (or self) of type <see cref="FrameworkElement"/> with a given name.
+        /// </summary>
+        /// <param name="element">The starting element.</param>
+        /// <param name="name">The name of the element to look for.</param>
+        /// <param name="comparisonType">The comparison type to use to match <paramref name="name"/>.</param>
+        /// <returns>The parent (or self) that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindParentOrSelf(this FrameworkElement element, string name, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            if (name.Equals(element.Name, comparisonType))
+            {
+                return element;
+            }
+
+            return FindParent(element, name, comparisonType);
+        }
+
+        /// <summary>
+        /// Find the first parent (or self) element of a given type.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <returns>The parent (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindParentOrSelf<T>(this FrameworkElement element)
+            where T : notnull, FrameworkElement
+        {
+            if (element is T result)
+            {
+                return result;
+            }
+
+            return FindParent<T>(element);
+        }
+
+        /// <summary>
+        /// Find the first parent (or self) element of a given type.
+        /// </summary>
+        /// <param name="element">The starting element.</param>
+        /// <param name="type">The type of element to match.</param>
+        /// <returns>The parent (or self) that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindParentOrSelf(this FrameworkElement element, Type type)
+        {
+            if (element.GetType() == type)
+            {
+                return element;
+            }
+
+            return FindParent(element, type);
+        }
+
+        /// <summary>
+        /// Find the first parent (or self) element matching a given predicate.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <param name="predicate">The predicatee to use to match the parent nodes.</param>
+        /// <returns>The parent (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindParentOrSelf<T>(this FrameworkElement element, Func<T, bool> predicate)
+            where T : notnull, FrameworkElement
+        {
+            if (element is T result && predicate(result))
+            {
+                return result;
+            }
+
+            return FindParent(element, predicate);
+        }
+
+        /// <summary>
+        /// Find the first parent (or self) element matching a given predicate.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <typeparam name="TState">The type of state to use when matching nodes.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <param name="state">The state to give as input to <paramref name="predicate"/>.</param>
+        /// <param name="predicate">The predicatee to use to match the parent nodes.</param>
+        /// <returns>The parent (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindParentOrSelf<T, TState>(this FrameworkElement element, TState state, Func<T, TState, bool> predicate)
+            where T : notnull, FrameworkElement
+        {
+            if (element is T result && predicate(result, state))
+            {
+                return result;
+            }
+
+            return FindParent(element, state, predicate);
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -9,6 +9,8 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 
+#nullable enable
+
 namespace Microsoft.Toolkit.Uwp.UI.Extensions
 {
     /// <summary>
@@ -199,56 +201,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         }
 
         /// <summary>
-        /// Finds the logical parent element with the given name or returns null. Note: Parent may only be set when the control is added to the VisualTree.
-        /// <seealso href="https://docs.microsoft.com/uwp/api/windows.ui.xaml.frameworkelement.parent#remarks"/>
-        /// </summary>
-        /// <param name="element">Child element.</param>
-        /// <param name="name">Name of the control to find.</param>
-        /// <returns>Parent control or null if not found.</returns>
-        public static FrameworkElement FindParentByName(this FrameworkElement element, string name)
-        {
-            if (element == null || string.IsNullOrWhiteSpace(name))
-            {
-                return null;
-            }
-
-            if (name.Equals(element.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                return element;
-            }
-
-            if (element.Parent == null)
-            {
-                return null;
-            }
-
-            return (element.Parent as FrameworkElement).FindParentByName(name);
-        }
-
-        /// <summary>
-        /// Find first logical parent control of a specified type. Note: Parent may only be set when the control is added to the VisualTree.
-        /// <seealso href="https://docs.microsoft.com/uwp/api/windows.ui.xaml.frameworkelement.parent#remarks"/>
-        /// </summary>
-        /// <typeparam name="T">Type to search for.</typeparam>
-        /// <param name="element">Child element.</param>
-        /// <returns>Parent control or null if not found.</returns>
-        public static T FindParent<T>(this FrameworkElement element)
-            where T : FrameworkElement
-        {
-            if (element.Parent == null)
-            {
-                return null;
-            }
-
-            if (element.Parent is T)
-            {
-                return element.Parent as T;
-            }
-
-            return (element.Parent as FrameworkElement).FindParent<T>();
-        }
-
-        /// <summary>
         /// Retrieves the Content control of this element as defined by the ContentPropertyAttribute.
         /// </summary>
         /// <param name="element">Parent element.</param>
@@ -297,6 +249,111 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             Application.Current?.Resources?.TryGetValue(resourceKey, out value);
 
             return value;
+        }
+
+        /// <summary>
+        /// Find the first parent of type <see cref="FrameworkElement"/> with a given name.
+        /// </summary>
+        /// <param name="element">The starting element.</param>
+        /// <param name="name">The name of the element to look for.</param>
+        /// <param name="comparisonType">The comparison type to use to match <paramref name="name"/>.</param>
+        /// <returns>The parent that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindParent(this FrameworkElement element, string name, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            return FindParent<FrameworkElement, (string Name, StringComparison ComparisonType)>(
+                element,
+                (name, comparisonType),
+                static (e, s) => s.Name.Equals(e.Name, s.ComparisonType));
+        }
+
+        /// <summary>
+        /// Find the first parent element of a given type.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <returns>The parent that was found, or <see langword="null"/>.</returns>
+        public static T? FindParent<T>(this FrameworkElement element)
+            where T : notnull, FrameworkElement
+        {
+            while (true)
+            {
+                if (element.Parent is not FrameworkElement parent)
+                {
+                    return null;
+                }
+
+                if (parent is T result)
+                {
+                    return result;
+                }
+
+                element = parent;
+            }
+        }
+
+        /// <summary>
+        /// Find the first parent element of a given type.
+        /// </summary>
+        /// <param name="element">The starting element.</param>
+        /// <param name="type">The type of element to match.</param>
+        /// <returns>The parent that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindParent(this FrameworkElement element, Type type)
+        {
+            return FindParent<FrameworkElement, Type>(element, type, static (e, t) => e.GetType() == t);
+        }
+
+        /// <summary>
+        /// Find the first parent element matching a given predicate.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <param name="predicate">The predicatee to use to match the parent nodes.</param>
+        /// <returns>The parent that was found, or <see langword="null"/>.</returns>
+        public static T? FindParent<T>(this FrameworkElement element, Func<T, bool> predicate)
+            where T : notnull, FrameworkElement
+        {
+            while (true)
+            {
+                if (element.Parent is not FrameworkElement parent)
+                {
+                    return null;
+                }
+
+                if (parent is T result && predicate(result))
+                {
+                    return result;
+                }
+
+                element = parent;
+            }
+        }
+
+        /// <summary>
+        /// Find the first parent element matching a given predicate.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <typeparam name="TState">The type of state to use when matching nodes.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <param name="state">The state to give as input to <paramref name="predicate"/>.</param>
+        /// <param name="predicate">The predicatee to use to match the parent nodes.</param>
+        /// <returns>The parent that was found, or <see langword="null"/>.</returns>
+        public static T? FindParent<T, TState>(this FrameworkElement element, TState state, Func<T, TState, bool> predicate)
+            where T : notnull, FrameworkElement
+        {
+            while (true)
+            {
+                if (element.Parent is not FrameworkElement parent)
+                {
+                    return null;
+                }
+
+                if (parent is T result && predicate(result, state))
+                {
+                    return result;
+                }
+
+                element = parent;
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         public static UIElement? TryGetContentControl(this FrameworkElement element)
         {
             Type type = element.GetType();
-            TypeInfo typeInfo = type.GetTypeInfo();
+            TypeInfo? typeInfo = type.GetTypeInfo();
 
             while (typeInfo is not null)
             {
@@ -584,7 +584,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     }
                 }
 
-                typeInfo = typeInfo.BaseType.GetTypeInfo();
+                typeInfo = typeInfo.BaseType?.GetTypeInfo();
             }
 
             return null;

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -639,7 +639,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         }
 
         /// <summary>
-        /// Provides a WPF compatible version of TryFindResource to provide a static resource lookup.
+        /// Provides a WPF compatible version of FindResource to provide a static resource lookup.
         /// If the key is not found in the current element's resources, the logical tree is then
         /// searched element-by-element to look for the resource in each element's resources.
         /// If none of the elements contain the resource, the Application's resources are then searched.

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -672,11 +672,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         /// </summary>
         /// <param name="element">The <see cref="FrameworkElement"/> to start searching for the target resource.</param>
         /// <param name="resourceKey">The resource key to search for.</param>
-        /// <param name="value">The resulting value, if present.</param>
-        /// <returns>Whether or not a value with the specified key has been found.</returns>
-        public static bool TryFindResource(this FrameworkElement element, object resourceKey, out object? value)
+        /// <returns>The requested resource, or <see langword="null"/> if it wasn't found.</returns>
+        public static object? TryFindResource(this FrameworkElement element, object resourceKey)
         {
-            value = null;
+            object? value = null;
 
             FrameworkElement? current = element;
 
@@ -687,7 +686,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             {
                 if (current.Resources?.TryGetValue(resourceKey, out value) == true)
                 {
-                    return true;
+                    return value;
                 }
 
                 current = current.Parent as FrameworkElement;
@@ -695,7 +694,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             while (current is not null);
 
             // Finally try application resources
-            return Application.Current?.Resources?.TryGetValue(resourceKey, out value) == true;
+            _ = Application.Current?.Resources?.TryGetValue(resourceKey, out value);
+
+            return value;
+        }
+
+        /// <summary>
+        /// Provides a WPF compatible version of TryFindResource to provide a static resource lookup.
+        /// If the key is not found in the current element's resources, the logical tree is then
+        /// searched element-by-element to look for the resource in each element's resources.
+        /// If none of the elements contain the resource, the Application's resources are then searched.
+        /// <para>See: <seealso href="https://docs.microsoft.com/dotnet/api/system.windows.frameworkelement.tryfindresource"/>.</para>
+        /// <para>And also: <seealso href="https://docs.microsoft.com/dotnet/desktop-wpf/fundamentals/xaml-resources-define#static-resource-lookup-behavior"/>.</para>
+        /// </summary>
+        /// <param name="element">The <see cref="FrameworkElement"/> to start searching for the target resource.</param>
+        /// <param name="resourceKey">The resource key to search for.</param>
+        /// <param name="value">The resulting value, if present.</param>
+        /// <returns>Whether or not a value with the specified key has been found.</returns>
+        public static bool TryFindResource(this FrameworkElement element, object resourceKey, out object? value)
+        {
+            return (value = TryFindResource(element, resourceKey)) is not null;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         /// </summary>
         /// <param name="element">Parent element.</param>
         /// <returns>Child Content control or null if not available.</returns>
-        public static UIElement GetContentControl(this FrameworkElement element)
+        public static UIElement? GetContentControl(this FrameworkElement element)
         {
             Type type = element.GetType();
 
@@ -217,38 +217,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Provides a WPF compatible version of TryFindResource to provide a static resource lookup.
-        /// If the key is not found in the current element's resources, the logical tree is then searched element-by-element to look for the resource in each element's resources.
-        /// If none of the elements contain the resource, the Application's resources are then searched.
-        /// <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.tryfindresource"/>
-        /// <seealso href="https://docs.microsoft.com/en-us/dotnet/desktop-wpf/fundamentals/xaml-resources-define#static-resource-lookup-behavior"/>
-        /// </summary>
-        /// <param name="start"><see cref="FrameworkElement"/> to start searching for Resource.</param>
-        /// <param name="resourceKey">Key to search for.</param>
-        /// <returns>Requested resource or null.</returns>
-        public static object TryFindResource(this FrameworkElement start, object resourceKey)
-        {
-            object value = null;
-            var current = start;
-
-            // Look in our dictionary and then walk-up parents
-            while (current != null)
-            {
-                if (current.Resources?.TryGetValue(resourceKey, out value) == true)
-                {
-                    return value;
-                }
-
-                current = current.Parent as FrameworkElement;
-            }
-
-            // Finally try application resources.
-            Application.Current?.Resources?.TryGetValue(resourceKey, out value);
-
-            return value;
         }
 
         /// <summary>
@@ -442,6 +410,42 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
 
             return FindParent(element, state, predicate);
+        }
+
+        /// <summary>
+        /// Provides a WPF compatible version of TryFindResource to provide a static resource lookup.
+        /// If the key is not found in the current element's resources, the logical tree is then
+        /// searched element-by-element to look for the resource in each element's resources.
+        /// If none of the elements contain the resource, the Application's resources are then searched.
+        /// <para>See: <seealso href="https://docs.microsoft.com/dotnet/api/system.windows.frameworkelement.tryfindresource"/></para>
+        /// <para>And also: <seealso href="https://docs.microsoft.com/dotnet/desktop-wpf/fundamentals/xaml-resources-define#static-resource-lookup-behavior"/></para>
+        /// </summary>
+        /// <param name="element">The <see cref="FrameworkElement"/> to start searching for the target resource.</param>
+        /// <param name="resourceKey">The resource key to search for.</param>
+        /// <returns>The requested resource, or <see langword="null"/>.</returns>
+        public static object? TryFindResource(this FrameworkElement element, object resourceKey)
+        {
+            object? value = null;
+            FrameworkElement? current = element;
+
+            // Look in our dictionary and then walk-up parents. We use a do-while loop here
+            // so that an implicit NRE will be thrown at the first iteration in case the
+            // input element is null. This is consistent with the other extensions.
+            do
+            {
+                if (current.Resources?.TryGetValue(resourceKey, out value) == true)
+                {
+                    return value!;
+                }
+
+                current = current.Parent as FrameworkElement;
+            }
+            while (current is not null);
+
+            // Finally try application resources
+            Application.Current?.Resources?.TryGetValue(resourceKey, out value);
+
+            return value;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         /// If the key is not found in the current element's resources, the logical tree is then
         /// searched element-by-element to look for the resource in each element's resources.
         /// If none of the elements contain the resource, the Application's resources are then searched.
-        /// <para>See: <seealso href="https://docs.microsoft.com/dotnet/api/system.windows.frameworkelement.tryfindresource"/>.</para>
+        /// <para>See: <seealso href="https://docs.microsoft.com/dotnet/api/system.windows.frameworkelement.findresource"/>.</para>
         /// <para>And also: <seealso href="https://docs.microsoft.com/dotnet/desktop-wpf/fundamentals/xaml-resources-define#static-resource-lookup-behavior"/>.</para>
         /// </summary>
         /// <param name="element">The <see cref="FrameworkElement"/> to start searching for the target resource.</param>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -566,24 +566,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         /// <returns>The retrieved content control, or <see langword="null"/> if not available.</returns>
         public static UIElement? TryGetContentControl(this FrameworkElement element)
         {
-            Type? type = element.GetType();
+            Type type = element.GetType();
+            TypeInfo typeInfo = type.GetTypeInfo();
 
-            while (type is not null)
+            while (typeInfo is not null)
             {
                 // We need to manually explore the custom attributes this way as the target one
-                // one is not returned by any of the other available GetCustomAttribute<T> APIs.
-                foreach (CustomAttributeData attribute in type.CustomAttributes)
+                // is not returned by any of the other available GetCustomAttribute<T> APIs.
+                foreach (CustomAttributeData attribute in typeInfo.CustomAttributes)
                 {
                     if (attribute.AttributeType == typeof(ContentPropertyAttribute))
                     {
                         string propertyName = (string)attribute.NamedArguments[0].TypedValue.Value;
-                        PropertyInfo propertyInfo = type.GetProperty(propertyName);
+                        PropertyInfo? propertyInfo = type.GetProperty(propertyName);
 
-                        return propertyInfo.GetValue(element) as UIElement;
+                        return propertyInfo?.GetValue(element) as UIElement;
                     }
                 }
 
-                type = type.BaseType;
+                typeInfo = typeInfo.BaseType.GetTypeInfo();
             }
 
             return null;

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -256,37 +255,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         /// <returns>Child Content control or null if not available.</returns>
         public static UIElement GetContentControl(this FrameworkElement element)
         {
-            var contentpropname = ContentPropertySearch(element.GetType());
-            if (contentpropname != null)
+            Type type = element.GetType();
+
+            if (type.GetCustomAttribute<ContentPropertyAttribute>(true) is ContentPropertyAttribute attribute &&
+                type.GetProperty(attribute.Name) is PropertyInfo propertyInfo &&
+                propertyInfo.GetValue(element) is UIElement content)
             {
-                return element.GetType()?.GetProperty(contentpropname)?.GetValue(element) as UIElement;
+                return content;
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Retrieves the Content Property's Name for the given type.
-        /// </summary>
-        /// <param name="type">UIElement based type to search for ContentProperty.</param>
-        /// <returns>String name of ContentProperty for control.</returns>
-        private static string ContentPropertySearch(Type type)
-        {
-            if (type == null)
-            {
-                return null;
-            }
-
-            // Using GetCustomAttribute directly isn't working for some reason, so we'll dig in ourselves: https://aka.ms/Rkzseg
-            ////var attr = type.GetTypeInfo().GetCustomAttribute(typeof(ContentPropertyAttribute), true);
-            var attr = type.GetTypeInfo().CustomAttributes.FirstOrDefault((element) => element.AttributeType == typeof(ContentPropertyAttribute));
-            if (attr != null)
-            {
-                ////return attr as ContentPropertyAttribute;
-                return attr.NamedArguments.First().TypedValue.Value as string;
-            }
-
-            return ContentPropertySearch(type.GetTypeInfo().BaseType);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -657,9 +657,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                 return value!;
             }
 
-            static object Throw() => throw new Exception("No resource was found with the specified key");
+            static object Throw(object resourceKey) => throw new KeyNotFoundException($"No resource was found with the key \"{resourceKey}\"");
 
-            return Throw();
+            return Throw(resourceKey);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/Interfaces/IPredicate{T}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/Interfaces/IPredicate{T}.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
+{
+    /// <summary>
+    /// An interface representing a predicate for items of a given type.
+    /// </summary>
+    /// <typeparam name="T">The type of items to match.</typeparam>
+    internal interface IPredicate<T>
+    {
+        /// <summary>
+        /// Performs a match with the current predicate over a target <typeparamref name="T"/> instance.
+        /// </summary>
+        /// <param name="element">The input element to match.</param>
+        /// <returns>Whether the match evaluation was successful.</returns>
+        bool Match(T element);
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/Interfaces/IPredicate{T}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/Interfaces/IPredicate{T}.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
     /// An interface representing a predicate for items of a given type.
     /// </summary>
     /// <typeparam name="T">The type of items to match.</typeparam>
-    internal interface IPredicate<T>
+    internal interface IPredicate<in T>
+        where T : class
     {
         /// <summary>
         /// Performs a match with the current predicate over a target <typeparamref name="T"/> instance.

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByAny{T}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByAny{T}.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
+{
+    /// <summary>
+    /// An <see cref="IPredicate{T}"/> type matching all instances of a given type.
+    /// </summary>
+    /// <typeparam name="T">The type of items to match.</typeparam>
+    internal readonly struct PredicateByAny<T> : IPredicate<T>
+    {
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Match(T element)
+        {
+            return true;
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByAny{T}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByAny{T}.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
     /// </summary>
     /// <typeparam name="T">The type of items to match.</typeparam>
     internal readonly struct PredicateByAny<T> : IPredicate<T>
+        where T : class
     {
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T,TState}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T,TState}.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
+{
+    /// <summary>
+    /// An <see cref="IPredicate{T}"/> type matching items of a given type.
+    /// </summary>
+    /// <typeparam name="T">The type of items to match.</typeparam>
+    /// <typeparam name="TState">The type of state to use when matching items.</typeparam>
+    internal readonly struct PredicateByFunc<T, TState> : IPredicate<T>
+    {
+        /// <summary>
+        /// The state to give as input to <see name="predicate"/>.
+        /// </summary>
+        private readonly TState state;
+
+        /// <summary>
+        /// The predicatee to use to match items.
+        /// </summary>
+        private readonly Func<T, TState, bool> predicate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PredicateByFunc{T, TState}"/> struct.
+        /// </summary>
+        /// <param name="state">The state to give as input to <paramref name="predicate"/>.</param>
+        /// <param name="predicate">The predicatee to use to match items.</param>
+        public PredicateByFunc(TState state, Func<T, TState, bool> predicate)
+        {
+            this.state = state;
+            this.predicate = predicate;
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Match(T element)
+        {
+            return this.predicate(element, state);
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T,TState}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T,TState}.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
     /// <typeparam name="T">The type of items to match.</typeparam>
     /// <typeparam name="TState">The type of state to use when matching items.</typeparam>
     internal readonly struct PredicateByFunc<T, TState> : IPredicate<T>
+        where T : class
     {
         /// <summary>
         /// The state to give as input to <see name="predicate"/>.

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T}.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
+{
+    /// <summary>
+    /// An <see cref="IPredicate{T}"/> type matching items of a given type.
+    /// </summary>
+    /// <typeparam name="T">The type of items to match.</typeparam>
+    internal readonly struct PredicateByFunc<T> : IPredicate<T>
+    {
+        /// <summary>
+        /// The predicatee to use to match items.
+        /// </summary>
+        private readonly Func<T, bool> predicate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PredicateByFunc{T}"/> struct.
+        /// </summary>
+        /// <param name="predicate">The predicatee to use to match items.</param>
+        public PredicateByFunc(Func<T, bool> predicate)
+        {
+            this.predicate = predicate;
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Match(T element)
+        {
+            return this.predicate(element);
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByFunc{T}.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
     /// </summary>
     /// <typeparam name="T">The type of items to match.</typeparam>
     internal readonly struct PredicateByFunc<T> : IPredicate<T>
+        where T : class
     {
         /// <summary>
         /// The predicatee to use to match items.

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByName.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByName.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Windows.UI.Xaml;
+
+namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
+{
+    /// <summary>
+    /// An <see cref="IPredicate{T}"/> type matching <see cref="FrameworkElement"/> instances by name.
+    /// </summary>
+    internal readonly struct PredicateByName : IPredicate<FrameworkElement>
+    {
+        /// <summary>
+        /// The name of the element to look for.
+        /// </summary>
+        private readonly string name;
+
+        /// <summary>
+        /// The comparison type to use to match <see name="name"/>.
+        /// </summary>
+        private readonly StringComparison comparisonType;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PredicateByName"/> struct.
+        /// </summary>
+        /// <param name="name">The name of the element to look for.</param>
+        /// <param name="comparisonType">The comparison type to use to match <paramref name="name"/>.</param>
+        public PredicateByName(string name, StringComparison comparisonType)
+        {
+            this.name = name;
+            this.comparisonType = comparisonType;
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Match(FrameworkElement element)
+        {
+            return element.Name.Equals(this.name, this.comparisonType);
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByType{T}.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/Predicates/PredicateByType{T}.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
+{
+    /// <summary>
+    /// An <see cref="IPredicate{T}"/> type matching items of a given type.
+    /// </summary>
+    /// <typeparam name="T">The type of items to match.</typeparam>
+    internal readonly struct PredicateByType<T> : IPredicate<T>
+    {
+        /// <summary>
+        /// The type of element to match.
+        /// </summary>
+        private readonly Type type;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PredicateByType{T}"/> struct.
+        /// </summary>
+        /// <param name="type">The type of element to match.</param>
+        public PredicateByType(Type type)
+        {
+            this.type = type;
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Match(T element)
+        {
+            return element.GetType() == this.type;
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/VisualTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/VisualTree.cs
@@ -140,6 +140,94 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         }
 
         /// <summary>
+        /// Find the first descendant (or self) of type <see cref="FrameworkElement"/> with a given name, using a depth-first search.
+        /// </summary>
+        /// <param name="element">The root element.</param>
+        /// <param name="name">The name of the element to look for.</param>
+        /// <param name="comparisonType">The comparison type to use to match <paramref name="name"/>.</param>
+        /// <returns>The descendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindDescendantOrSelf(this DependencyObject element, string name, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            if (element is FrameworkElement result && name.Equals(result.Name, comparisonType))
+            {
+                return result;
+            }
+
+            return FindDescendant(element, name, comparisonType);
+        }
+
+        /// <summary>
+        /// Find the first descendant (or self) element of a given type, using a depth-first search.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The root element.</param>
+        /// <returns>The descendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindDescendantOrSelf<T>(this DependencyObject element)
+            where T : notnull, DependencyObject
+        {
+            if (element is T result)
+            {
+                return result;
+            }
+
+            return FindDescendant<T>(element);
+        }
+
+        /// <summary>
+        /// Find the first descendant (or self) element of a given type, using a depth-first search.
+        /// </summary>
+        /// <param name="element">The root element.</param>
+        /// <param name="type">The type of element to match.</param>
+        /// <returns>The descendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static DependencyObject? FindDescendantOrSelf(this DependencyObject element, Type type)
+        {
+            if (element.GetType() == type)
+            {
+                return element;
+            }
+
+            return FindDescendant(element, type);
+        }
+
+        /// <summary>
+        /// Find the first descendant (or self) element matching a given predicate, using a depth-first search.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The root element.</param>
+        /// <param name="predicate">The predicatee to use to match the descendant nodes.</param>
+        /// <returns>The descendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindDescendantOrSelf<T>(this DependencyObject element, Func<T, bool> predicate)
+            where T : notnull, DependencyObject
+        {
+            if (element is T result && predicate(result))
+            {
+                return result;
+            }
+
+            return FindDescendant(element, predicate);
+        }
+
+        /// <summary>
+        /// Find the first descendant (or self) element matching a given predicate, using a depth-first search.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <typeparam name="TState">The type of state to use when matching nodes.</typeparam>
+        /// <param name="element">The root element.</param>
+        /// <param name="state">The state to give as input to <paramref name="predicate"/>.</param>
+        /// <param name="predicate">The predicatee to use to match the descendant nodes.</param>
+        /// <returns>The descendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindDescendantOrSelf<T, TState>(this DependencyObject element, TState state, Func<T, TState, bool> predicate)
+            where T : notnull, DependencyObject
+        {
+            if (element is T result && predicate(result, state))
+            {
+                return result;
+            }
+
+            return FindDescendant(element, state, predicate);
+        }
+
+        /// <summary>
         /// Find all descendant controls of the specified type.
         /// </summary>
         /// <typeparam name="T">Type to search for.</typeparam>
@@ -275,6 +363,94 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
                 element = parent;
             }
+        }
+
+        /// <summary>
+        /// Find the first ascendant (or self) of type <see cref="FrameworkElement"/> with a given name.
+        /// </summary>
+        /// <param name="element">The starting element.</param>
+        /// <param name="name">The name of the element to look for.</param>
+        /// <param name="comparisonType">The comparison type to use to match <paramref name="name"/>.</param>
+        /// <returns>The ascendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static FrameworkElement? FindAscendantOrSelf(this DependencyObject element, string name, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            if (element is FrameworkElement result && name.Equals(result.Name, comparisonType))
+            {
+                return result;
+            }
+
+            return FindAscendant(element, name, comparisonType);
+        }
+
+        /// <summary>
+        /// Find the first ascendant (or self) element of a given type.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <returns>The ascendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindAscendantOrSelf<T>(this DependencyObject element)
+            where T : notnull, DependencyObject
+        {
+            if (element is T result)
+            {
+                return result;
+            }
+
+            return FindAscendant<T>(element);
+        }
+
+        /// <summary>
+        /// Find the first ascendant (or self) element of a given type.
+        /// </summary>
+        /// <param name="element">The starting element.</param>
+        /// <param name="type">The type of element to match.</param>
+        /// <returns>The ascendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static DependencyObject? FindAscendantOrSelf(this DependencyObject element, Type type)
+        {
+            if (element.GetType() == type)
+            {
+                return element;
+            }
+
+            return FindAscendant(element, type);
+        }
+
+        /// <summary>
+        /// Find the first ascendant (or self) element matching a given predicate.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <param name="predicate">The predicatee to use to match the ascendant nodes.</param>
+        /// <returns>The ascendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindAscendantOrSelf<T>(this DependencyObject element, Func<T, bool> predicate)
+            where T : notnull, DependencyObject
+        {
+            if (element is T result && predicate(result))
+            {
+                return result;
+            }
+
+            return FindAscendant(element, predicate);
+        }
+
+        /// <summary>
+        /// Find the first ascendant (or self) element matching a given predicate.
+        /// </summary>
+        /// <typeparam name="T">The type of elements to match.</typeparam>
+        /// <typeparam name="TState">The type of state to use when matching nodes.</typeparam>
+        /// <param name="element">The starting element.</param>
+        /// <param name="state">The state to give as input to <paramref name="predicate"/>.</param>
+        /// <param name="predicate">The predicatee to use to match the ascendant nodes.</param>
+        /// <returns>The ascendant (or self) that was found, or <see langword="null"/>.</returns>
+        public static T? FindAscendantOrSelf<T, TState>(this DependencyObject element, TState state, Func<T, TState, bool> predicate)
+            where T : notnull, DependencyObject
+        {
+            if (element is T result && predicate(result, state))
+            {
+                return result;
+            }
+
+            return FindAscendant(element, state, predicate);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/VisualTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/VisualTree.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
                 T? descendant = FindDescendant(child, predicate);
 
-                if (descendant is not null && predicate(descendant))
+                if (descendant is not null)
                 {
                     return descendant;
                 }
@@ -130,7 +130,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
                 T? descendant = FindDescendant(child, state, predicate);
 
-                if (descendant is not null && predicate(descendant, state))
+                if (descendant is not null)
                 {
                     return descendant;
                 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/VisualTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/VisualTree.cs
@@ -228,28 +228,30 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         }
 
         /// <summary>
-        /// Find all descendant controls of the specified type.
+        /// Find all descendant elements of the specified element. This method can be chained with
+        /// LINQ calls to add additional filters or projections on top of the returned results.
+        /// <para>
+        /// This method is meant to provide extra flexibility in specific scenarios and it should not
+        /// be used when only the first item is being looked for. In those cases, use one of the
+        /// available <see cref="FindDescendant{T}(DependencyObject)"/> overloads instead, which will
+        /// offer a more compact syntax as well as better performance in those cases.
+        /// </para>
         /// </summary>
-        /// <typeparam name="T">Type to search for.</typeparam>
-        /// <param name="element">Parent element.</param>
-        /// <returns>Descendant controls or empty if not found.</returns>
-        public static IEnumerable<T> FindDescendants<T>(this DependencyObject element)
-            where T : DependencyObject
+        /// <param name="element">The root element.</param>
+        /// <returns>All the descendant <see cref="DependencyObject"/> instance from <paramref name="element"/>.</returns>
+        public static IEnumerable<DependencyObject> FindDescendants(this DependencyObject element)
         {
-            var childrenCount = VisualTreeHelper.GetChildrenCount(element);
+            int childrenCount = VisualTreeHelper.GetChildrenCount(element);
 
             for (var i = 0; i < childrenCount; i++)
             {
-                var child = VisualTreeHelper.GetChild(element, i);
-                var type = child as T;
-                if (type != null)
-                {
-                    yield return type;
-                }
+                DependencyObject child = VisualTreeHelper.GetChild(element, i);
 
-                foreach (T childofChild in child.FindDescendants<T>())
+                yield return child;
+
+                foreach (DependencyObject childOfChild in FindDescendants(child))
                 {
-                    yield return childofChild;
+                    yield return childOfChild;
                 }
             }
         }
@@ -454,18 +456,31 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         }
 
         /// <summary>
-        /// Find all visual ascendants for the element.
+        /// Find all ascendant elements of the specified element. This method can be chained with
+        /// LINQ calls to add additional filters or projections on top of the returned results.
+        /// <para>
+        /// This method is meant to provide extra flexibility in specific scenarios and it should not
+        /// be used when only the first item is being looked for. In those cases, use one of the
+        /// available <see cref="FindAscendant{T}(DependencyObject)"/> overloads instead, which will
+        /// offer a more compact syntax as well as better performance in those cases.
+        /// </para>
         /// </summary>
-        /// <param name="element">Child element.</param>
-        /// <returns>A collection of parent elements or null if none found.</returns>
+        /// <param name="element">The root element.</param>
+        /// <returns>All the descendant <see cref="DependencyObject"/> instance from <paramref name="element"/>.</returns>
         public static IEnumerable<DependencyObject> FindAscendants(this DependencyObject element)
         {
-            var parent = VisualTreeHelper.GetParent(element);
-
-            while (parent != null)
+            while (true)
             {
+                DependencyObject? parent = VisualTreeHelper.GetParent(element);
+
+                if (parent is null)
+                {
+                    yield break;
+                }
+
                 yield return parent;
-                parent = VisualTreeHelper.GetParent(parent);
+
+                element = parent;
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI/Microsoft.Toolkit.Uwp.UI.csproj
+++ b/Microsoft.Toolkit.Uwp.UI/Microsoft.Toolkit.Uwp.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>uap10.0.17763</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Title>Windows Community Toolkit UI</Title>
     <Description>
       This library provides UI components, such as XAML extensions, helpers, converters and more. It is part of the Windows Community Toolkit.

--- a/Microsoft.Toolkit.uwp.UI/Extensions/Tree/Predicates/PredicateByType.cs
+++ b/Microsoft.Toolkit.uwp.UI/Extensions/Tree/Predicates/PredicateByType.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
     /// <summary>
     /// An <see cref="IPredicate{T}"/> type matching items of a given type.
     /// </summary>
-    /// <typeparam name="T">The type of items to match.</typeparam>
-    internal readonly struct PredicateByType<T> : IPredicate<T>
+    internal readonly struct PredicateByType : IPredicate<object>
     {
         /// <summary>
         /// The type of element to match.
@@ -19,7 +18,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
         private readonly Type type;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PredicateByType{T}"/> struct.
+        /// Initializes a new instance of the <see cref="PredicateByType"/> struct.
         /// </summary>
         /// <param name="type">The type of element to match.</param>
         public PredicateByType(Type type)
@@ -29,7 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions.Tree
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Match(T element)
+        public bool Match(object element)
         {
             return element.GetType() == this.type;
         }

--- a/UITests/UITests.App/RequestPageMessage.cs
+++ b/UITests/UITests.App/RequestPageMessage.cs
@@ -12,7 +12,7 @@ namespace UITests.App
         {
             PageName = name;
         }
-        
+
         public string PageName { get; }
     }
 }

--- a/UnitTests/UnitTests.UWP/Extensions/Test_BitmapIconExtensionMarkupExtension.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_BitmapIconExtensionMarkupExtension.cs
@@ -33,7 +33,7 @@ namespace UnitTests.Extensions
         </Button>
 </Page>") as FrameworkElement;
 
-            var button = treeroot.FindChildByName("RootButton") as Button;
+            var button = treeroot.FindChild("RootButton") as Button;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(Button)} control in tree.");
 
@@ -66,7 +66,7 @@ namespace UnitTests.Extensions
         </Button>
 </Page>") as FrameworkElement;
 
-            var button = treeroot.FindChildByName("RootButton") as Button;
+            var button = treeroot.FindChild("RootButton") as Button;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(Button)} control in tree.");
 

--- a/UnitTests/UnitTests.UWP/Extensions/Test_EnumValuesExtension.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_EnumValuesExtension.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Extensions
         <ListView x:Name=""Check"" ItemsSource=""{ex:EnumValues Type=local:Animal}""/>
 </Page>") as FrameworkElement;
 
-            var list = treeRoot.FindChildByName("Check") as ListView;
+            var list = treeRoot.FindChild("Check") as ListView;
 
             Assert.IsNotNull(list, "Could not find ListView control in tree.");
 

--- a/UnitTests/UnitTests.UWP/Extensions/Test_FontIconExtensionMarkupExtension.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_FontIconExtensionMarkupExtension.cs
@@ -26,7 +26,7 @@ namespace UnitTests.Extensions
         <AppBarButton x:Name=""Check"" Icon=""{ex:FontIcon Glyph=&#xE105;}""/>
 </Page>") as FrameworkElement;
 
-            var button = treeroot.FindChildByName("Check") as AppBarButton;
+            var button = treeroot.FindChild("Check") as AppBarButton;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(AppBarButton)} control in tree.");
 
@@ -49,7 +49,7 @@ namespace UnitTests.Extensions
         <AppBarButton x:Name=""Check"" Icon=""{ex:FontIcon Glyph=&#xE14D;, FontFamily='Segoe UI'}""/>
 </Page>") as FrameworkElement;
 
-            var button = treeroot.FindChildByName("Check") as AppBarButton;
+            var button = treeroot.FindChild("Check") as AppBarButton;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(AppBarButton)} control in tree.");
 
@@ -72,7 +72,7 @@ namespace UnitTests.Extensions
         <AppBarButton x:Name=""Check"" Icon=""{ex:FontIcon Glyph=&#xE14D;, FontSize=7, FontFamily='Segoe MDL2 Assets', FontWeight=Bold, FontStyle=Italic, IsTextScaleFactorEnabled=True, MirroredWhenRightToLeft=True}""/>
 </Page>") as FrameworkElement;
 
-            var button = treeroot.FindChildByName("Check") as AppBarButton;
+            var button = treeroot.FindChild("Check") as AppBarButton;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(AppBarButton)} control in tree.");
 

--- a/UnitTests/UnitTests.UWP/Extensions/Test_FontIconSourceExtensionMarkupExtension.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_FontIconSourceExtensionMarkupExtension.cs
@@ -28,7 +28,7 @@ namespace UnitTests.Extensions
         <controls:MockSwipeItem x:Name=""Check"" IconSource=""{ex:FontIconSource Glyph=&#xE105;}""/>
 </Page>") as FrameworkElement;
 
-            var button = treeRoot.FindChildByName("Check") as MockSwipeItem;
+            var button = treeRoot.FindChild("Check") as MockSwipeItem;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(MockSwipeItem)} control in tree.");
 
@@ -52,7 +52,7 @@ namespace UnitTests.Extensions
         <controls:MockSwipeItem x:Name=""Check"" IconSource=""{ex:FontIconSource Glyph=&#xE14D;, FontFamily='Segoe UI'}""/>
 </Page>") as FrameworkElement;
 
-            var button = treeRoot.FindChildByName("Check") as MockSwipeItem;
+            var button = treeRoot.FindChild("Check") as MockSwipeItem;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(MockSwipeItem)} control in tree.");
 
@@ -76,7 +76,7 @@ namespace UnitTests.Extensions
         <controls:MockSwipeItem x:Name=""Check"" IconSource=""{ex:FontIconSource Glyph=&#xE14D;, FontSize=7, FontFamily='Segoe MDL2 Assets', FontWeight=Bold, FontStyle=Italic, IsTextScaleFactorEnabled=True, MirroredWhenRightToLeft=True}""/>
 </Page>") as FrameworkElement;
 
-            var button = treeRoot.FindChildByName("Check") as MockSwipeItem;
+            var button = treeRoot.FindChild("Check") as MockSwipeItem;
 
             Assert.IsNotNull(button, $"Could not find the {nameof(MockSwipeItem)} control in tree.");
 

--- a/UnitTests/UnitTests.UWP/Extensions/Test_LogicalTreeExtensions.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_LogicalTreeExtensions.cs
@@ -294,7 +294,7 @@ xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""> <!-- Starting Point --
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var thing = treeRoot.FindChildren<UniformGrid>();
+                var thing = treeRoot.FindChildren().OfType<UniformGrid>();
 
                 Assert.IsNotNull(thing, "Expected to still have enumerable.");
 

--- a/UnitTests/UnitTests.UWP/Extensions/Test_LogicalTreeExtensions.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_LogicalTreeExtensions.cs
@@ -44,7 +44,7 @@ namespace UnitTests.Extensions
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var textBlock = treeRoot.FindChildByName("TargetElement");
+                var textBlock = treeRoot.FindChild("TargetElement");
 
                 Assert.IsNotNull(textBlock, "Expected to find something.");
                 Assert.IsInstanceOfType(textBlock, typeof(TextBlock), "Didn't find expected typed element.");
@@ -79,7 +79,7 @@ namespace UnitTests.Extensions
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var textBlock = treeRoot.FindChildByName("TargetElement");
+                var textBlock = treeRoot.FindChild("TargetElement");
 
                 Assert.IsNull(textBlock, "Didn't expect to find anything.");
             });
@@ -250,7 +250,7 @@ xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""> <!-- Starting Point --
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var textBlocks = treeRoot.FindChildren<TextBlock>();
+                var textBlocks = treeRoot.FindChildren().OfType<TextBlock>();
 
                 Assert.IsNotNull(textBlocks, "Expected to find something.");
 
@@ -438,7 +438,7 @@ xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""> <!-- Starting Point --
                 Assert.IsNotNull(startingPoint, "Could not find starting element.");
 
                 // Main Test
-                var grid = startingPoint.FindParentByName("TargetElement");
+                var grid = startingPoint.FindParent("TargetElement");
 
                 Assert.IsNotNull(grid, "Expected to find Grid");
                 Assert.AreEqual(targetGrid, grid, "Grid didn't match expected.");
@@ -485,7 +485,7 @@ xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""> <!-- Starting Point --
                 Assert.IsNotNull(startingPoint, "Could not find starting element.");
 
                 // Main Test
-                var grid = startingPoint.FindParentByName("TargetElement");
+                var grid = startingPoint.FindParent("TargetElement");
 
                 Assert.IsNull(grid, "Didn't expect to find anything.");
             });

--- a/UnitTests/UnitTests.UWP/Extensions/Test_NullableBoolMarkupExtension.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_NullableBoolMarkupExtension.cs
@@ -26,7 +26,7 @@ namespace UnitTests.Extensions
         <CheckBox x:Name=""Check"" IsChecked=""{ex:NullableBool Value=True}""/>
 </Page>") as FrameworkElement;
 
-            var toggle = treeroot.FindChildByName("Check") as CheckBox;
+            var toggle = treeroot.FindChild("Check") as CheckBox;
 
             Assert.IsNotNull(toggle, "Could not find checkbox control in tree.");
 
@@ -44,7 +44,7 @@ namespace UnitTests.Extensions
         <CheckBox x:Name=""Check"" IsChecked=""{ex:NullableBool Value=False}""/>
 </Page>") as FrameworkElement;
 
-            var toggle = treeroot.FindChildByName("Check") as CheckBox;
+            var toggle = treeroot.FindChild("Check") as CheckBox;
 
             Assert.IsNotNull(toggle, "Could not find checkbox control in tree.");
 
@@ -62,7 +62,7 @@ namespace UnitTests.Extensions
         <CheckBox x:Name=""Check"" IsChecked=""{ex:NullableBool IsNull=True}""/>
 </Page>") as FrameworkElement;
 
-            var toggle = treeroot.FindChildByName("Check") as CheckBox;
+            var toggle = treeroot.FindChild("Check") as CheckBox;
 
             Assert.IsNotNull(toggle, "Could not find checkbox control in tree.");
 
@@ -80,7 +80,7 @@ namespace UnitTests.Extensions
         <CheckBox x:Name=""Check"" IsChecked=""{ex:NullableBool IsNull=True, Value=True}""/>
 </Page>") as FrameworkElement;
 
-            var toggle = treeroot.FindChildByName("Check") as CheckBox;
+            var toggle = treeroot.FindChild("Check") as CheckBox;
 
             Assert.IsNotNull(toggle, "Could not find checkbox control in tree.");
 
@@ -99,7 +99,7 @@ namespace UnitTests.Extensions
         <CheckBox x:Name=""Check"" IsChecked=""{ex:NullableBool IsNull=True, Value=False}""/>
 </Page>") as FrameworkElement;
 
-            var toggle = treeroot.FindChildByName("Check") as CheckBox;
+            var toggle = treeroot.FindChild("Check") as CheckBox;
 
             Assert.IsNotNull(toggle, "Could not find checkbox control in tree.");
 

--- a/UnitTests/UnitTests.UWP/Extensions/Test_VisualTreeExtensions.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_VisualTreeExtensions.cs
@@ -45,7 +45,7 @@ namespace UnitTests.Extensions
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var textBlock = treeRoot.FindDescendantByName("TargetElement");
+                var textBlock = treeRoot.FindDescendant("TargetElement");
 
                 Assert.IsNotNull(textBlock, "Expected to find something.");
                 Assert.IsInstanceOfType(textBlock, typeof(TextBlock), "Didn't find expected typed element.");
@@ -80,7 +80,7 @@ namespace UnitTests.Extensions
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var textBlock = treeRoot.FindDescendantByName("TargetElement");
+                var textBlock = treeRoot.FindDescendant("TargetElement");
 
                 Assert.IsNull(textBlock, "Didn't expect to find anything.");
             });
@@ -220,7 +220,7 @@ namespace UnitTests.Extensions
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var textBlocks = treeRoot.FindDescendants<TextBlock>();
+                var textBlocks = treeRoot.FindDescendants().OfType<TextBlock>();
 
                 Assert.IsNotNull(textBlocks, "Expected to find something.");
 
@@ -267,7 +267,7 @@ namespace UnitTests.Extensions
                 await SetTestContentAsync(treeRoot);
 
                 // Main Test
-                var thing = treeRoot.FindDescendants<UniformGrid>();
+                var thing = treeRoot.FindDescendants().OfType<UniformGrid>();
 
                 Assert.IsNotNull(thing, "Expected to find something.");
 
@@ -411,7 +411,7 @@ namespace UnitTests.Extensions
                 Assert.IsNotNull(startingPoint, "Could not find starting element.");
 
                 // Main Test
-                var grid = startingPoint.FindAscendantByName("TargetElement");
+                var grid = startingPoint.FindAscendant("TargetElement");
 
                 Assert.IsNotNull(grid, "Expected to find Grid");
                 Assert.AreEqual(targetGrid, grid, "Grid didn't match expected.");
@@ -458,7 +458,7 @@ namespace UnitTests.Extensions
                 Assert.IsNotNull(startingPoint, "Could not find starting element.");
 
                 // Main Test
-                var grid = startingPoint.FindAscendantByName("TargetElement");
+                var grid = startingPoint.FindAscendant("TargetElement");
 
                 Assert.IsNull(grid, "Didn't expect to find anything.");
             });

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_TextToolbar_Localization.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_TextToolbar_Localization.cs
@@ -43,7 +43,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var toolbar = treeRoot.FindChildByName("TextToolbarControl") as TextToolbar;
+            var toolbar = treeRoot.FindChild("TextToolbarControl") as TextToolbar;
 
             Assert.IsNotNull(toolbar, "Could not find TextToolbar in tree.");
 

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_TokenizingTextBox_General.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_TokenizingTextBox_General.cs
@@ -31,7 +31,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var tokenBox = treeRoot.FindChildByName("tokenboxname") as TokenizingTextBox;
+            var tokenBox = treeRoot.FindChild("tokenboxname") as TokenizingTextBox;
 
             Assert.IsNotNull(tokenBox, "Could not find TokenizingTextBox in tree.");
 

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_UniformGrid_AutoLayout.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_UniformGrid_AutoLayout.cs
@@ -51,7 +51,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -116,7 +116,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -176,7 +176,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -222,7 +222,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -232,14 +232,14 @@ namespace UnitTests.UI.Controls
 
             grid.Measure(new Size(1000, 1000));
 
-            var border = treeRoot.FindChildByName("OurItem") as Border;
+            var border = treeRoot.FindChild("OurItem") as Border;
 
             Assert.IsNotNull(border, "Could not find our item to test.");
 
             Assert.AreEqual(1, Grid.GetRow(border));
             Assert.AreEqual(1, Grid.GetColumn(border));
 
-            var border2 = treeRoot.FindChildByName("Shifted") as Border;
+            var border2 = treeRoot.FindChild("Shifted") as Border;
 
             Assert.IsNotNull(border2, "Could not find shifted item to test.");
 
@@ -269,7 +269,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -279,14 +279,14 @@ namespace UnitTests.UI.Controls
 
             grid.Measure(new Size(1000, 1000));
 
-            var border = treeRoot.FindChildByName("OurItem") as Border;
+            var border = treeRoot.FindChild("OurItem") as Border;
 
             Assert.IsNotNull(border, "Could not find our item to test.");
 
             Assert.AreEqual(1, Grid.GetRow(border));
             Assert.AreEqual(1, Grid.GetColumn(border));
 
-            var border2 = treeRoot.FindChildByName("Shifted") as Border;
+            var border2 = treeRoot.FindChild("Shifted") as Border;
 
             Assert.IsNotNull(border2, "Could not find shifted item to test.");
 
@@ -316,7 +316,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -326,14 +326,14 @@ namespace UnitTests.UI.Controls
 
             grid.Measure(new Size(1000, 1000));
 
-            var border = treeRoot.FindChildByName("OurItem") as Border;
+            var border = treeRoot.FindChild("OurItem") as Border;
 
             Assert.IsNotNull(border, "Could not find our item to test.");
 
             Assert.AreEqual(0, Grid.GetRow(border));
             Assert.AreEqual(1, Grid.GetColumn(border));
 
-            var border2 = treeRoot.FindChildByName("Shifted") as Border;
+            var border2 = treeRoot.FindChild("Shifted") as Border;
 
             Assert.IsNotNull(border2, "Could not find shifted item to test.");
 
@@ -371,7 +371,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -411,7 +411,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -421,14 +421,14 @@ namespace UnitTests.UI.Controls
 
             grid.Measure(new Size(1000, 1000));
 
-            var border = treeRoot.FindChildByName("OurItem") as Border;
+            var border = treeRoot.FindChild("OurItem") as Border;
 
             Assert.IsNotNull(border, "Could not find our item to test.");
 
             Assert.AreEqual(1, Grid.GetRow(border));
             Assert.AreEqual(1, Grid.GetColumn(border));
 
-            var border2 = treeRoot.FindChildByName("Shifted") as Border;
+            var border2 = treeRoot.FindChild("Shifted") as Border;
 
             Assert.IsNotNull(border2, "Could not find shifted item to test.");
 

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_UniformGrid_Dimensions.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_UniformGrid_Dimensions.cs
@@ -29,7 +29,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -65,7 +65,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -101,7 +101,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -142,7 +142,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -178,7 +178,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -213,7 +213,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-            var grid = treeRoot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeRoot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 

--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_UniformGrid_RowColDefinitions.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_UniformGrid_RowColDefinitions.cs
@@ -36,7 +36,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -110,7 +110,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -206,7 +206,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -310,7 +310,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -437,7 +437,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -511,7 +511,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -609,7 +609,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 
@@ -713,7 +713,7 @@ namespace UnitTests.UI.Controls
 
             Assert.IsNotNull(treeroot, "Could not load XAML tree.");
 
-            var grid = treeroot.FindChildByName("UniformGrid") as UniformGrid;
+            var grid = treeroot.FindChild("UniformGrid") as UniformGrid;
 
             Assert.IsNotNull(grid, "Could not find UniformGrid in tree.");
 

--- a/UnitTests/UnitTests.XamlIslands.UWPApp/XamlIslandsTest_StringExtensions.cs
+++ b/UnitTests/UnitTests.XamlIslands.UWPApp/XamlIslandsTest_StringExtensions.cs
@@ -70,7 +70,7 @@ namespace UnitTests.XamlIslands.UWPApp
 
                 Assert.IsNotNull(treeRoot, "Could not load XAML tree.");
 
-                var toolbar = treeRoot.FindChildByName("TextToolbarControl") as TextToolbar;
+                var toolbar = treeRoot.FindChild("TextToolbarControl") as TextToolbar;
 
                 Assert.IsNotNull(toolbar, "Could not find TextToolbar in tree.");
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Closes #3487 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

 - Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Overview
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are some inconsistencies in the visual tree extensions mentioned in the linked issue, and some missing features.
This PR applies the changes mentioned in https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3487#issuecomment-765028697.

## APIs breakdown

<details>
    <summary><b>VisualTree (click to expand):</b></summary>
<br/>

```csharp
namespace Microsoft.Toolkit.Uwp.UI.Extensions
{
    public static class VisualTree
    {
        static FrameworkElement? FindDescendant(this DependencyObject element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindDescendant<T>(this DependencyObject element) where T : notnull, DependencyObject;
        static DependencyObject? FindDescendant(this DependencyObject element, Type type);
        static T? FindDescendant<T>(this DependencyObject element, Func<T, bool> predicate) where T : notnull, DependencyObject;
        static T? FindDescendant<T, TState>(this DependencyObject element, TState state, Func<T, TState, bool> predicate) where T : notnull, DependencyObject;
        static FrameworkElement? FindDescendantOrSelf(this DependencyObject element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindDescendantOrSelf<T>(this DependencyObject element) where T : notnull, DependencyObject;
        static DependencyObject? FindDescendantOrSelf(this DependencyObject element, Type type);
        static T? FindDescendantOrSelf<T>(this DependencyObject element, Func<T, bool> predicate) where T : notnull, DependencyObject;
        static T? FindDescendantOrSelf<T, TState>(this DependencyObject element, TState state, Func<T, TState, bool> predicate) where T : notnull, DependencyObject;

        static IEnumerable<DependencyObject> FindDescendants(this DependencyObject element);

        static FrameworkElement? FindAscendant(this DependencyObject element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindAscendant<T>(this DependencyObject element) where T : notnull, DependencyObject;
        static DependencyObject? FindAscendant(this DependencyObject element, Type type);
        static T? FindAscendant<T>(this DependencyObject element, Func<T, bool> predicate) where T : notnull, DependencyObject;
        static T? FindAscendant<T, TState>(this DependencyObject element, TState state, Func<T, TState, bool> predicate) where T : notnull, DependencyObject;
        static FrameworkElement? FindAscendantOrSelf(this DependencyObject element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindAscendantOrSelf<T>(this DependencyObject element) where T : notnull, DependencyObject;
        static DependencyObject? FindAscendantOrSelf(this DependencyObject element, Type type);
        static T? FindAscendantOrSelf<T>(this DependencyObject element, Func<T, bool> predicate) where T : notnull, DependencyObject;
        static T? FindAscendantOrSelf<T, TState>(this DependencyObject element, TState state, Func<T, TState, bool> predicate) where T : notnull, DependencyObject;

        static IEnumerable<DependencyObject> FindAscendants(this DependencyObject element);
    }
}
```
</details>

<details>
    <summary><b>LogicalTree (click to expand):</b></summary>
<br/>

```csharp
namespace Microsoft.Toolkit.Uwp.UI.Extensions
{
    public static class LogicalTree
    {
        static FrameworkElement? FindChild(this FrameworkElement element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindChild<T>(this FrameworkElement element) where T : notnull, FrameworkElement;
        static FrameworkElement? FindChild(this FrameworkElement element, Type type);
        static T? FindChild<T>(this FrameworkElement element, Func<T, bool> predicate) where T : notnull, FrameworkElement;
        static T? FindChild<T, TState>(this FrameworkElement element, TState state, Func<T, TState, bool> predicate) where T : notnull, FrameworkElement;
        static FrameworkElement? FindChildOrSelf(this FrameworkElement element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindChildOrSelf<T>(this FrameworkElement element) where T : notnull, FrameworkElement;
        static FrameworkElement? FindChildOrSelf(this FrameworkElement element, Type type);
        static T? FindChildOrSelf<T>(this FrameworkElement element, Func<T, bool> predicate) where T : notnull, FrameworkElement;
        static T? FindChildOrSelf<T, TState>(this FrameworkElement element, TState state, Func<T, TState, bool> predicate) where T : notnull, FrameworkElement;

        static IEnumerable<FrameworkElement> FindChildren(this FrameworkElement element);

        static FrameworkElement? FindParent(this FrameworkElement element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindParent<T>(this FrameworkElement element) where T : notnull, FrameworkElement;
        static FrameworkElement? FindParent(this FrameworkElement element, Type type);
        static T? FindParent<T>(this FrameworkElement element, Func<T, bool> predicate) where T : notnull, FrameworkElement;
        static T? FindParent<T, TState>(this FrameworkElement element, TState state, Func<T, TState, bool> predicate) where T : notnull, FrameworkElement;
        static FrameworkElement? FindParentOrSelf(this FrameworkElement element, string name, StringComparison comparisonType = StringComparison.Ordinal);
        static T? FindParentOrSelf<T>(this FrameworkElement element) where T : notnull, FrameworkElement;
        static FrameworkElement? FindParentOrSelf(this FrameworkElement element, Type type);
        static T? FindParentOrSelf<T>(this FrameworkElement element, Func<T, bool> predicate) where T : notnull, FrameworkElement;
        static T? FindParentOrSelf<T, TState>(this FrameworkElement element, TState state, Func<T, TState, bool> predicate) where T : notnull, FrameworkElement;

        static IEnumerable<FrameworkElement> FindParents(this FrameworkElement element);
        
        static UIElement? TryGetContentControl(this FrameworkElement element);
        static object? TryFindResource(this FrameworkElement element, object resourceKey);
    }
}
```
</details>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
Opening as draft, missing updated/revamped unit tests.