### PR TITLE
Fix wrong bracket matching when parsing Vectors

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
@@ -182,6 +182,12 @@ namespace Microsoft.Toolkit.Uwp.UI
             static Quaternion Throw(string text) => throw new FormatException($"Cannot convert \"{text}\" to {nameof(Quaternion)}. Use the format \"float, float, float, float\"");
         }
 
+        /// <summary>
+        /// Converts a angle bracketed <see cref="string"/> value to its unbracketed form (e.g. "&lt;float, float&gt;" to "float, float").
+        /// If the value is already unbracketed, this method will return the value unchanged.
+        /// </summary>
+        /// <param name="text">A bracketed <see cref="string"/> value.</param>
+        /// <returns>The unbracketed <see cref="string"/> value.</returns>
         private static string Unbracket(string text)
         {
             if (text.Length >= 2 &&

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
@@ -29,12 +29,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             if (text.Length > 0)
             {
                 // The format <x> or <x, y> is supported
-                if (text.Length >= 2 &&
-                    text[0] == '>' &&
-                    text[text.Length - 1] == '>')
-                {
-                    text = text.Substring(1, text.Length - 2);
-                }
+                text = Unbracket(text);
 
                 // Skip allocations when only a component is used
                 if (text.IndexOf(',') == -1)
@@ -78,12 +73,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             if (text.Length > 0)
             {
-                if (text.Length >= 2 &&
-                    text[0] == '<' &&
-                    text[text.Length - 1] == '>')
-                {
-                    text = text.Substring(1, text.Length - 2);
-                }
+                text = Unbracket(text);
 
                 if (text.IndexOf(',') == -1)
                 {
@@ -127,12 +117,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             if (text.Length > 0)
             {
-                if (text.Length >= 2 &&
-                    text[0] == '>' &&
-                    text[text.Length - 1] == '>')
-                {
-                    text = text.Substring(1, text.Length - 2);
-                }
+                text = Unbracket(text);
 
                 if (text.IndexOf(',') == -1)
                 {
@@ -176,12 +161,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             if (text.Length > 0)
             {
-                if (text.Length >= 2 &&
-                    text[0] == '>' &&
-                    text[text.Length - 1] == '>')
-                {
-                    text = text.Substring(1, text.Length - 2);
-                }
+                text = Unbracket(text);
 
                 string[] values = text.Split(',');
 
@@ -200,6 +180,18 @@ namespace Microsoft.Toolkit.Uwp.UI
             return Throw(text);
 
             static Quaternion Throw(string text) => throw new FormatException($"Cannot convert \"{text}\" to {nameof(Quaternion)}. Use the format \"float, float, float, float\"");
+        }
+
+        private static string Unbracket(string text)
+        {
+            if (text.Length >= 2 &&
+                text[0] == '<' &&
+                text[text.Length - 1] == '>')
+            {
+                text = text.Substring(1, text.Length - 2);
+            }
+
+            return text;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             if (text.Length > 0)
             {
                 if (text.Length >= 2 &&
-                    text[0] == '>' &&
+                    text[0] == '<' &&
                     text[text.Length - 1] == '>')
                 {
                     text = text.Substring(1, text.Length - 2);

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/StringExtensions.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         }
 
         /// <summary>
-        /// Converts a angle bracketed <see cref="string"/> value to its unbracketed form (e.g. "&lt;float, float&gt;" to "float, float").
+        /// Converts an angle bracketed <see cref="string"/> value to its unbracketed form (e.g. "&lt;float, float&gt;" to "float, float").
         /// If the value is already unbracketed, this method will return the value unchanged.
         /// </summary>
         /// <param name="text">A bracketed <see cref="string"/> value.</param>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #3834
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
Fixed wrong bracket matching in `StringExtensions.ToVectorN(string)` and `StringExtensions.ToQuaternion(string)` methods.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Sample app crashes.


## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Sample app does not crash.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
