### PR TITLE
Added unit tests for Vector2/3/4/Quaternion parsing

### DIFF
--- a/UnitTests/UnitTests.UWP/Extensions/Test_StringExtensions.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_StringExtensions.cs
@@ -1,0 +1,240 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Microsoft.Toolkit.Uwp.UI;
+using System.Numerics;
+using System.Globalization;
+
+namespace UnitTests.Extensions
+{
+    [TestClass]
+    public class Test_StringExtensions
+    {
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow(0f)]
+        [DataRow(3.14f)]
+        public void Test_StringExtensions_ToVector2_XX(float x)
+        {
+            string text = x.ToString("R", CultureInfo.InvariantCulture);
+
+            Vector2
+                expected = new(x),
+                result = text.ToVector2();
+
+            Assert.AreEqual(expected, result);
+
+            result = $"<{text}>".ToVector2();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow(0f, 0f)]
+        [DataRow(0f, 22f)]
+        [DataRow(3.14f, 3.24724928f)]
+        [DataRow(float.MaxValue / 2, 0.3248f)]
+        public void Test_StringExtensions_ToVector2_XYZW(float x, float y)
+        {
+            string text = $"{x.ToString("R", CultureInfo.InvariantCulture)},{y.ToString("R", CultureInfo.InvariantCulture)}";
+
+            Vector2
+                expected = new(x, y),
+                result = text.ToVector2();
+
+            Assert.AreEqual(expected, result);
+
+            result = text.Replace(",", ", ").ToVector2();
+
+            Assert.AreEqual(expected, result);
+
+            result = $"<{text}>".ToVector2();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("Hello")]
+        [DataRow("1, 2, 3")]
+        [DataRow("<1, 2, 3")]
+        [DataRow("<1, 2, 3>")]
+        [DataRow("<1, 2, 3, 4>")]
+        [ExpectedException(typeof(FormatException))]
+        public void Test_StringExtensions_ToVector2_Fail(string text)
+        {
+            _ = text.ToVector2();
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow(0f)]
+        [DataRow(3.14f)]
+        public void Test_StringExtensions_ToVector3_XXX(float x)
+        {
+            string text = x.ToString("R", CultureInfo.InvariantCulture);
+
+            Vector3
+                expected = new(x),
+                result = text.ToVector3();
+
+            Assert.AreEqual(expected, result);
+
+            result = $"<{text}>".ToVector3();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow(0f, 0f, 0f)]
+        [DataRow(0f, 0f, 22f)]
+        [DataRow(3.14f, 6.55f, 3.24724928f)]
+        [DataRow(float.MaxValue / 2, 22f, 0.3248f)]
+        public void Test_StringExtensions_ToVector3_XYZW(float x, float y, float z)
+        {
+            string text = $"{x.ToString("R", CultureInfo.InvariantCulture)},{y.ToString("R", CultureInfo.InvariantCulture)},{z.ToString("R", CultureInfo.InvariantCulture)}";
+
+            Vector3
+                expected = new(x, y, z),
+                result = text.ToVector3();
+
+            Assert.AreEqual(expected, result);
+
+            result = text.Replace(",", ", ").ToVector3();
+
+            Assert.AreEqual(expected, result);
+
+            result = $"<{text}>".ToVector3();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("Hello")]
+        [DataRow("1, 2")]
+        [DataRow("1, 2, 3, 99")]
+        [DataRow("<1, 2>")]
+        [DataRow("<1, 2, 3")]
+        [DataRow("<1, 2, 3, 4>")]
+        [ExpectedException(typeof(FormatException))]
+        public void Test_StringExtensions_ToVector3_Fail(string text)
+        {
+            _ = text.ToVector3();
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow(0f)]
+        [DataRow(3.14f)]
+        public void Test_StringExtensions_ToVector4_XXXX(float x)
+        {
+            string text = x.ToString("R", CultureInfo.InvariantCulture);
+
+            Vector4
+                expected = new(x),
+                result = text.ToVector4();
+
+            Assert.AreEqual(expected, result);
+
+            result = $"<{text}>".ToVector4();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow(0f, 0f, 0f, 0f)]
+        [DataRow(0f, 0f, 22f, 6.89f)]
+        [DataRow(3.14f, 6.55f, 3838f, 3.24724928f)]
+        [DataRow(float.MaxValue / 2, float.Epsilon, 22f, 0.3248f)]
+        public void Test_StringExtensions_ToVector4_XYZW(float x, float y, float z, float w)
+        {
+            string text = $"{x.ToString("R", CultureInfo.InvariantCulture)},{y.ToString("R", CultureInfo.InvariantCulture)},{z.ToString("R", CultureInfo.InvariantCulture)},{w.ToString("R", CultureInfo.InvariantCulture)}";
+
+            Vector4
+                expected = new(x, y, z, w),
+                result = text.ToVector4();
+
+            // Test the "1,2,3,4" format
+            Assert.AreEqual(expected, result);
+
+            result = text.Replace(",", ", ").ToVector4();
+
+            // Test the "1, 2, 3, 4" format
+            Assert.AreEqual(expected, result);
+
+            // Test the "<1, 2, 3, 4>" format
+            result = $"<{text}>".ToVector4();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("Hello")]
+        [DataRow("1, 2")]
+        [DataRow("1, 2, 3")]
+        [DataRow("1, 2, 3, 99, 100")]
+        [DataRow("<1, 2, 3>")]
+        [DataRow("<1, 2, 3, 4")]
+        [DataRow("<1, 2, 3, 4, 5>")]
+        [ExpectedException(typeof(FormatException))]
+        public void Test_StringExtensions_ToVector4_Fail(string text)
+        {
+            _ = text.ToVector4();
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow(0f, 0f, 0f, 0f)]
+        [DataRow(0f, 0f, 22f, 6.89f)]
+        [DataRow(3.14f, 6.55f, 3838f, 3.24724928f)]
+        [DataRow(float.MaxValue / 2, float.Epsilon, 22f, 0.3248f)]
+        public void Test_StringExtensions_ToQuaternion_XYZW(float x, float y, float z, float w)
+        {
+            string text = $"{x.ToString("R", CultureInfo.InvariantCulture)},{y.ToString("R", CultureInfo.InvariantCulture)},{z.ToString("R", CultureInfo.InvariantCulture)},{w.ToString("R", CultureInfo.InvariantCulture)}";
+
+            Quaternion
+                expected = new(x, y, z, w),
+                result = text.ToQuaternion();
+
+            // Test the "1,2,3,4" format
+            Assert.AreEqual(expected, result);
+
+            result = text.Replace(",", ", ").ToQuaternion();
+
+            // Test the "1, 2, 3, 4" format
+            Assert.AreEqual(expected, result);
+
+            // Test the "<1, 2, 3, 4>" format
+            result = $"<{text}>".ToQuaternion();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCategory("StringExtensions")]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("Hello")]
+        [DataRow("1, 2")]
+        [DataRow("1, 2, 3")]
+        [DataRow("1, 2, 3, 99, 100")]
+        [DataRow("<1, 2, 3>")]
+        [DataRow("<1, 2, 3, 4")]
+        [DataRow("<1, 2, 3, 4, 5>")]
+        [ExpectedException(typeof(FormatException))]
+        public void Test_StringExtensions_ToQuaternion_Fail(string text)
+        {
+            _ = text.ToQuaternion();
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Converters\Test_StringFormatConverter.cs" />
     <Compile Include="Converters\Test_TypeToObjectConverter.cs" />
     <Compile Include="Extensions\Helpers\ObjectWithNullableBoolProperty.cs" />
+    <Compile Include="Extensions\Test_StringExtensions.cs" />
     <Compile Include="Extensions\Test_VisualTreeExtensions.cs" />
     <Compile Include="Extensions\Test_PointExtensions.cs" />
     <Compile Include="Extensions\Test_RectExtensions.cs" />


### PR DESCRIPTION
## Follow up for #3743 and #3837 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Unit tests
<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are no unit tests for `ToVector2/3/4` and `ToQuaternion` extensions.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Added unit tests for all those extensions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes