### PR TITLE
Windows 10X and Two-pane view support

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListDetailsView/ListDetailsView.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListDetailsView/ListDetailsView.bind
@@ -1,4 +1,4 @@
-<Page
+﻿<Page
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
@@ -72,7 +72,7 @@
                     </StackPanel>
                 </DataTemplate>
             </controls:ListDetailsView.NoSelectionContentTemplate>
-            <controls:ListDetailsView.ListCommandBar>
+            <controls:ListDetailsView.ListPaneCommandBar>
                 <CommandBar>
                     <AppBarButton Icon="Back" Label="Back"/>
                     <AppBarButton Icon="Forward" Label="Forward"/>
@@ -84,14 +84,14 @@
             </TextBlock>
           </CommandBar.Content>
         </CommandBar>
-      </controls:ListDetailsView.ListCommandBar>
-      <controls:ListDetailsView.DetailsCommandBar>
+      </controls:ListDetailsView.ListPaneCommandBar>
+      <controls:ListDetailsView.DetailsPaneCommandBar>
         <CommandBar>
           <AppBarButton Icon="MailReply" Label="Reply" />
           <AppBarButton Icon="MailReplyAll" Label="Reply All" />
           <AppBarButton Icon="MailForward" Label="Forward" />
         </CommandBar>
-      </controls:ListDetailsView.DetailsCommandBar>
+      </controls:ListDetailsView.DetailsPaneCommandBar>
     </controls:ListDetailsView>
   </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListDetailsView/ListDetailsViewPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ListDetailsView/ListDetailsViewPage.xaml
@@ -4,7 +4,6 @@
       xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:models="using:Microsoft.Toolkit.Uwp.SampleApp.Models"
       mc:Ignorable="d">
 
     <controls:ListDetailsView Visibility="Collapsed" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Metadata.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Metadata.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -37,8 +37,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
                         new EditorBrowsableAttribute(EditorBrowsableState.Advanced)
                     );
                     b.AddCustomAttributes(nameof(ListDetailsView.ViewState), new CategoryAttribute(Resources.CategoryCommon));
