### PR TITLE
Fixes #3871 - Can't see InAppNotification border

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Core/InAppNotification/InAppNotification.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Core/InAppNotification/InAppNotification.xaml
@@ -11,7 +11,7 @@
            TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransientBorderBrush}" />
         <Setter Property="Visibility" Value="Collapsed" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />


### PR DESCRIPTION
Fixes #3871

Changes the border from transparent to SystemControlTransientBorderBrush so that changing the BorderThickness property alone can make an impact.