### PR TITLE
Adding control width trigger

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Triggers/ControlWidthTrigger.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Triggers/ControlWidthTrigger.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI.Xaml;
+
+namespace Microsoft.Toolkit.Uwp.UI.Triggers
+{
+    /// <summary>
+    /// A conditional state trigger that functions
+    /// based on the target control's width.
+    /// </summary>
+    public class ControlWidthTrigger : StateTriggerBase
+    {
+        /// <summary>
+        /// Gets or sets a value indicating
+        /// whether this trigger will be active or not.
+        /// </summary>
+        public bool CanTrigger
+        {
+            get => (bool)GetValue(CanTriggerProperty);
+            set => SetValue(CanTriggerProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="CanTrigger"/> DependencyProperty.
+        /// </summary>
+        public static readonly DependencyProperty CanTriggerProperty = DependencyProperty.Register(
+            nameof(CanTrigger),
+            typeof(bool),
+            typeof(ControlWidthTrigger),
+            new PropertyMetadata(true, OnCanTriggerProperty));
+
+        private static void OnCanTriggerProperty(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ControlWidthTrigger)d).UpdateTrigger();
+        }
+
+        /// <summary>
+        /// Gets or sets the max size at which to trigger.
+        /// </summary>
+        public double MaxWidth
+        {
+            get => (double)GetValue(MaxWidthProperty);
+            set => SetValue(MaxWidthProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="MaxWidth"/> DependencyProperty.
+        /// </summary>
+        public static readonly DependencyProperty MaxWidthProperty = DependencyProperty.Register(
+            nameof(MaxWidth),
+            typeof(double),
+            typeof(ControlWidthTrigger),
+            new PropertyMetadata(double.PositiveInfinity, OnMaxWidthPropertyChanged));
+
+        private static void OnMaxWidthPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ControlWidthTrigger)d).UpdateTrigger();
+        }
+
+        /// <summary>
+        /// Gets or sets the min size at which to trigger.
+        /// </summary>
+        public double MinWidth
+        {
+            get => (double)GetValue(MinWidthProperty);
+            set => SetValue(MinWidthProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="MinWidth"/> DependencyProperty.
+        /// </summary>
+        public static readonly DependencyProperty MinWidthProperty = DependencyProperty.Register(
+            nameof(MinWidth),
+            typeof(double),
+            typeof(ControlWidthTrigger),
+            new PropertyMetadata(0.0, OnMinWidthPropertyChanged));
+
+        private static void OnMinWidthPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ControlWidthTrigger)d).UpdateTrigger();
+        }
+
+        /// <summary>
+        /// Gets or sets the element whose width will observed
+        /// for the trigger.
+        /// </summary>
+        public FrameworkElement TargetElement
+        {
+            get => (FrameworkElement)GetValue(TargetElementProperty);
+            set => SetValue(TargetElementProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="TargetElement"/> DependencyProperty.
+        /// </summary>
+        /// <remarks>
+        /// Using a DependencyProperty as the backing store for TargetElement. This enables animation, styling, binding, etc.
+        /// </remarks>
+        public static readonly DependencyProperty TargetElementProperty = DependencyProperty.Register(
+            nameof(TargetElement),
+            typeof(FrameworkElement),
+            typeof(ControlWidthTrigger),
+            new PropertyMetadata(null, OnTargetElementPropertyChanged));
+
+        private static void OnTargetElementPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ControlWidthTrigger)d).UpdateTargetElement((FrameworkElement)e.OldValue, (FrameworkElement)e.NewValue);
+        }
+
+        // Handle event to get current values
+        private void OnTargetElementSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateTrigger();
+        }
+
+        private void UpdateTargetElement(FrameworkElement oldValue, FrameworkElement newValue)
+        {
+            if (oldValue != null)
+            {
+                oldValue.SizeChanged -= OnTargetElementSizeChanged;
+            }
+
+            if (newValue != null)
+            {
+                newValue.SizeChanged += OnTargetElementSizeChanged;
+            }
+
+            UpdateTrigger();
+        }
+
+        // Logic to evaluate and apply trigger value
+        private void UpdateTrigger()
+        {
+            if (TargetElement == null || !CanTrigger)
+            {
+                SetActive(false);
+                return;
+            }
+
+            SetActive(MinWidth <= TargetElement.ActualWidth && TargetElement.ActualWidth < MaxWidth);
+        }
+    }
+}


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
Adding a new visual state trigger which can be triggered based on a the width of a UI element rather than the width of the app's entire window.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
 Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
