### PR TITLE
Fixed crash in InvokeActionsActivity sample page

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Properties/Default.rd.xml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Properties/Default.rd.xml
@@ -27,5 +27,8 @@
     <!-- Add your application specific runtime directives here. -->
     <Type Name="Windows.UI.Xaml.Controls.Border" Dynamic="Required Public" />
 
+    <!-- Fix for https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3883 -->
+    <Type Name="Windows.UI.Xaml.Controls.TextBlock" Dynamic="Required Public" />
+
   </Application>
 </Directives>


### PR DESCRIPTION

## Fixes https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3883
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Sample app bugfix
<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Running the sample in "InvokeActionsActivity" sample page crashes the sample app.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
The "InvokeActionsActivity" sample page works correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes