### PR TITLE
Fix WrapPanel behavior with collapsed children

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/WrapPanel/WrapPanel.cs
@@ -166,6 +166,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     foreach (var rect in row.ChildrenRects)
                     {
                         var child = Children[childIndex++];
+                        while (child.Visibility == Visibility.Collapsed)
+                        {
+                            // Collapsed children are not added into the rows,
+                            // we skip them.
+                            child = Children[childIndex++];
+                        }
+
                         var arrangeRect = new UvRect
                         {
                             Position = rect.Position,

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/WrapPanel/WrapPanel.cs
@@ -209,12 +209,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var finalMeasure = new UvMeasure(Orientation, width: 0.0, height: 0.0);
             void Arrange(UIElement child, bool isLast = false)
             {
-                var desiredMeasure = new UvMeasure(Orientation, child.DesiredSize);
-                if (desiredMeasure.U == 0)
+                if (child.Visibility == Visibility.Collapsed)
                 {
                     return; // if an item is collapsed, avoid adding the spacing
                 }
 
+                var desiredMeasure = new UvMeasure(Orientation, child.DesiredSize);
                 if ((desiredMeasure.U + position.U + paddingEnd.U) > parentMeasure.U)
                 {
                     // next row!


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #3695
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

The `WrapPanel` is not rendering its children as expected if one of them is collapsed.

## PR Type
What kind of change does this PR introduce?
- Bugfix 

## What is the current behavior?
Children after the collapsed one may not be rendered.

## What is the new behavior?
All visible children will be displayed


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
This issue comes from `UpdateRows()` which ignores/skips the collapsed items since they are not part of the final layout. When doing the `Arrange()` pass, we were not accounting this and were trying to arrange the collapsed children. 
I've updated the `Arrange()` method to properly ignore the collapsed items and be sure to only arrange the visible items (the one from our pre-computed rows collection).

I used the following snippet to validate the changes:
```xml
<StackPanel>
    <controls:WrapPanel HorizontalSpacing="10">
        <Border Height="100" Width="100" Background="Red" Visibility="{Binding IsChecked,ElementName=RedCheck}" />
        <Border Height="100" Width="100" Background="Green" Visibility="{Binding IsChecked,ElementName=GreenCheck}" />
        <Border Height="100" Width="100" Background="Blue" Visibility="{Binding IsChecked,ElementName=BlueCheck}" />
    </controls:WrapPanel>

  <CheckBox x:Name="RedCheck" IsChecked="True"/>
  <CheckBox x:Name="GreenCheck" IsChecked="True"/>
  <CheckBox x:Name="BlueCheck" IsChecked="True"/>
</StackPanel>

```