### PR TITLE
Fixed unit tests for Point/Rect/Size extensions

### DIFF
--- a/UnitTests/UnitTests.UWP/Extensions/Test_PointExtensions.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_PointExtensions.cs
@@ -13,51 +13,51 @@ namespace UnitTests.Extensions
     {
         [TestCategory("PointExtensions")]
         [TestMethod]
-        [DataRow(0d, 0d, 0, 0)]
-        [DataRow(0d, 0d, 22, 6.89d)]
+        [DataRow(0d, 0d, 0d, 0d)]
+        [DataRow(0d, 0d, 22d, 6.89d)]
         [DataRow(3.14d, 6.55f, 3838d, 3.24724928d)]
-        [DataRow(double.MinValue, double.Epsilon, 22, 0.3248d)]
-        public static void Test_PointExtensions_ToRect_FromWidthHeight(double width, double height, int x, int y)
+        [DataRow(double.MaxValue / 2, double.Epsilon, 22d, 0.3248d)]
+        public void Test_PointExtensions_ToRect_FromWidthHeight(double width, double height, double x, double y)
         {
-            Point p = new Point(x, y);
+            Point p = new(x, y);
             Rect
                 a = p.ToRect(width, height),
-                b = new Rect(x, y, width, height);
+                b = new(x, y, width, height);
 
             Assert.AreEqual(a, b);
         }
 
         [TestCategory("SizeExtensions")]
         [TestMethod]
-        [DataRow(0d, 0d, 0, 0)]
-        [DataRow(0d, 0d, 22, 6.89d)]
+        [DataRow(0d, 0d, 0d, 0d)]
+        [DataRow(0d, 0d, 22d, 6.89d)]
         [DataRow(3.14d, 6.55f, 3838d, 3.24724928d)]
-        [DataRow(double.MinValue, double.Epsilon, 22, 0.3248d)]
-        public static void Test_PointExtensions_ToRect_FromPoint(double width, double height, int x, int y)
+        [DataRow(double.MaxValue / 2, double.Epsilon, 22, 0.3248d)]
+        public void Test_PointExtensions_ToRect_FromPoint(double width, double height, double x, double y)
         {
             Point
-                p1 = new Point(x, y),
-                p2 = new Point(x + width, y + height);
+                p1 = new(x, y),
+                p2 = new(x + width, y + height);
             Rect
                 a = p1.ToRect(p2),
-                b = new Rect(p1, p2);
+                b = new(p1, p2);
 
             Assert.AreEqual(a, b);
         }
 
         [TestCategory("SizeExtensions")]
         [TestMethod]
-        [DataRow(0d, 0d, 0, 0)]
-        [DataRow(0d, 0d, 22, 6.89d)]
+        [DataRow(0d, 0d, 0d, 0d)]
+        [DataRow(0d, 0d, 22d, 6.89d)]
         [DataRow(3.14d, 6.55f, 3838d, 3.24724928d)]
-        [DataRow(double.MinValue, double.Epsilon, 22, 0.3248d)]
-        public static void Test_PointExtensions_ToRect_FromSize(double width, double height, int x, int y)
+        [DataRow(double.MaxValue / 2, double.Epsilon, 22, 0.3248d)]
+        public void Test_PointExtensions_ToRect_FromSize(double width, double height, double x, double y)
         {
-            Point p = new Point(x, y);
-            Size s = new Size(width, height);
+            Point p = new(x, y);
+            Size s = new(width, height);
             Rect
                 a = p.ToRect(s),
-                b = new Rect(p, s);
+                b = new(p, s);
 
             Assert.AreEqual(a, b);
         }

--- a/UnitTests/UnitTests.UWP/Extensions/Test_RectExtensions.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_RectExtensions.cs
@@ -26,14 +26,15 @@ namespace UnitTests.Extensions
         [DataRow(0, 0, 2, 2, -2, 2, 2, 2, true)]// Left bottom corner(0, 2) intersection.
         [DataRow(0, 0, 2, 2, 3, 0, 2, 2, false)]// No intersection.
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:Parameters should be on same line or separate lines", Justification = "Put the parameters of the same rectangle on the same line is clearer.")]
-        public static void Test_RectExtensions_IntersectsWith(
+        public void Test_RectExtensions_IntersectsWith(
             double rect1X, double rect1Y, double rect1Width, double rect1Height,
             double rect2X, double rect2Y, double rect2Width, double rect2Height,
             bool shouldIntersectsWith)
         {
-            var rect1 = new Rect(rect1X, rect1Y, rect1Width, rect1Height);
-            var rect2 = new Rect(rect2X, rect2Y, rect2Width, rect2Height);
-            var isIntersectsWith = rect1.IntersectsWith(rect2);
+            Rect rect1 = new(rect1X, rect1Y, rect1Width, rect1Height);
+            Rect rect2 = new(rect2X, rect2Y, rect2Width, rect2Height);
+            bool isIntersectsWith = rect1.IntersectsWith(rect2);
+
             Assert.IsTrue(isIntersectsWith == shouldIntersectsWith);
         }
     }

--- a/UnitTests/UnitTests.UWP/Extensions/Test_SizeExtensions.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_SizeExtensions.cs
@@ -14,47 +14,47 @@ namespace UnitTests.Extensions
         [TestCategory("SizeExtensions")]
         [TestMethod]
         [DataRow(0d, 0d)]
-        [DataRow(3.14d, 6.55f)]
-        [DataRow(double.MinValue, double.Epsilon)]
-        public static void Test_SizeExtensions_ToRect_FromSize(double width, double height)
+        [DataRow(3.14d, 6.55d)]
+        [DataRow(double.MaxValue / 2, double.Epsilon)]
+        public void Test_SizeExtensions_ToRect_FromSize(double width, double height)
         {
-            Size s = new Size(width, height);
+            Size s = new(width, height);
             Rect
                 a = s.ToRect(),
-                b = new Rect(0, 0, s.Width, s.Height);
+                b = new(0, 0, s.Width, s.Height);
 
             Assert.AreEqual(a, b);
         }
 
         [TestCategory("SizeExtensions")]
         [TestMethod]
-        [DataRow(0d, 0d, 0, 0)]
-        [DataRow(0d, 0d, 22, 6.89d)]
+        [DataRow(0d, 0d, 0d, 0d)]
+        [DataRow(0d, 0d, 22d, 6.89d)]
         [DataRow(3.14d, 6.55f, 3838d, 3.24724928d)]
-        [DataRow(double.MinValue, double.Epsilon, 22, 0.3248d)]
-        public static void Test_SizeExtensions_ToRect_FromSizeAndPosition(double width, double height, int x, int y)
+        [DataRow(double.MaxValue / 2, double.Epsilon, 22, 0.3248d)]
+        public void Test_SizeExtensions_ToRect_FromSizeAndPosition(double width, double height, double x, double y)
         {
-            Size s = new Size(width, height);
+            Size s = new(width, height);
             Rect
                 a = s.ToRect(x, y),
-                b = new Rect(x, y, s.Width, s.Height);
+                b = new(x, y, s.Width, s.Height);
 
             Assert.AreEqual(a, b);
         }
 
         [TestCategory("SizeExtensions")]
         [TestMethod]
-        [DataRow(0d, 0d, 0, 0)]
-        [DataRow(0d, 0d, 22, 6.89d)]
+        [DataRow(0d, 0d, 0d, 0d)]
+        [DataRow(0d, 0d, 22d, 6.89d)]
         [DataRow(3.14d, 6.55f, 3838d, 3.24724928d)]
-        [DataRow(double.MinValue, double.Epsilon, 22, 0.3248d)]
-        public static void Test_SizeExtensions_ToRect_FromSizeAndPoint(double width, double height, int x, int y)
+        [DataRow(double.MaxValue / 2, double.Epsilon, 22d, 0.3248d)]
+        public void Test_SizeExtensions_ToRect_FromSizeAndPoint(double width, double height, double x, double y)
         {
-            Point p = new Point(x, y);
-            Size s = new Size(width, height);
+            Point p = new(x, y);
+            Size s = new(width, height);
             Rect
                 a = s.ToRect(p),
-                b = new Rect(p, s);
+                b = new(p, s);
 
             Assert.AreEqual(a, b);
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Unit test fixes
<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The tests for `Point`/`Rect`/`Size` extensions are skipped, and some are just incorrect anyway and fail even when run.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Fixed those tests to run correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