-                    b.AddCustomAttributes(nameof(ListDetailsView.ListCommandBar), new CategoryAttribute(Resources.CategoryCommon));
-                    b.AddCustomAttributes(nameof(ListDetailsView.DetailsCommandBar), new CategoryAttribute(Resources.CategoryCommon));
+                    b.AddCustomAttributes(nameof(ListDetailsView.ListPaneCommandBar), new CategoryAttribute(Resources.CategoryCommon));
+                    b.AddCustomAttributes(nameof(ListDetailsView.DetailsPaneCommandBar), new CategoryAttribute(Resources.CategoryCommon));
                     b.AddCustomAttributes(new ToolboxCategoryAttribute(ToolboxCategoryPaths.Toolkit, false));
                 }
             );

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Typedata.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout.Design/Controls/ListDetailsView.Typedata.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-using System;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
 {
@@ -13,9 +11,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
 
     internal static class ListDetailsView
     {
-        internal const string DetailsCommandBar = nameof(DetailsCommandBar);
+        internal const string DetailsPaneCommandBar = nameof(DetailsPaneCommandBar);
         internal const string DetailsTemplate = nameof(DetailsTemplate);
-        internal const string ListCommandBar = nameof(ListCommandBar);
+        internal const string ListPaneCommandBar = nameof(ListPaneCommandBar);
         internal const string ListHeader = nameof(ListHeader);
         internal const string ListHeaderTemplate = nameof(ListHeaderTemplate);
         internal const string ListPaneBackground = nameof(ListPaneBackground);

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.BackButton.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.BackButton.cs
@@ -1,0 +1,166 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Windows.ApplicationModel;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// Panel that allows for a List/Details pattern.
+    /// </summary>
+    /// <seealso cref="ItemsControl" />
+    public partial class ListDetailsView
+    {
+        private AppViewBackButtonVisibility? _previousSystemBackButtonVisibility;
+        private bool _previousNavigationViewBackEnabled;
+
+        // Int used because the underlying type is an enum, but we don't have access to the enum
+        private int _previousNavigationViewBackVisibilty;
+        private Button _inlineBackButton;
+        private object _navigationView;
+        private Frame _frame;
+
+        /// <summary>
+        /// Sets the back button visibility based on the current visual state and selected item
+        /// </summary>
+        private void SetBackButtonVisibility(ListDetailsViewState? previousState = null)
+        {
+            const int backButtonVisible = 1;
+
+            if (DesignMode.DesignModeEnabled)
+            {
+                return;
+            }
+
+            if (ViewState == ListDetailsViewState.Details)
+            {
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
+                {
+                    _inlineBackButton.Visibility = Visibility.Visible;
+                }
+                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
+                {
+                    // Continue to support the system back button if it is being used
+                    SystemNavigationManager navigationManager = SystemNavigationManager.GetForCurrentView();
+                    if (navigationManager.AppViewBackButtonVisibility == AppViewBackButtonVisibility.Visible)
+                    {
+                        // Setting this indicates that the system back button is being used
+                        _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+                    }
+                    else if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
+                    {
+                        // We can only use the new NavigationView if we also have a Frame
+                        // If there is no frame we have to use the inline button
+                        _inlineBackButton.Visibility = Visibility.Visible;
+                    }
+                    else
+                    {
+                        SetNavigationViewBackButtonState(backButtonVisible, true);
+                    }
+                }
+                else if (BackButtonBehavior != BackButtonBehavior.Manual)
+                {
+                    SystemNavigationManager navigationManager = SystemNavigationManager.GetForCurrentView();
+                    _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+
+                    navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
+                }
+            }
+            else if (previousState == ListDetailsViewState.Details)
+            {
+                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
+                {
+                    _inlineBackButton.Visibility = Visibility.Collapsed;
+                }
+                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
+                {
+                    if (!_previousSystemBackButtonVisibility.HasValue)
+                    {
+                        if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
+                        {
+                            _inlineBackButton.Visibility = Visibility.Collapsed;
+                        }
+                        else
+                        {
+                            SetNavigationViewBackButtonState(_previousNavigationViewBackVisibilty, _previousNavigationViewBackEnabled);
+                        }
+                    }
+                }
+
+                if (_previousSystemBackButtonVisibility.HasValue)
+                {
+                    // Make sure we show the back button if the stack can navigate back
+                    SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = _previousSystemBackButtonVisibility.Value;
+                    _previousSystemBackButtonVisibility = null;
+                }
+            }
+        }
+
+        private void SetNavigationViewBackButtonState(int visible, bool enabled)
+        {
+            if (_navigationView == null)
+            {
+                return;
+            }
+
+            System.Type navType = _navigationView.GetType();
+            PropertyInfo visibleProperty = navType.GetProperty("IsBackButtonVisible");
+            if (visibleProperty != null)
+            {
+                _previousNavigationViewBackVisibilty = (int)visibleProperty.GetValue(_navigationView);
+                visibleProperty.SetValue(_navigationView, visible);
+            }
+
+            PropertyInfo enabledProperty = navType.GetProperty("IsBackEnabled");
+            if (enabledProperty != null)
+            {
+                _previousNavigationViewBackEnabled = (bool)enabledProperty.GetValue(_navigationView);
+                enabledProperty.SetValue(_navigationView, enabled);
+            }
+        }
+
+        /// <summary>
+        /// Closes the details pane if we are in narrow state
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="args">The event args</param>
+        private void OnFrameNavigating(object sender, NavigatingCancelEventArgs args)
+        {
+            if ((args.NavigationMode == NavigationMode.Back) && (ViewState == ListDetailsViewState.Details))
+            {
+                ClearSelectedItem();
+                args.Cancel = true;
+            }
+        }
+
+        /// <summary>
+        /// Closes the details pane if we are in narrow state
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="args">The event args</param>
+        private void OnBackRequested(object sender, BackRequestedEventArgs args)
+        {
+            if (ViewState == ListDetailsViewState.Details)
+            {
+                // let the OnFrameNavigating method handle it if
+                if (_frame == null || !_frame.CanGoBack)
+                {
+                    ClearSelectedItem();
+                }
+
+                args.Handled = true;
+            }
+        }
+
+        private void OnInlineBackButtonClicked(object sender, RoutedEventArgs e)
+        {
+            ClearSelectedItem();
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Events.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// Panel that allows for a List/Details pattern.
     /// </summary>
-    /// <seealso cref="Windows.UI.Xaml.Controls.ItemsControl" />
+    /// <seealso cref="ItemsControl" />
     public partial class ListDetailsView
     {
         /// <summary>
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public event SelectionChangedEventHandler SelectionChanged;
 
         /// <summary>
-        /// Occurs when the view state changes
+        /// Occurs when the view state changes.
         /// </summary>
         public event EventHandler<ListDetailsViewState> ViewStateChanged;
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.Properties.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,16 +15,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <seealso cref="Windows.UI.Xaml.Controls.ItemsControl" />
     public partial class ListDetailsView
     {
-        /// <summary>
-        /// Identifies the SelectedIndex dependency property.
-        /// </summary>
-        public static readonly DependencyProperty SelectedIndexProperty =
-            DependencyProperty.Register(
-                nameof(SelectedIndex),
-                typeof(int),
-                typeof(ListDetailsView),
-                new PropertyMetadata(-1, OnSelectedIndexChanged));
-
         /// <summary>
         /// Identifies the <see cref="SelectedItem"/> dependency property.
         /// </summary>
@@ -63,7 +53,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(ListHeader),
             typeof(object),
             typeof(ListDetailsView),
-            new PropertyMetadata(null, OnListHeaderChanged));
+            new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="ListHeaderTemplate"/> dependency property.
@@ -95,15 +85,46 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             typeof(ListDetailsView),
             new PropertyMetadata(null));
 
+
+        /// <summary>
+        /// Identifies the <see cref="DetailsPaneBackground"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="DetailsPaneBackground"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsPaneBackgroundProperty = DependencyProperty.Register(
+            nameof(DetailsPaneBackground),
+            typeof(Brush),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="ListPaneNoItemsContent"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="ListPaneNoItemsContent"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneNoItemsContentProperty = DependencyProperty.Register(
+            nameof(ListPaneNoItemsContent),
+            typeof(object),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="ListPaneNoItemsContentTemplate"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="ListPaneNoItemsContentTemplate"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneNoItemsContentTemplateProperty = DependencyProperty.Register(
+            nameof(ListPaneNoItemsContentTemplate),
+            typeof(DataTemplate),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
         /// <summary>
         /// Identifies the <see cref="ListPaneWidth"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="ListPaneWidth"/> dependency property.</returns>
         public static readonly DependencyProperty ListPaneWidthProperty = DependencyProperty.Register(
             nameof(ListPaneWidth),
-            typeof(double),
+            typeof(GridLength),
             typeof(ListDetailsView),
-            new PropertyMetadata(320d));
+            new PropertyMetadata(new GridLength(320)));
 
         /// <summary>
         /// Identifies the <see cref="NoSelectionContent"/> dependency property.
@@ -126,7 +147,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
-        /// Identifies the <see cref="ViewState"/> dependency property
+        /// Identifies the <see cref="ViewState"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="ViewState"/> dependency property.</returns>
         public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(
@@ -136,52 +157,64 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(default(ListDetailsViewState)));
 
         /// <summary>
-        /// Identifies the <see cref="ListCommandBar"/> dependency property
+        /// Identifies the <see cref="ListPaneCommandBar"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="ListCommandBar"/> dependency property.</returns>
-        public static readonly DependencyProperty ListCommandBarProperty = DependencyProperty.Register(
-            nameof(ListCommandBar),
+        /// <returns>The identifier for the <see cref="ListPaneCommandBar"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneCommandBarProperty = DependencyProperty.Register(
+            nameof(ListPaneCommandBar),
             typeof(CommandBar),
             typeof(ListDetailsView),
-            new PropertyMetadata(null, OnListCommandBarChanged));
+            new PropertyMetadata(null, OnListPaneCommandBarChanged));
 
         /// <summary>
-        /// Identifies the <see cref="DetailsCommandBar"/> dependency property
+        /// Identifies the <see cref="DetailsPaneCommandBar"/> dependency property.
         /// </summary>
-        /// <returns>The identifier for the <see cref="DetailsCommandBar"/> dependency property.</returns>
-        public static readonly DependencyProperty DetailsCommandBarProperty = DependencyProperty.Register(
-            nameof(DetailsCommandBar),
+        /// <returns>The identifier for the <see cref="DetailsPaneCommandBar"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsPaneCommandBarProperty = DependencyProperty.Register(
+            nameof(DetailsPaneCommandBar),
             typeof(CommandBar),
             typeof(ListDetailsView),
-            new PropertyMetadata(null, OnDetailsCommandBarChanged));
+            new PropertyMetadata(null, OnDetailsPaneCommandBarChanged));
 
         /// <summary>
-        /// Identifies the <see cref="CompactModeThresholdWidth"/> dependency property
+        /// Identifies the <see cref="CompactModeThresholdWidth"/> dependency property.
         /// </summary>
+        /// <returns>The identifier for the <see cref="CompactModeThresholdWidth"/> dependency property.</returns>
         public static readonly DependencyProperty CompactModeThresholdWidthProperty = DependencyProperty.Register(
             nameof(CompactModeThresholdWidth),
             typeof(double),
             typeof(ListDetailsView),
-            new PropertyMetadata(720d, OnCompactModeThresholdWidthChanged));
+            new PropertyMetadata(640d));
 
         /// <summary>
-        /// Identifies the <see cref="BackButtonBehavior"/> dependency property
+        /// Identifies the <see cref="BackButtonBehavior"/> dependency property.
         /// </summary>
+        /// <returns>The identifier for the <see cref="BackButtonBehavior"/> dependency property.</returns>
         public static readonly DependencyProperty BackButtonBehaviorProperty = DependencyProperty.Register(
             nameof(BackButtonBehavior),
             typeof(BackButtonBehavior),
             typeof(ListDetailsView),
-            new PropertyMetadata(BackButtonBehavior.System, OnBackButtonBehaviorChanged));
+            new PropertyMetadata(null, OnBackButtonBehaviorChanged));
 
         /// <summary>
-        /// Gets or sets the index of the current selection.
+        /// Identifies the <see cref="DetailsContentTemplateSelector"/> dependency property.
         /// </summary>
-        /// <returns>The index of the current selection, or -1 if the selection is empty.</returns>
-        public int SelectedIndex
-        {
-            get { return (int)GetValue(SelectedIndexProperty); }
-            set { SetValue(SelectedIndexProperty, value); }
-        }
+        /// <returns>The identifier for the <see cref="DetailsContentTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty DetailsContentTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(DetailsContentTemplateSelector),
+            typeof(DataTemplateSelector),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
+
+        /// <summary>
+        /// Identifies the <see cref="ListPaneItemTemplateSelector"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="ListPaneItemTemplateSelector"/> dependency property.</returns>
+        public static readonly DependencyProperty ListPaneItemTemplateSelectorProperty = DependencyProperty.Register(
+            nameof(ListPaneItemTemplateSelector),
+            typeof(DataTemplateSelector),
+            typeof(ListDetailsView),
+            new PropertyMetadata(null));
 
         /// <summary>
         /// Gets or sets the selected item.
@@ -213,7 +246,41 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the content for the list pane's header
+        /// Gets or sets the Brush to apply to the background of the details area of the control.
+        /// </summary>
+        /// <returns>The Brush to apply to the background of the details area of the control.</returns>
+        public Brush DetailsPaneBackground
+        {
+            get { return (Brush)GetValue(DetailsPaneBackgroundProperty); }
+            set { SetValue(DetailsPaneBackgroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the content for the list pane's no items presenter.
+        /// </summary>
+        /// <returns>
+        /// The content of the list pane's header. The default is null.
+        /// </returns>
+        public object ListPaneNoItemsContent
+        {
+            get { return GetValue(ListPaneNoItemsContentProperty); }
+            set { SetValue(ListPaneNoItemsContentProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the DataTemplate used to display the list pane's no items presenter.
+        /// </summary>
+        /// <returns>
+        /// The template that specifies the visualization of the list pane no items object. The default is null.
+        /// </returns>
+        public DataTemplate ListPaneNoItemsContentTemplate
+        {
+            get { return (DataTemplate)GetValue(ListPaneNoItemsContentTemplateProperty); }
+            set { SetValue(ListPaneNoItemsContentTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the content for the list pane's header.
         /// </summary>
         /// <returns>
         /// The content of the list pane's header. The default is null.
@@ -267,14 +334,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// The width of the SplitView pane when it's fully expanded. The default is 320
         /// device-independent pixel (DIP).
         /// </returns>
-        public double ListPaneWidth
+        public GridLength ListPaneWidth
         {
-            get { return (double)GetValue(ListPaneWidthProperty); }
+            get { return (GridLength)GetValue(ListPaneWidthProperty); }
             set { SetValue(ListPaneWidthProperty, value); }
         }
 
         /// <summary>
-        /// Gets or sets the content to dsiplay when there is no item selected in the list list.
+        /// Gets or sets the content to display when there is no item selected in the list pane.
         /// </summary>
         public object NoSelectionContent
         {
@@ -296,34 +363,34 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets the current visual state of the control
+        /// Gets or sets gets the current visual state of the control.
         /// </summary>
         public ListDetailsViewState ViewState
         {
             get { return (ListDetailsViewState)GetValue(ViewStateProperty); }
-            private set { SetValue(ViewStateProperty, value); }
+            set { SetValue(ViewStateProperty, value); }
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="CommandBar"/> for the list section.
+        /// Gets or sets the <see cref="CommandBar"/> for the list pane.
         /// </summary>
-        public CommandBar ListCommandBar
+        public CommandBar ListPaneCommandBar
         {
-            get { return (CommandBar)GetValue(ListCommandBarProperty); }
-            set { SetValue(ListCommandBarProperty, value); }
+            get { return (CommandBar)GetValue(ListPaneCommandBarProperty); }
+            set { SetValue(ListPaneCommandBarProperty, value); }
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="CommandBar"/> for the details section.
+        /// Gets or sets the <see cref="CommandBar"/> for the details pane.
         /// </summary>
-        public CommandBar DetailsCommandBar
+        public CommandBar DetailsPaneCommandBar
         {
-            get { return (CommandBar)GetValue(DetailsCommandBarProperty); }
-            set { SetValue(DetailsCommandBarProperty, value); }
+            get { return (CommandBar)GetValue(DetailsPaneCommandBarProperty); }
+            set { SetValue(DetailsPaneCommandBarProperty, value); }
         }
 
         /// <summary>
-        /// Gets or sets the Threshold width that will trigger the control to go into compact mode
+        /// Gets or sets the Threshold width that will trigger the control to go into compact mode.
         /// </summary>
         public double CompactModeThresholdWidth
         {
@@ -332,7 +399,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the behavior to use for the back button
+        /// Gets or sets the behavior to use for the back button.
         /// </summary>
         /// <returns>The current BackButtonBehavior. The default is System.</returns>
         public BackButtonBehavior BackButtonBehavior
@@ -342,9 +409,47 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the details presenter.
+        /// </summary>
+        public DataTemplateSelector DetailsContentTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(DetailsContentTemplateSelectorProperty); }
+            set { SetValue(DetailsContentTemplateSelectorProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="DataTemplateSelector"/> for the list pane items.
+        /// </summary>
+        public DataTemplateSelector ListPaneItemTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(ListPaneItemTemplateSelectorProperty); }
+            set { SetValue(ListPaneItemTemplateSelectorProperty, value); }
+        }
+
+        /// <summary>
         /// Gets or sets a function for mapping the selected item to a different model.
         /// This new model will be the DataContext of the Details area.
         /// </summary>
         public Func<object, object> MapDetails { get; set; }
+
+        private static void OnDetailsPaneCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnDetailsPaneCommandBarChanged();
+        }
+
+        private static void OnListPaneCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnListPaneCommandBarChanged();
+        }
+
+        private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).OnSelectedItemChanged(e);
+        }
+
+        private static void OnBackButtonBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ListDetailsView)d).SetBackButtonVisibility();
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,7 +10,6 @@ using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
@@ -23,33 +22,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplateVisualState(Name = NoSelectionWideState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = HasSelectionWideState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = HasSelectionNarrowState, GroupName = SelectionStates)]
-    [TemplateVisualState(Name = NarrowState, GroupName = WidthStates)]
-    [TemplateVisualState(Name = WideState, GroupName = WidthStates)]
     public partial class ListDetailsView : ItemsControl
     {
-        private const string PartDetailsPresenter = "DetailsPresenter";
-        private const string PartDetailsPanel = "DetailsPanel";
-        private const string PartBackButton = "ListDetailsBackButton";
-        private const string PartHeaderContentPresenter = "HeaderContentPresenter";
-        private const string NarrowState = "NarrowState";
-        private const string WideState = "WideState";
-        private const string WidthStates = "WidthStates";
+        // All view states:
         private const string SelectionStates = "SelectionStates";
-        private const string HasSelectionNarrowState = "HasSelectionNarrow";
+        private const string NoSelectionWideState = "NoSelectionWide";
         private const string HasSelectionWideState = "HasSelectionWide";
         private const string NoSelectionNarrowState = "NoSelectionNarrow";
-        private const string NoSelectionWideState = "NoSelectionWide";
+        private const string HasSelectionNarrowState = "HasSelectionNarrow";
 
-        private AppViewBackButtonVisibility? _previousSystemBackButtonVisibility;
-        private bool _previousNavigationViewBackEnabled;
+        private const string HasItemsStates = "HasItemsStates";
+        private const string HasItemsState = "HasItemsState";
+        private const string HasNoItemsState = "HasNoItemsState";
 
-        // Int used because the underlying type is an enum, but we don't have access to the enum
-        private int _previousNavigationViewBackVisibilty;
+        // Control names:
+        private const string PartRootPanel = "RootPanel";
+        private const string PartDetailsPresenter = "DetailsPresenter";
+        private const string PartDetailsPanel = "DetailsPanel";
+        private const string PartMasterList = "MasterList";
+        private const string PartBackButton = "ListDetailsBackButton";
+        private const string PartHeaderContentPresenter = "HeaderContentPresenter";
+        private const string PartListPaneCommandBarPanel = "ListPaneCommandBarPanel";
+        private const string PartDetailsPaneCommandBarPanel = "DetailsPaneCommandBarPanel";
+
+        /// <summary>
+        /// Used to prevent screen flickering if only the order of the selected item changed.
+        /// </summary>
+        private bool _ignoreClearSelectedItem;
+
         private ContentPresenter _detailsPresenter;
+        private Microsoft.UI.Xaml.Controls.TwoPaneView _twoPaneView;
         private VisualStateGroup _selectionStateGroup;
-        private Button _inlineBackButton;
-        private object _navigationView;
-        private Frame _frame;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ListDetailsView"/> class.
@@ -63,248 +66,45 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Invoked whenever application code or internal processes (such as a rebuilding layout pass) call
-        /// ApplyTemplate. In simplest terms, this means the method is called just before a UI element displays
-        /// in your app. Override this method to influence the default post-template logic of a class.
+        /// Updates the visual state of the control.
         /// </summary>
-        protected override void OnApplyTemplate()
+        /// <param name="animate">False to skip animations.</param>
+        private void SetVisualState(bool animate)
         {
-            base.OnApplyTemplate();
-
-            if (_inlineBackButton != null)
+            string noSelectionState;
+            string hasSelectionState;
+            if (ViewState == ListDetailsViewState.Both)
             {
-                _inlineBackButton.Click -= OnInlineBackButtonClicked;
+                noSelectionState = NoSelectionWideState;
+                hasSelectionState = HasSelectionWideState;
+            }
+            else
+            {
+                noSelectionState = NoSelectionNarrowState;
+                hasSelectionState = HasSelectionNarrowState;
             }
 
-            _inlineBackButton = (Button)GetTemplateChild(PartBackButton);
-            if (_inlineBackButton != null)
+            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : hasSelectionState, animate);
+            VisualStateManager.GoToState(this, Items.Count > 0 ? HasItemsState : HasNoItemsState, animate);
+        }
+
+        /// <summary>
+        /// Sets the content of the <see cref="SelectedItem"/> based on current <see cref="MapDetails"/> function.
+        /// </summary>
+        private void SetDetailsContent()
+        {
+            if (_detailsPresenter != null)
             {
-                _inlineBackButton.Click += OnInlineBackButtonClicked;
-            }
-
-            _detailsPresenter = (ContentPresenter)GetTemplateChild(PartDetailsPresenter);
-            SetDetailsContent();
-
-            SetListHeaderVisibility();
-            OnDetailsCommandBarChanged();
-            OnListCommandBarChanged();
-
-            SizeChanged -= ListDetailsView_SizeChanged;
-            SizeChanged += ListDetailsView_SizeChanged;
-
-            UpdateView(true);
-        }
-
-        /// <summary>
-        /// Fired when the SelectedIndex changes.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        /// <remarks>
-        /// Sets up animations for the DetailsPresenter for animating in/out.
-        /// </remarks>
-        private static void OnSelectedIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-
-            var newValue = (int)e.NewValue < 0 ? null : view.Items[(int)e.NewValue];
-            var oldValue = e.OldValue == null ? null : view.Items.ElementAtOrDefault((int)e.OldValue);
-
-            // check if selection actually changed
-            if (view.SelectedItem != newValue)
-            {
-                // sync SelectedItem
-                view.SetValue(SelectedItemProperty, newValue);
-                view.UpdateSelection(oldValue, newValue);
-            }
-        }
-
-        /// <summary>
-        /// Fired when the SelectedItem changes.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        /// <remarks>
-        /// Sets up animations for the DetailsPresenter for animating in/out.
-        /// </remarks>
-        private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            var index = e.NewValue == null ? -1 : view.Items.IndexOf(e.NewValue);
-
-            // check if selection actually changed
-            if (view.SelectedIndex != index)
-            {
-                // sync SelectedIndex
-                view.SetValue(SelectedIndexProperty, index);
-                view.UpdateSelection(e.OldValue, e.NewValue);
-            }
-        }
-
-        /// <summary>
-        /// Fired when the <see cref="ListHeader"/> is changed.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnListHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.SetListHeaderVisibility();
-        }
-
-        /// <summary>
-        /// Fired when the DetailsCommandBar changes.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnDetailsCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.OnDetailsCommandBarChanged();
-        }
-
-        /// <summary>
-        /// Fired when CompactModeThresholdWIdthChanged
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnCompactModeThresholdWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            ((ListDetailsView)d).HandleStateChanges();
-        }
-
-        private static void OnBackButtonBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.SetBackButtonVisibility();
-        }
-
-        /// <summary>
-        /// Fired when the <see cref="ListCommandBar"/> changes.
-        /// </summary>
-        /// <param name="d">The sender</param>
-        /// <param name="e">The event args</param>
-        private static void OnListCommandBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var view = (ListDetailsView)d;
-            view.OnListCommandBarChanged();
-        }
-
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            if (DesignMode.DesignModeEnabled == false)
-            {
-                SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
-                if (_frame != null)
+                // Update the content template:
+                if (_detailsPresenter.ContentTemplateSelector != null)
                 {
-                    _frame.Navigating -= OnFrameNavigating;
+                    _detailsPresenter.ContentTemplate = _detailsPresenter.ContentTemplateSelector.SelectTemplate(SelectedItem, _detailsPresenter);
                 }
 
-                _navigationView = this.FindAscendants().FirstOrDefault(p => p.GetType().FullName == "Microsoft.UI.Xaml.Controls.NavigationView");
-                _frame = this.FindAscendant<Frame>();
-                if (_frame != null)
-                {
-                    _frame.Navigating += OnFrameNavigating;
-                }
-
-                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
-                if (_selectionStateGroup != null)
-                {
-                    _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
-                }
-
-                UpdateView(true);
-            }
-        }
-
-        private void OnUnloaded(object sender, RoutedEventArgs e)
-        {
-            if (DesignMode.DesignModeEnabled == false)
-            {
-                SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested;
-                if (_frame != null)
-                {
-                    _frame.Navigating -= OnFrameNavigating;
-                }
-
-                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
-                if (_selectionStateGroup != null)
-                {
-                    _selectionStateGroup.CurrentStateChanged -= OnSelectionStateChanged;
-                    _selectionStateGroup = null;
-                }
-            }
-        }
-
-        private void ListDetailsView_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            // if size is changing
-            if ((e.PreviousSize.Width < CompactModeThresholdWidth && e.NewSize.Width >= CompactModeThresholdWidth) ||
-                (e.PreviousSize.Width >= CompactModeThresholdWidth && e.NewSize.Width < CompactModeThresholdWidth))
-            {
-                HandleStateChanges();
-            }
-        }
-
-        private void OnInlineBackButtonClicked(object sender, RoutedEventArgs e)
-        {
-            SelectedItem = null;
-        }
-
-        /// <summary>
-        /// Raises SelectionChanged event and updates view.
-        /// </summary>
-        /// <param name="oldSelection">Old selection.</param>
-        /// <param name="newSelection">New selection.</param>
-        private void UpdateSelection(object oldSelection, object newSelection)
-        {
-            OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { oldSelection }, new List<object> { newSelection }));
-
-            UpdateView(true);
-
-            // If there is no selection, do not remove the DetailsPresenter content but let it animate out.
-            if (SelectedItem != null)
-            {
-                SetDetailsContent();
-            }
-        }
-
-        private void HandleStateChanges()
-        {
-            UpdateView(true);
-            SetListSelectionWithKeyboardFocusOnVisualStateChanged(ViewState);
-        }
-
-        /// <summary>
-        /// Closes the details pane if we are in narrow state
-        /// </summary>
-        /// <param name="sender">The sender</param>
-        /// <param name="args">The event args</param>
-        private void OnFrameNavigating(object sender, NavigatingCancelEventArgs args)
-        {
-            if ((args.NavigationMode == NavigationMode.Back) && (ViewState == ListDetailsViewState.Details))
-            {
-                SelectedItem = null;
-                args.Cancel = true;
-            }
-        }
-
-        /// <summary>
-        /// Closes the details pane if we are in narrow state
-        /// </summary>
-        /// <param name="sender">The sender</param>
-        /// <param name="args">The event args</param>
-        private void OnBackRequested(object sender, BackRequestedEventArgs args)
-        {
-            if (ViewState == ListDetailsViewState.Details)
-            {
-                // let the OnFrameNavigating method handle it if
-                if (_frame == null || !_frame.CanGoBack)
-                {
-                    SelectedItem = null;
-                }
-
-                args.Handled = true;
+                // Update the content:
+                _detailsPresenter.Content = MapDetails == null
+                    ? SelectedItem
+                    : SelectedItem != null ? MapDetails(SelectedItem) : null;
             }
         }
 
@@ -318,96 +118,81 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
+        /// <summary>
+        /// Clears the <see cref="SelectedItem"/> and prevent flickering of the UI if only the order of the items changed.
+        /// </summary>
+        public void ClearSelectedItem()
+        {
+            _ignoreClearSelectedItem = true;
+            SelectedItem = null;
+            _ignoreClearSelectedItem = false;
+        }
+
+        private void OnCommandBarChanged(string panelName, CommandBar commandbar)
+        {
+            if (GetTemplateChild(panelName) is Panel panel)
+            {
+                panel.Children.Clear();
+                if (commandbar != null)
+                {
+                    panel.Children.Add(commandbar);
+                }
+            }
+        }
+
+        private void OnListPaneCommandBarChanged()
+        {
+            OnCommandBarChanged(PartListPaneCommandBarPanel, ListPaneCommandBar);
+        }
+
+        private void OnDetailsPaneCommandBarChanged()
+        {
+            OnCommandBarChanged(PartDetailsPaneCommandBarPanel, DetailsPaneCommandBar);
+        }
+
+        private void OnSelectedItemChanged(DependencyPropertyChangedEventArgs e)
+        {
+            // Prevent setting the SelectedItem to null if only the order changed (=> collection reset got triggered).
+            if (!_ignoreClearSelectedItem && e.OldValue != null && e.NewValue == null && Items.Contains(e.OldValue))
+            {
+                SelectedItem = e.OldValue;
+                return;
+            }
+
+            OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { e.OldValue }, new List<object> { e.NewValue }));
+
+            UpdateView(true);
+
+            // If there is no selection, do not remove the DetailsPresenter content but let it animate out.
+            if (SelectedItem != null)
+            {
+                SetDetailsContent();
+            }
+        }
+
         private void UpdateView(bool animate)
         {
             UpdateViewState();
             SetVisualState(animate);
         }
 
-        /// <summary>
-        /// Sets the back button visibility based on the current visual state and selected item
-        /// </summary>
-        private void SetBackButtonVisibility(ListDetailsViewState? previousState = null)
-        {
-            const int backButtonVisible = 1;
-
-            if (DesignMode.DesignModeEnabled)
-            {
-                return;
-            }
-
-            if (ViewState == ListDetailsViewState.Details)
-            {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
-                {
-                    _inlineBackButton.Visibility = Visibility.Visible;
-                }
-                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
-                {
-                    // Continue to support the system back button if it is being used
-                    var navigationManager = SystemNavigationManager.GetForCurrentView();
-                    if (navigationManager.AppViewBackButtonVisibility == AppViewBackButtonVisibility.Visible)
-                    {
-                        // Setting this indicates that the system back button is being used
-                        _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
-                    }
-                    else if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
-                    {
-                        // We can only use the new NavigationView if we also have a Frame
-                        // If there is no frame we have to use the inline button
-                        _inlineBackButton.Visibility = Visibility.Visible;
-                    }
-                    else
-                    {
-                        SetNavigationViewBackButtonState(backButtonVisible, true);
-                    }
-                }
-                else if (BackButtonBehavior != BackButtonBehavior.Manual)
-                {
-                    var navigationManager = SystemNavigationManager.GetForCurrentView();
-                    _previousSystemBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
-
-                    navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
-                }
-            }
-            else if (previousState == ListDetailsViewState.Details)
-            {
-                if ((BackButtonBehavior == BackButtonBehavior.Inline) && (_inlineBackButton != null))
-                {
-                    _inlineBackButton.Visibility = Visibility.Collapsed;
-                }
-                else if (BackButtonBehavior == BackButtonBehavior.Automatic)
-                {
-                    if (_previousSystemBackButtonVisibility.HasValue == false)
-                    {
-                        if ((_inlineBackButton != null) && ((_navigationView == null) || (_frame == null)))
-                        {
-                            _inlineBackButton.Visibility = Visibility.Collapsed;
-                        }
-                        else
-                        {
-                            SetNavigationViewBackButtonState(_previousNavigationViewBackVisibilty, _previousNavigationViewBackEnabled);
-                        }
-                    }
-                }
-
-                if (_previousSystemBackButtonVisibility.HasValue)
-                {
-                    // Make sure we show the back button if the stack can navigate back
-                    SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = _previousSystemBackButtonVisibility.Value;
-                    _previousSystemBackButtonVisibility = null;
-                }
-            }
-        }
-
         private void UpdateViewState()
         {
-            var previousState = ViewState;
+            ListDetailsViewState previousState = ViewState;
 
-            if (ActualWidth < CompactModeThresholdWidth)
+            if (_twoPaneView == null)
+            {
+                ViewState = ListDetailsViewState.Both;
+            }
+
+            // Single pane:
+            else if (_twoPaneView.Mode == Microsoft.UI.Xaml.Controls.TwoPaneViewMode.SinglePane)
             {
                 ViewState = SelectedItem == null ? ListDetailsViewState.List : ListDetailsViewState.Details;
+                _twoPaneView.PanePriority = SelectedItem == null ? Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane1 : Microsoft.UI.Xaml.Controls.TwoPaneViewPriority.Pane2;
             }
+
+            // Dual pane:
             else
             {
                 ViewState = ListDetailsViewState.Both;
@@ -418,128 +203,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 ViewStateChanged?.Invoke(this, ViewState);
                 SetBackButtonVisibility(previousState);
             }
-        }
-
-        private void SetVisualState(bool animate)
-        {
-            string state;
-            string noSelectionState;
-            string hasSelectionState;
-            if (ActualWidth < CompactModeThresholdWidth)
-            {
-                state = NarrowState;
-                noSelectionState = NoSelectionNarrowState;
-                hasSelectionState = HasSelectionNarrowState;
-            }
-            else
-            {
-                state = WideState;
-                noSelectionState = NoSelectionWideState;
-                hasSelectionState = HasSelectionWideState;
-            }
-
-            VisualStateManager.GoToState(this, state, animate);
-            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : hasSelectionState, animate);
-        }
-
-        private void SetNavigationViewBackButtonState(int visible, bool enabled)
-        {
-            if (_navigationView == null)
-            {
-                return;
-            }
-
-            var navType = _navigationView.GetType();
-            var visibleProperty = navType.GetProperty("IsBackButtonVisible");
-            if (visibleProperty != null)
-            {
-                _previousNavigationViewBackVisibilty = (int)visibleProperty.GetValue(_navigationView);
-                visibleProperty.SetValue(_navigationView, visible);
-            }
-
-            var enabledProperty = navType.GetProperty("IsBackEnabled");
-            if (enabledProperty != null)
-            {
-                _previousNavigationViewBackEnabled = (bool)enabledProperty.GetValue(_navigationView);
-                enabledProperty.SetValue(_navigationView, enabled);
-            }
-        }
-
-        private void SetDetailsContent()
-        {
-            if (_detailsPresenter != null)
-            {
-                _detailsPresenter.Content = MapDetails == null
-                    ? SelectedItem
-                    : SelectedItem != null ? MapDetails(SelectedItem) : null;
-            }
-        }
-
-        private void OnListCommandBarChanged()
-        {
-            OnCommandBarChanged("ListCommandBarPanel", ListCommandBar);
-        }
-
-        private void OnDetailsCommandBarChanged()
-        {
-            OnCommandBarChanged("DetailsCommandBarPanel", DetailsCommandBar);
-        }
-
-        private void OnCommandBarChanged(string panelName, CommandBar commandbar)
-        {
-            var panel = GetTemplateChild(panelName) as Panel;
-            if (panel == null)
-            {
-                return;
-            }
-
-            panel.Children.Clear();
-            if (commandbar != null)
-            {
-                panel.Children.Add(commandbar);
-            }
-        }
-
-        /// <summary>
-        /// Sets whether the selected item should change when focused with the keyboard based on the view state
-        /// </summary>
-        /// <param name="viewState">the view state</param>
-        private void SetListSelectionWithKeyboardFocusOnVisualStateChanged(ListDetailsViewState viewState)
-        {
-            if (viewState == ListDetailsViewState.Both)
-            {
-                SetListSelectionWithKeyboardFocus(true);
-            }
-            else
-            {
-                SetListSelectionWithKeyboardFocus(false);
-            }
-        }
-
-        /// <summary>
-        /// Sets whether the selected item should change when focused with the keyboard
-        /// </summary>
-        private void SetListSelectionWithKeyboardFocus(bool singleSelectionFollowsFocus)
-        {
-            if (GetTemplateChild("List") is Windows.UI.Xaml.Controls.ListViewBase list)
-            {
-                list.SingleSelectionFollowsFocus = singleSelectionFollowsFocus;
-            }
-        }
-
-        /// <summary>
-        /// Fires when the selection state of the control changes
-        /// </summary>
-        /// <param name="sender">the sender</param>
-        /// <param name="e">the event args</param>
-        /// <remarks>
-        /// Sets focus to the item list when the viewState is not Details.
-        /// Sets whether the selected item should change when focused with the keyboard.
-        /// </remarks>
-        private void OnSelectionStateChanged(object sender, VisualStateChangedEventArgs e)
-        {
-            SetFocus(ViewState);
-            SetListSelectionWithKeyboardFocusOnVisualStateChanged(ViewState);
         }
 
         /// <summary>
@@ -565,7 +228,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (GetTemplateChild(PartDetailsPanel) is DependencyObject details)
             {
-                var focusableElement = FocusManager.FindFirstFocusableElement(details);
+                DependencyObject focusableElement = FocusManager.FindFirstFocusableElement(details);
                 (focusableElement as Control)?.Focus(FocusState.Programmatic);
             }
         }
@@ -575,10 +238,147 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void FocusItemList()
         {
-            if (GetTemplateChild("List") is Control list)
+            if (GetTemplateChild(PartMasterList) is Control masterList)
             {
-                list.Focus(FocusState.Programmatic);
+                masterList.Focus(FocusState.Programmatic);
             }
+        }
+
+        /// <summary>
+        /// Sets whether the selected item should change when focused with the keyboard based on the view state
+        /// </summary>
+        /// <param name="viewState">the view state</param>
+        private void SetListSelectionWithKeyboardFocusOnVisualStateChanged(ListDetailsViewState viewState)
+        {
+            if (viewState == ListDetailsViewState.Both)
+            {
+                SetListSelectionWithKeyboardFocus(true);
+            }
+            else
+            {
+                SetListSelectionWithKeyboardFocus(false);
+            }
+        }
+
+        /// <summary>
+        /// Sets whether the selected item should change when focused with the keyboard
+        /// </summary>
+        private void SetListSelectionWithKeyboardFocus(bool singleSelectionFollowsFocus)
+        {
+            if (GetTemplateChild(PartListPaneCommandBarPanel) is ListViewBase masterList)
+            {
+                masterList.SingleSelectionFollowsFocus = singleSelectionFollowsFocus;
+            }
+        }
+
+        /// <summary>
+        /// Invoked once the items changed and ensures the visual state is constant.
+        /// </summary>
+        protected override void OnItemsChanged(object e)
+        {
+            base.OnItemsChanged(e);
+            UpdateView(true);
+        }
+
+        /// <summary>
+        /// Invoked whenever application code or internal processes (such as a rebuilding layout pass) call
+        /// ApplyTemplate. In simplest terms, this means the method is called just before a UI element displays
+        /// in your app. Override this method to influence the default post-template logic of a class.
+        /// </summary>
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            if (_inlineBackButton != null)
+            {
+                _inlineBackButton.Click -= OnInlineBackButtonClicked;
+            }
+
+            _inlineBackButton = (Button)GetTemplateChild(PartBackButton);
+            if (_inlineBackButton != null)
+            {
+                _inlineBackButton.Click += OnInlineBackButtonClicked;
+            }
+
+            _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
+            if (_selectionStateGroup != null)
+            {
+                _selectionStateGroup.CurrentStateChanged += OnSelectionStateChanged;
+            }
+
+            _twoPaneView = (Microsoft.UI.Xaml.Controls.TwoPaneView)GetTemplateChild(PartRootPanel);
+            if (_twoPaneView != null)
+            {
+                _twoPaneView.ModeChanged += OnModeChanged;
+            }
+
+            _detailsPresenter = (ContentPresenter)GetTemplateChild(PartDetailsPresenter);
+
+            SetDetailsContent();
+
+            SetListHeaderVisibility();
+            OnDetailsPaneCommandBarChanged();
+            OnListPaneCommandBarChanged();
+
+            UpdateView(true);
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            if (!DesignMode.DesignModeEnabled)
+            {
+                SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested;
+                if (_frame != null)
+                {
+                    _frame.Navigating -= OnFrameNavigating;
+                }
+
+                _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
+                if (_selectionStateGroup != null)
+                {
+                    _selectionStateGroup.CurrentStateChanged -= OnSelectionStateChanged;
+                    _selectionStateGroup = null;
+                }
+            }
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (!DesignMode.DesignModeEnabled)
+            {
+                SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
+                if (_frame != null)
+                {
+                    _frame.Navigating -= OnFrameNavigating;
+                }
+
+                _navigationView = this.FindAscendants().FirstOrDefault(p => p.GetType().FullName == "Microsoft.UI.Xaml.Controls.NavigationView");
+                _frame = this.FindAscendant<Frame>();
+                if (_frame != null)
+                {
+                    _frame.Navigating += OnFrameNavigating;
+                }
+            }
+        }
+
+        private void OnModeChanged(Microsoft.UI.Xaml.Controls.TwoPaneView sender, object args)
+        {
+            UpdateView(true);
+        }
+
+        /// <summary>
+        /// Fires when the selection state of the control changes
+        /// </summary>
+        /// <param name="sender">the sender</param>
+        /// <param name="e">the event args</param>
+        /// <remarks>
+        /// Sets focus to the item list when the viewState is not Details.
+        /// Sets whether the selected item should change when focused with the keyboard.
+        /// </remarks>
+        private void OnSelectionStateChanged(object sender, VisualStateChangedEventArgs e)
+        {
+            SetFocus(ViewState);
+            SetListSelectionWithKeyboardFocusOnVisualStateChanged(ViewState);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsView.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls">
+                    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+                    xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
     <Style TargetType="controls:ListDetailsView">
         <Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
@@ -13,92 +14,122 @@
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}">
-                        <Grid x:Name="RootPanel">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="ListColumn"
-                                                  Width="Auto" />
-                                <ColumnDefinition x:Name="DetailsColumn"
-                                                  Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid x:Name="ListPanel"
-                                  Width="{TemplateBinding ListPaneWidth}"
-                                  Background="{TemplateBinding ListPaneBackground}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="0,0,1,0">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <ContentPresenter x:Name="HeaderContentPresenter"
-                                                  Margin="12,0"
-                                                  x:DeferLoadStrategy="Lazy"
-                                                  Content="{TemplateBinding ListHeader}"
-                                                  ContentTemplate="{TemplateBinding ListHeaderTemplate}"
-                                                  Visibility="Collapsed" />
-                                <ListView x:Name="List"
-                                          Grid.Row="1"
-                                          IsTabStop="False"
-                                          ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
-                                          ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
-                                          ItemTemplate="{TemplateBinding ItemTemplate}"
-                                          ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                          ItemsSource="{TemplateBinding ItemsSource}"
-                                          SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
-                                <Grid x:Name="ListCommandBarPanel" Grid.Row="2"></Grid>
-                            </Grid>
-                            <Grid x:Name="DetailsPanel"
-                                  Grid.Column="1">
-                                <ContentPresenter x:Name="NoSelectionPresenter"
-                                                  Content="{TemplateBinding NoSelectionContent}"
-                                                  ContentTemplate="{TemplateBinding NoSelectionContentTemplate}" />
-                                <Grid x:Name="SelectionDetailsPanel">
+                        <muxc:TwoPaneView x:Name="RootPanel"
+                                          MinWideModeWidth="{TemplateBinding CompactModeThresholdWidth}"
+                                          Pane1Length="{TemplateBinding ListPaneWidth}"
+                                          PanePriority="Pane1"
+                                          TallModeConfiguration="SinglePane"
+                                          WideModeConfiguration="LeftRight">
+                            <muxc:TwoPaneView.Pane1>
+                                <Grid x:Name="MasterPanel"
+                                      Background="{TemplateBinding ListPaneBackground}">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="*" />
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Grid Background="{TemplateBinding Background}">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Button x:Name="ListDetailsBackButton"
-                                                Background="Transparent"
-                                                Height="44" 
-                                                Width="48" 
-                                                Visibility="Collapsed">
-                                            <SymbolIcon Symbol="Back"/>
-                                        </Button>
-                                        <ContentPresenter x:Name="DetailsHeaderPresenter"
-                                                          Content="{TemplateBinding DetailsHeader}"
-                                                          ContentTemplate="{TemplateBinding DetailsHeaderTemplate}"
-                                                          Grid.Column="1"/>
-                                    </Grid>
-                                    <ContentPresenter x:Name="DetailsPresenter"
-                                                      Background="{TemplateBinding Background}"
-                                                      ContentTemplate="{TemplateBinding DetailsTemplate}"
-                                                      Grid.Row="1">
-                                    </ContentPresenter>
-                                    <Grid x:Name="DetailsCommandBarPanel" Grid.Row="2"></Grid>
+                                    <ContentPresenter x:Name="HeaderContentPresenter"
+                                                      Margin="12,0"
+                                                      x:DeferLoadStrategy="Lazy"
+                                                      Content="{TemplateBinding ListHeader}"
+                                                      ContentTemplate="{TemplateBinding ListHeaderTemplate}"
+                                                      Visibility="Collapsed" />
+                                    <ContentPresenter x:Name="MasterNoItemsPresenter"
+                                                      Grid.Row="1"
+                                                      Content="{TemplateBinding ListPaneNoItemsContent}"
+                                                      ContentTemplate="{TemplateBinding ListPaneNoItemsContentTemplate}" />
+                                    <ListView x:Name="MasterList"
+                                              Grid.Row="1"
+                                              IsTabStop="False"
+                                              ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+                                              ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
+                                              ItemTemplate="{TemplateBinding ItemTemplate}"
+                                              ItemTemplateSelector="{TemplateBinding ListPaneItemTemplateSelector}"
+                                              ItemsSource="{TemplateBinding ItemsSource}"
+                                              SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              Visibility="Collapsed" />
+                                    <Grid x:Name="ListPaneCommandBarPanel"
+                                          Grid.Row="2" />
                                     <Grid.RenderTransform>
