### PR TITLE
Fixes #3629 TileControl crashes when moving monitors

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Core/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Core/TileControl/TileControl.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 void LoadCompleted(LoadedImageSurface sender, LoadedImageSourceLoadCompletedEventArgs args)
                 {
-                    _imageSurface.LoadCompleted -= LoadCompleted;
+                    sender.LoadCompleted -= LoadCompleted;
 
                     if (args.Status == LoadedImageSourceLoadStatus.Success)
                     {

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Core/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Core/TileControl/TileControl.cs
@@ -173,9 +173,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 var loadCompletedSource = new TaskCompletionSource<bool>();
                 _brushVisual = compositor.CreateSurfaceBrush(_imageSurface);
 
-                _imageSurface.LoadCompleted += (s, e) =>
+                void LoadCompleted(LoadedImageSurface sender, LoadedImageSourceLoadCompletedEventArgs args)
                 {
-                    if (e.Status == LoadedImageSourceLoadStatus.Success)
+                    _imageSurface.LoadCompleted -= LoadCompleted;
+
+                    if (args.Status == LoadedImageSourceLoadStatus.Success)
                     {
                         loadCompletedSource.SetResult(true);
                     }
@@ -183,7 +185,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     {
                         loadCompletedSource.SetException(new ArgumentException("Image loading failed."));
                     }
-                };
+                }
+
+                _imageSurface.LoadCompleted += LoadCompleted;
 
                 await loadCompletedSource.Task;
                 _imageSize = _imageSurface.DecodedPhysicalSize;


### PR DESCRIPTION
## Fixes #3629 TileControl crashes when moving monitors
The LoadCompleted event was never unregistering and firing twice when reloaded across monitors causing an issue with the TaskCompletionSource.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Would crash when moving between different monitors (of different DPIs?)

## What is the new behavior?
No Crash.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
