### PR TITLE
Changed TextBoxExtensions.PlaceHolder property name

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMask.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMask.bind
@@ -41,7 +41,7 @@
 
                 <TextBox Grid.Row="1"
                          ui:TextBoxExtensions.Mask="+1999-9999"
-                         ui:TextBoxExtensions.MaskPlaceholderCharacter=" "
+                         ui:TextBoxExtensions.MaskPlaceholder=" "
                          Header="Text box with Mask +1999-9999 and placeHolder as space (placeholder represents the characters the user can change on runtime)"
                          HeaderTemplate="{StaticResource HeaderTemplate}"
                          Style="{StaticResource MaskedTextBoxStyle}" />

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMask.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMask.bind
@@ -33,34 +33,34 @@
                 </Grid.RowDefinitions>
 
                 <TextBox Name="AlphaTextBox"
-					     ui:TextBoxMask.Mask="9a9a-a9a*"
+                         ui:TextBoxExtensions.Mask="9a9a-a9a*"
                          Header="Text box with Mask 9a9a-a9a* (9 allows from 0 to 9, a allow from a to Z and * allows both a and 9)"
                          HeaderTemplate="{StaticResource HeaderTemplate}"
                          Style="{StaticResource MaskedTextBoxStyle}" 
-					               Text="TextBoxMask" />
+                         Text="TextBoxMask" />
 
                 <TextBox Grid.Row="1"
-                         ui:TextBoxMask.Mask="+1999-9999"
-                         ui:TextBoxMask.PlaceHolder=" "
+                         ui:TextBoxExtensions.Mask="+1999-9999"
+                         ui:TextBoxExtensions.MaskPlaceholderCharacter=" "
                          Header="Text box with Mask +1999-9999 and placeHolder as space (placeholder represents the characters the user can change on runtime)"
                          HeaderTemplate="{StaticResource HeaderTemplate}"
                          Style="{StaticResource MaskedTextBoxStyle}" />
 
                 <TextBox Grid.Row="2"
-                         ui:TextBoxMask.Mask="+\964 799 999 9999"
+                         ui:TextBoxExtensions.Mask="+\964 799 999 9999"
                          Header="Text box with Mask +964 799 999 9999 (Notice how we escape the first 9 with a backslash)"
                          HeaderTemplate="{StaticResource HeaderTemplate}"
                          Style="{StaticResource MaskedTextBoxStyle}" />
 
                 <TextBox Grid.Row="3"
-                         ui:TextBoxMask.Mask="99\\99\\9999"
+                         ui:TextBoxExtensions.Mask="99\\99\\9999"
                          Header="Text box with Mask 99\99\9999 (You can escape a backslash with another backslash)"
                          HeaderTemplate="{StaticResource HeaderTemplate}"
                          Style="{StaticResource MaskedTextBoxStyle}" />
 
                 <TextBox Grid.Row="4"
-                         ui:TextBoxMask.CustomMask="5:[1-5],c:[a-c]"
-                         ui:TextBoxMask.Mask="a5c-5c*9"
+                         ui:TextBoxExtensions.CustomMask="5:[1-5],c:[a-c]"
+                         ui:TextBoxExtensions.Mask="a5c-5c*9"
                          Header="Text box with CustomMask in case you want to define your own variable character like a, 9 and *. Mask: a5c-5c*9, 5: [1-5], c: [a-c]"
                          HeaderTemplate="{StaticResource HeaderTemplate}"
                          Style="{StaticResource MaskedTextBoxStyle}" />

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMaskPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMaskPage.xaml
@@ -11,10 +11,10 @@
         <TextBox ui:TextBoxExtensions.Mask="9a9a--a9a*"/>
 
         <TextBox ui:TextBoxExtensions.Mask="+1999-9999"
-                 ui:TextBoxExtensions.PlaceHolder=" " />
+                 ui:TextBoxExtensions.MaskPlaceholderCharacter=" " />
 
         <TextBox ui:TextBoxExtensions.Mask="+\964 799 999 9999"
-                 ui:TextBoxExtensions.PlaceHolder=" " />
+                 ui:TextBoxExtensions.MaskPlaceholderCharacter=" " />
 
         <TextBox ui:TextBoxExtensions.CustomMask="5:[1-5],c:[a-c]"
                  ui:TextBoxExtensions.Mask="a5c-5c*9" />

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMaskPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxMask/TextBoxMaskPage.xaml
@@ -11,10 +11,10 @@
         <TextBox ui:TextBoxExtensions.Mask="9a9a--a9a*"/>
 
         <TextBox ui:TextBoxExtensions.Mask="+1999-9999"
-                 ui:TextBoxExtensions.MaskPlaceholderCharacter=" " />
+                 ui:TextBoxExtensions.MaskPlaceholder=" " />
 
         <TextBox ui:TextBoxExtensions.Mask="+\964 799 999 9999"