-                                        <TranslateTransform x:Name="DetailsPresenterTransform" />
+                                        <TranslateTransform x:Name="MasterPresenterTransform" />
                                     </Grid.RenderTransform>
                                 </Grid>
-                            </Grid>
-                        </Grid>
+                            </muxc:TwoPaneView.Pane1>
+                            <muxc:TwoPaneView.Pane2>
+                                <Grid x:Name="DetailsPanel"
+                                      Background="{TemplateBinding DetailsPaneBackground}">
+                                    <ContentPresenter x:Name="NoSelectionPresenter"
+                                                      Content="{TemplateBinding NoSelectionContent}"
+                                                      ContentTemplate="{TemplateBinding NoSelectionContentTemplate}" />
+                                    <Grid x:Name="SelectionDetailsPanel">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Button x:Name="ListDetailsBackButton"
+                                                    Width="48"
+                                                    Height="44"
+                                                    Background="Transparent"
+                                                    Visibility="Collapsed">
+                                                <SymbolIcon Symbol="Back" />
+                                            </Button>
+                                            <ContentPresenter x:Name="DetailsHeaderPresenter"
+                                                              Grid.Column="1"
+                                                              Content="{TemplateBinding DetailsHeader}"
+                                                              ContentTemplate="{TemplateBinding DetailsHeaderTemplate}" />
+                                        </Grid>
+                                        <ContentPresenter x:Name="DetailsPresenter"
+                                                          Grid.Row="1"
+                                                          ContentTemplate="{TemplateBinding DetailsTemplate}"
+                                                          ContentTemplateSelector="{TemplateBinding DetailsContentTemplateSelector}" />
+                                        <Grid x:Name="DetailsPaneCommandBarPanel"
+                                              Grid.Row="2" />
+                                        <Grid.RenderTransform>
+                                            <TranslateTransform x:Name="DetailsPresenterTransform" />
+                                        </Grid.RenderTransform>
+                                    </Grid>
+                                </Grid>
+                            </muxc:TwoPaneView.Pane2>
+                        </muxc:TwoPaneView>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="SelectionStates">
+                                <VisualState x:Name="NoSelectionWide">
+                                    <VisualState.Setters>
+                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="HasSelectionWide">
+                                    <VisualState.Setters>
+                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="NoSelectionNarrow">
+                                    <VisualState.Setters>
+                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="HasSelectionNarrow">
+                                    <VisualState.Setters>
+                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="NoSelectionWide"
-                                                      To="HasSelection">
+                                                      To="HasSelectionWide">
                                         <Storyboard>
                                             <DrillInThemeAnimation EntranceTargetName="SelectionDetailsPanel"
                                                                    ExitTargetName="NoSelectionPresenter" />
                                         </Storyboard>
                                     </VisualTransition>
                                     <VisualTransition From="NoSelectionNarrow"
-                                                      To="HasSelection">
+                                                      To="HasSelectionNarrow">
                                         <Storyboard>
                                             <DoubleAnimation BeginTime="0:0:0"
                                                              Storyboard.TargetName="DetailsPresenterTransform"
@@ -120,85 +151,65 @@
                                                     <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
+                                            <DoubleAnimation BeginTime="0:0:0"
+                                                             Storyboard.TargetName="NoSelectionPresenter"
+                                                             Storyboard.TargetProperty="Opacity"
+                                                             From="1"
+                                                             To="0"
+                                                             Duration="0:0:0">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <QuarticEase EasingMode="EaseOut" />
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HasSelection"
+                                    <VisualTransition From="HasSelectionWide"
                                                       To="NoSelectionWide">
                                         <Storyboard>
                                             <DrillOutThemeAnimation EntranceTargetName="NoSelectionPresenter"
                                                                     ExitTargetName="SelectionDetailsPanel" />
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HasSelection"
+                                    <VisualTransition From="HasSelectionNarrow"
                                                       To="NoSelectionNarrow">
                                         <Storyboard>
                                             <DoubleAnimation BeginTime="0:0:0"
-                                                             Storyboard.TargetName="DetailsPresenterTransform"
+                                                             Storyboard.TargetName="MasterPresenterTransform"
                                                              Storyboard.TargetProperty="X"
-                                                             From="0"
-                                                             To="200"
-                                                             Duration="0:0:0.25" />
-                                            <DoubleAnimation BeginTime="0:0:0.08"
-                                                             Storyboard.TargetName="SelectionDetailsPanel"
-                                                             Storyboard.TargetProperty="Opacity"
-                                                             From="1"
+                                                             From="-200"
                                                              To="0"
-                                                             Duration="0:0:0.17">
+                                                             Duration="0:0:0.25">
                                                 <DoubleAnimation.EasingFunction>
                                                     <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
-                                            <DoubleAnimation BeginTime="0:0:0.0"
-                                                             Storyboard.TargetName="ListPanel"
+                                            <DoubleAnimation BeginTime="0:0:0"
+                                                             Storyboard.TargetName="MasterPanel"
                                                              Storyboard.TargetProperty="Opacity"
                                                              From="0"
                                                              To="1"
                                                              Duration="0:0:0.25">
                                                 <DoubleAnimation.EasingFunction>
-                                                    <QuarticEase EasingMode="EaseIn" />
+                                                    <QuarticEase EasingMode="EaseOut" />
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
-                                <VisualState x:Name="NoSelectionWide">
-                                    <VisualState.Setters>
-                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="HasSelectionWide">
-                                    <VisualState.Setters>
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="HasSelectionNarrow">
-                                    <VisualState.Setters>
-                                        <Setter Target="ListPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="NoSelectionNarrow">
-                                    <VisualState.Setters>
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="SelectionDetailsPanel.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
                             </VisualStateGroup>
-                            <VisualStateGroup x:Name="WidthStates">
-                                <VisualState x:Name="NarrowState">
+
+                            <VisualStateGroup x:Name="HasItemsStates">
+                                <VisualState x:Name="HasItemsState">
                                     <VisualState.Setters>
-                                        <Setter Target="ListColumn.Width" Value="*" />
-                                        <Setter Target="DetailsColumn.Width" Value="0" />
-                                        <Setter Target="DetailsPanel.(Grid.Column)" Value="0" />
-                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
-                                        <Setter Target="ListPanel.BorderThickness" Value="0" />
-                                        <Setter Target="ListPanel.Width" Value="NaN" />
+                                        <Setter Target="MasterList.Visibility" Value="Visible" />
+                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState x:Name="WideState">
+                                <VisualState x:Name="HasNoItemsState">
+                                    <VisualState.Setters>
+                                        <Setter Target="MasterList.Visibility" Value="Collapsed" />
+                                        <Setter Target="MasterNoItemsPresenter.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsViewState.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/ListDetailsView/ListDetailsViewState.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -10,17 +10,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public enum ListDetailsViewState
     {
         /// <summary>
-        /// Only the List view is shown
+        /// Only the List view is shown.
         /// </summary>
         List,
 
         /// <summary>
-        /// Only the Details view is shown
+        /// Only the Details view is shown.
         /// </summary>
         Details,
 
         /// <summary>
-        /// Both the List and Details views are shown
+        /// Both the List and Details views are shown.
         /// </summary>
         Both
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Layout/Microsoft.Toolkit.Uwp.UI.Controls.Layout.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Layout/Microsoft.Toolkit.Uwp.UI.Controls.Layout.csproj
@@ -34,6 +34,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.UI.Xaml" Version="2.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PRIResource Include="Strings\en-us\Resources.resw" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #3173
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
The [ListDetailsView](https://docs.microsoft.com/en-us/windows/communitytoolkit/controls/masterdetailsview) does not take advantage of multiple screens on Windows 10X devices.


## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
The new and refactored [ListDetailsView](https://docs.microsoft.com/en-us/windows/communitytoolkit/controls/masterdetailsview) control is aware of multiple screens when used on Windows 10X devices.
We archive this by replacing the current `grid`-based layout with the new [Two-pane view](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/two-pane-view) based layout.

## Additional changes
- I added additional properties: `DetailsPaneBackground`, `DetailsContentTemplateSelector`, `ListPaneNoItemsContent`, `ListPaneNoItemsContentTemplate` and `ListPaneItemTemplateSelector`.
- I added a new NuGet dependency: [Microsoft.UI.Xaml](https://github.com/microsoft/microsoft-ui-xaml) to `Microsoft.Toolkit.Uwp.UI.Controls.Layout`, so I would be able to use the [TwoPaneView](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.twopaneview) class regardlessof the current Windows 10 version.
- Renamed the `ListCommandBar` property to `ListPaneCommandBar`. For more consitency with property names.
- Renamed the `DetailsCommandBar` property to `DetailsPaneCommandBar`.  For more consitency with property names.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
### Old behavior
![Old Toolkit](https://user-images.githubusercontent.com/11741404/77059461-408ba480-69d7-11ea-9e68-9d15d299d7f2.png)

### New behavior 
![New Toolkit](https://user-images.githubusercontent.com/11741404/77059480-47b2b280-69d7-11ea-8b3a-d7522a2c2c42.png)