### PR TITLE
Fix notification Group property being overwritten in unpackaged apps

### DIFF
--- a/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotifierCompat.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotifierCompat.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             // For apps that don't have identity...
             if (!DesktopBridgeHelpers.HasIdentity())
             {
-                // If tag is specified
-                if (!string.IsNullOrEmpty(notification.Tag))
+                // If tag is specified and group isn't specified
+                if (!string.IsNullOrEmpty(notification.Tag) && string.IsNullOrEmpty(notification.Group))
                 {
-                    // If group isn't specified, we have to add a group since otherwise can't remove without a group
+                    // We have to add a group since otherwise can't remove without a group
                     notification.Group = ToastNotificationManagerCompat.DEFAULT_GROUP;
                 }
             }

--- a/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotifierCompat.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotifierCompat.cs
@@ -157,10 +157,10 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             // For apps that don't have identity...
             if (!DesktopBridgeHelpers.HasIdentity())
             {
-                // If tag is specified
-                if (!string.IsNullOrEmpty(notification.Tag))
+                // If tag is specified and group isn't specified
+                if (!string.IsNullOrEmpty(notification.Tag) && string.IsNullOrEmpty(notification.Group))
                 {
-                    // If group isn't specified, we have to add a group since otherwise can't remove without a group
+                    // We have to add a group since otherwise can't remove without a group
                     notification.Group = ToastNotificationManagerCompat.DEFAULT_GROUP;
                 }
             }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #3835
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

For unpackaged apps, we were accidently overwriting the Group property on toasts if developers were setting that. Thus, scenarios like #3835 where a progress bar toast is using both group and tag, updating the progress bar didn't work

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Group property gets overwritten

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->

Group property only gets written if developers didn't specify it


## PR Checklist

Verified via...
 - [x] Sample app modified with both using group and not using group for progress bar (and for removing toasts)
 - [ ] Final NuGet package in separate sample app (pending a build) 

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