-                 ui:TextBoxExtensions.MaskPlaceholderCharacter=" " />
+                 ui:TextBoxExtensions.MaskPlaceholder=" " />
 
         <TextBox ui:TextBoxExtensions.CustomMask="5:[1-5],c:[a-c]"
                  ui:TextBoxExtensions.Mask="a5c-5c*9" />

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxRegex/TextBoxRegex.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/TextBoxRegex/TextBoxRegex.bind
@@ -34,70 +34,70 @@
 
                 <StackPanel Margin="10,10,10,0">
         <TextBox Name="PhoneNumberValidator"
-                 ui:TextBoxRegex.Regex="^\s*\+?\s*([0-9][\s-]*){9,}$"
+                 ui:TextBoxExtensions.Regex="^\s*\+?\s*([0-9][\s-]*){9,}$"
                  Header="Text box with Regex extension for phone number, validation occurs on TextChanged"
                  HeaderTemplate="{StaticResource HeaderTemplate}"
                  Style="{StaticResource TextBoxRegexStyle}" />
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Is Valid: " />
-          <TextBlock Text="{Binding (ui:TextBoxRegex.IsValid), ElementName=PhoneNumberValidator, Converter={StaticResource StringFormatConverter}}" />
+          <TextBlock Text="{Binding (ui:TextBoxExtensions.IsValid), ElementName=PhoneNumberValidator, Converter={StaticResource StringFormatConverter}}" />
         </StackPanel>
 
       </StackPanel>
 
       <StackPanel Grid.Row="1"
-                        Margin="10,10,10,0">
+                  Margin="10,10,10,0">
         <TextBox Name="CharactValidator"
-                 ui:TextBoxRegex.ValidationMode="Dynamic"
-                 ui:TextBoxRegex.ValidationType="Characters"
+                 ui:TextBoxExtensions.ValidationMode="Dynamic"
+                 ui:TextBoxExtensions.ValidationType="Characters"
                  Header="Text box with ValidationType=Characters, validation occurs at input with ValidationMode=Dynamic and clear only single character when value is invalid"
                  HeaderTemplate="{StaticResource HeaderTemplate}"
                  Style="{StaticResource TextBoxRegexStyle}"
                  Text="abcdef" />
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Is Valid: " />
-          <TextBlock Text="{Binding (ui:TextBoxRegex.IsValid), ElementName=CharactValidator, Converter={StaticResource StringFormatConverter}}" />
+          <TextBlock Text="{Binding (ui:TextBoxExtensions.IsValid), ElementName=CharactValidator, Converter={StaticResource StringFormatConverter}}" />
         </StackPanel>
       </StackPanel>
 
       <StackPanel Grid.Row="2"
-                        Margin="10,10,10,0">
+                  Margin="10,10,10,0">
         <TextBox Name="EmailValidator"
-                 ui:TextBoxRegex.ValidationType="Email"
+                 ui:TextBoxExtensions.ValidationType="Email"
                  Header="Text box with ValidationType=Email, validation occurs on TextChanged"
                  HeaderTemplate="{StaticResource HeaderTemplate}"
                  Style="{StaticResource TextBoxRegexStyle}" />
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Is Valid: " />
-          <TextBlock Text="{Binding (ui:TextBoxRegex.IsValid), ElementName=EmailValidator, Converter={StaticResource StringFormatConverter}}" />
+          <TextBlock Text="{Binding (ui:TextBoxExtensions.IsValid), ElementName=EmailValidator, Converter={StaticResource StringFormatConverter}}" />
         </StackPanel>
       </StackPanel>
 
       <StackPanel Grid.Row="3"
                   Margin="10,10,10,0">
         <TextBox Name="DecimalValidatorForce"
-                 ui:TextBoxRegex.ValidationMode="Forced"
-                 ui:TextBoxRegex.ValidationType="Decimal"
+                 ui:TextBoxExtensions.ValidationMode="Forced"
+                 ui:TextBoxExtensions.ValidationType="Decimal"
                  Header="Text box with ValidationType=Decimal, validation occurs on TextChanged and force occurs on lose focus with ValidationMode=Force (333,111 or 333.111)"
                  HeaderTemplate="{StaticResource HeaderTemplate}"
                  Style="{StaticResource TextBoxRegexStyle}" />
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Is Valid: " />
-          <TextBlock Text="{Binding (ui:TextBoxRegex.IsValid), ElementName=DecimalValidatorForce, Converter={StaticResource StringFormatConverter}}" />
+          <TextBlock Text="{Binding (ui:TextBoxExtensions.IsValid), ElementName=DecimalValidatorForce, Converter={StaticResource StringFormatConverter}}" />
         </StackPanel>
       </StackPanel>
 
       <StackPanel Grid.Row="4"
                         Margin="10,10,10,0">
         <TextBox Name="NumberValidatorDynamic"
-                 ui:TextBoxRegex.ValidationMode="Dynamic"
-                 ui:TextBoxRegex.ValidationType="Number"
+                 ui:TextBoxExtensions.ValidationMode="Dynamic"
+                 ui:TextBoxExtensions.ValidationType="Number"
                  Header="Text box with ValidationType=Number, validation occurs at input with ValidationMode=Dynamic and clear only single character when value is invalid"
                  HeaderTemplate="{StaticResource HeaderTemplate}"
                  Style="{StaticResource TextBoxRegexStyle}" />
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Is Valid: " />
-          <TextBlock Text="{Binding (ui:TextBoxRegex.IsValid), ElementName=NumberValidatorDynamic, Converter={StaticResource StringFormatConverter}}" />
+          <TextBlock Text="{Binding (ui:TextBoxExtensions.IsValid), ElementName=NumberValidatorDynamic, Converter={StaticResource StringFormatConverter}}" />
         </StackPanel>
       </StackPanel>
 

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/SurfaceDialOptions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/SurfaceDialOptions.cs
@@ -5,7 +5,6 @@
 using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
 
 namespace Microsoft.Toolkit.Uwp.UI
 {

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Internals.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Internals.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 return;
             }
 
-            var placeHolderValue = textbox.GetValue(PlaceHolderProperty) as string;
+            var placeHolderValue = textbox.GetValue(MaskPlaceholderCharacterProperty) as string;
             if (string.IsNullOrEmpty(placeHolderValue))
             {
                 throw new ArgumentException("PlaceHolder can't be null or empty");
@@ -152,7 +152,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             var textbox = (TextBox)sender;
             var mask = textbox?.GetValue(MaskProperty) as string;
-            var placeHolderValue = textbox?.GetValue(PlaceHolderProperty) as string;
+            var placeHolderValue = textbox?.GetValue(MaskPlaceholderCharacterProperty) as string;
             var representationDictionary = textbox?.GetValue(RepresentationDictionaryProperty) as Dictionary<char, string>;
             if (string.IsNullOrWhiteSpace(mask) ||
                 representationDictionary == null ||
@@ -194,7 +194,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var textbox = (TextBox)sender;
             var mask = textbox.GetValue(MaskProperty) as string;
             var representationDictionary = textbox?.GetValue(RepresentationDictionaryProperty) as Dictionary<char, string>;
-            var placeHolderValue = textbox.GetValue(PlaceHolderProperty) as string;
+            var placeHolderValue = textbox.GetValue(MaskPlaceholderCharacterProperty) as string;
             if (string.IsNullOrWhiteSpace(mask) ||
             representationDictionary == null ||
             string.IsNullOrEmpty(placeHolderValue))
@@ -262,7 +262,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var escapedChars = textbox.GetValue(EscapedCharacterIndicesProperty) as List<int>;
 
             var representationDictionary = textbox.GetValue(RepresentationDictionaryProperty) as Dictionary<char, string>;
-            var placeHolderValue = textbox?.GetValue(PlaceHolderProperty) as string;
+            var placeHolderValue = textbox?.GetValue(MaskPlaceholderCharacterProperty) as string;
             var oldText = textbox.GetValue(OldTextProperty) as string;
             var oldSelectionStart = (int)textbox.GetValue(OldSelectionStartProperty);
             var oldSelectionLength = (int)textbox.GetValue(OldSelectionLengthProperty);

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Internals.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Internals.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 return;
             }
 
-            var placeHolderValue = textbox.GetValue(MaskPlaceholderCharacterProperty) as string;
+            var placeHolderValue = textbox.GetValue(MaskPlaceholderProperty) as string;
             if (string.IsNullOrEmpty(placeHolderValue))
             {
                 throw new ArgumentException("PlaceHolder can't be null or empty");
@@ -152,7 +152,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             var textbox = (TextBox)sender;
             var mask = textbox?.GetValue(MaskProperty) as string;
-            var placeHolderValue = textbox?.GetValue(MaskPlaceholderCharacterProperty) as string;
+            var placeHolderValue = textbox?.GetValue(MaskPlaceholderProperty) as string;
             var representationDictionary = textbox?.GetValue(RepresentationDictionaryProperty) as Dictionary<char, string>;
             if (string.IsNullOrWhiteSpace(mask) ||
                 representationDictionary == null ||
@@ -194,7 +194,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var textbox = (TextBox)sender;
             var mask = textbox.GetValue(MaskProperty) as string;
             var representationDictionary = textbox?.GetValue(RepresentationDictionaryProperty) as Dictionary<char, string>;
-            var placeHolderValue = textbox.GetValue(MaskPlaceholderCharacterProperty) as string;
+            var placeHolderValue = textbox.GetValue(MaskPlaceholderProperty) as string;
             if (string.IsNullOrWhiteSpace(mask) ||
             representationDictionary == null ||
             string.IsNullOrEmpty(placeHolderValue))
@@ -262,7 +262,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var escapedChars = textbox.GetValue(EscapedCharacterIndicesProperty) as List<int>;
 
             var representationDictionary = textbox.GetValue(RepresentationDictionaryProperty) as Dictionary<char, string>;
-            var placeHolderValue = textbox?.GetValue(MaskPlaceholderCharacterProperty) as string;
+            var placeHolderValue = textbox?.GetValue(MaskPlaceholderProperty) as string;
             var oldText = textbox.GetValue(OldTextProperty) as string;
             var oldSelectionStart = (int)textbox.GetValue(OldSelectionStartProperty);
             var oldSelectionLength = (int)textbox.GetValue(OldSelectionLengthProperty);

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Properties.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         /// <param name="obj">TextBox control</param>
         /// <returns>placeholder value</returns>
-        public static string GetPlaceHolder(TextBox obj)
+        public static string GetMaskPlaceholderCharacter(TextBox obj)
         {
             return (string)obj.GetValue(MaskPlaceholderCharacterProperty);
         }
@@ -70,7 +70,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         /// <param name="obj">TextBox Control</param>
         /// <param name="value">placeholder Value</param>
-        public static void SetPlaceHolder(TextBox obj, string value)
+        public static void SetMaskPlaceholderCharacter(TextBox obj, string value)
         {
             obj.SetValue(MaskPlaceholderCharacterProperty, value);
         }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Properties.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <summary>
         /// Represents the mask place holder which represents the variable character that the user can edit in the textbox
         /// </summary>
-        public static readonly DependencyProperty PlaceHolderProperty = DependencyProperty.RegisterAttached("PlaceHolder", typeof(string), typeof(TextBoxExtensions), new PropertyMetadata(DefaultPlaceHolder, InitTextBoxMask));
+        public static readonly DependencyProperty MaskPlaceholderCharacterProperty = DependencyProperty.RegisterAttached("MaskPlaceholderCharacter", typeof(string), typeof(TextBoxExtensions), new PropertyMetadata(DefaultPlaceHolder, InitTextBoxMask));
 
         /// <summary>
         /// Represents the custom mask that the user can create to add his own variable characters based on regex expression
@@ -62,7 +62,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>placeholder value</returns>
         public static string GetPlaceHolder(TextBox obj)
         {
-            return (string)obj.GetValue(PlaceHolderProperty);
+            return (string)obj.GetValue(MaskPlaceholderCharacterProperty);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="value">placeholder Value</param>
         public static void SetPlaceHolder(TextBox obj, string value)
         {
-            obj.SetValue(PlaceHolderProperty, value);
+            obj.SetValue(MaskPlaceholderCharacterProperty, value);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/TextBox/TextBoxExtensions.Mask.Properties.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <summary>
         /// Represents the mask place holder which represents the variable character that the user can edit in the textbox
         /// </summary>
-        public static readonly DependencyProperty MaskPlaceholderCharacterProperty = DependencyProperty.RegisterAttached("MaskPlaceholderCharacter", typeof(string), typeof(TextBoxExtensions), new PropertyMetadata(DefaultPlaceHolder, InitTextBoxMask));
+        public static readonly DependencyProperty MaskPlaceholderProperty = DependencyProperty.RegisterAttached("MaskPlaceholder", typeof(string), typeof(TextBoxExtensions), new PropertyMetadata(DefaultPlaceHolder, InitTextBoxMask));
 
         /// <summary>
         /// Represents the custom mask that the user can create to add his own variable characters based on regex expression
@@ -60,9 +60,9 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         /// <param name="obj">TextBox control</param>
         /// <returns>placeholder value</returns>
-        public static string GetMaskPlaceholderCharacter(TextBox obj)
+        public static string GetMaskPlaceholder(TextBox obj)
         {
-            return (string)obj.GetValue(MaskPlaceholderCharacterProperty);
+            return (string)obj.GetValue(MaskPlaceholderProperty);
         }
 
         /// <summary>
@@ -70,9 +70,9 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         /// <param name="obj">TextBox Control</param>
         /// <param name="value">placeholder Value</param>
-        public static void SetMaskPlaceholderCharacter(TextBox obj, string value)
+        public static void SetMaskPlaceholder(TextBox obj, string value)
         {
-            obj.SetValue(MaskPlaceholderCharacterProperty, value);
+            obj.SetValue(MaskPlaceholderProperty, value);
         }
 
         /// <summary>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Refactoring with API changes
<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The mask placeholder property is called `PlaceHolder`.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
It's now called `MaskPlaceholder` instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [X] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [X] Sample in sample app has been added / updated (for bug fixes / features)
    - [X] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes