### PR TITLE
Add ContentPresenter to Logical Tree helpers

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/FrameworkElement/FrameworkElementExtensions.LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/FrameworkElement/FrameworkElementExtensions.LogicalTree.cs
@@ -153,13 +153,13 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
             else if (element is ContentControl contentControl)
             {
-                if (contentControl.Content is T result && predicate.Match(result))
-                {
-                    return result;
-                }
-
                 if (contentControl.Content is FrameworkElement content)
                 {
+                    if (content is T result && predicate.Match(result))
+                    {
+                        return result;
+                    }
+
                     element = content;
 
                     goto Start;
@@ -167,13 +167,13 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
             else if (element is Border border)
             {
-                if (border.Child is T result && predicate.Match(result))
-                {
-                    return result;
-                }
-
                 if (border.Child is FrameworkElement child)
                 {
+                    if (child is T result && predicate.Match(result))
+                    {
+                        return result;
+                    }
+
                     element = child;
 
                     goto Start;
@@ -181,16 +181,16 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
             else if (element is ContentPresenter contentPresenter)
             {
-                // Sometimes ContentPresenters are used in control templates instead of ContentControls
-                // Therefore we should still check if it's Content is a FrameworkElement and match.
+                // Sometimes ContentPresenter is used in control templates instead of ContentControl,
+                // therefore we should still check if its Content is a matching FrameworkElement instance.
                 // This also makes this work for SwitchPresenter.
-                if (contentPresenter.Content is T result && predicate.Match(result))
-                {
-                    return result;
-                }
-
                 if (contentPresenter.Content is FrameworkElement content)
                 {
+                    if (content is T result && predicate.Match(result))
+                    {
+                        return result;
+                    }
+
                     element = content;
 
                     goto Start;
@@ -200,13 +200,13 @@ namespace Microsoft.Toolkit.Uwp.UI
             {
                 // We put UserControl right before the slower reflection fallback path as
                 // this type is less likely to be used compared to the other ones above.
-                if (userControl.Content is T result && predicate.Match(result))
-                {
-                    return result;
-                }
-
                 if (userControl.Content is FrameworkElement content)
                 {
+                    if (content is T result && predicate.Match(result))
+                    {
+                        return result;
+                    }
+
                     element = content;
 
                     goto Start;

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/FrameworkElement/FrameworkElementExtensions.LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/FrameworkElement/FrameworkElementExtensions.LogicalTree.cs
@@ -179,6 +179,23 @@ namespace Microsoft.Toolkit.Uwp.UI
                     goto Start;
                 }
             }
+            else if (element is ContentPresenter contentPresenter)
+            {
+                // Sometimes ContentPresenters are used in control templates instead of ContentControls
+                // Therefore we should still check if it's Content is a FrameworkElement and match.
+                // This also makes this work for SwitchPresenter.
+                if (contentPresenter.Content is T result && predicate.Match(result))
+                {
+                    return result;
+                }
+
+                if (contentPresenter.Content is FrameworkElement content)
+                {
+                    element = content;
+
+                    goto Start;
+                }
+            }
             else if (element is UserControl userControl)
             {
                 // We put UserControl right before the slower reflection fallback path as
@@ -366,6 +383,17 @@ namespace Microsoft.Toolkit.Uwp.UI
                     yield return child;
 
                     element = child;
+
+                    goto Start;
+                }
+            }
+            else if (element is ContentPresenter contentPresenter)
+            {
+                if (contentPresenter.Content is FrameworkElement content)
+                {
+                    yield return content;
+
+                    element = content;
 
                     goto Start;
                 }


### PR DESCRIPTION
## Fixes N/A
As I was writing the SwitchPresenter docs, I was doing some tests about how it loads/doesn't load content into the VisualTree. I noticed the VisualTree could find the descendants, but our logical helpers could not.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
Can't find the loaded children in the Logical Tree.

## What is the new behavior?
If ContentPresenter (like SwitchPresenter) have content which are also Framework Elements (and not data) then we'll continue walking like we would with a ContentControl.

This is important as some templates for controls use ContentPresenter more often than ContentControl in other places as ContentPresenter is lighter-weight than ContentControl.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
