### PR TITLE
Fix for FocusTracker Sample App hang

### DIFF
--- a/Microsoft.Toolkit.Uwp.DeveloperTools/FocusTracker/FocusTracker.cs
+++ b/Microsoft.Toolkit.Uwp.DeveloperTools/FocusTracker/FocusTracker.cs
@@ -34,19 +34,19 @@ namespace Microsoft.Toolkit.Uwp.DeveloperTools
 
         private static void OnIsActiveChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var focusTracker = d as FocusTracker;
-
-            if (e.NewValue != null && (bool)e.NewValue)
+            if (d is FocusTracker focusTracker)
             {
-                focusTracker?.Start();
-            }
-            else
-            {
-                focusTracker?.Stop();
+                if (e.NewValue != null && (bool)e.NewValue)
+                {
+                    focusTracker.Start();
+                }
+                else
+                {
+                    focusTracker.Stop();
+                }
             }
         }
 
-        private DispatcherQueueTimer updateTimer;
         private TextBlock controlName;
         private TextBlock controlType;
         private TextBlock controlAutomationName;
@@ -69,23 +69,6 @@ namespace Microsoft.Toolkit.Uwp.DeveloperTools
             DefaultStyleKey = typeof(FocusTracker);
         }
 
-        private void Start()
-        {
-            if (updateTimer == null)
-            {
-                updateTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-                updateTimer.Tick += UpdateTimer_Tick;
-            }
-
-            updateTimer.Start();
-        }
-
-        private void Stop()
-        {
-            updateTimer?.Stop();
-            ClearContent();
-        }
-
         /// <summary>
         /// Update the visual state of the control when its template is changed.
         /// </summary>
@@ -97,6 +80,33 @@ namespace Microsoft.Toolkit.Uwp.DeveloperTools
             controlFirstParentWithName = GetTemplateChild("ControlFirstParentWithName") as TextBlock;
         }
 
+        private void Start()
+        {
+            // Get currently focused control once when we start
+            if (Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Windows.UI.Xaml.UIElement", "XamlRoot") && XamlRoot != null)
+            {
+                FocusOnControl(FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement);
+            }
+            else
+            {
+                FocusOnControl(FocusManager.GetFocusedElement() as FrameworkElement);
+            }
+
+            // Then use FocusManager event from 1809 to listen to updates
+            FocusManager.GotFocus += FocusManager_GotFocus;
+        }
+
+        private void Stop()
+        {
+            FocusManager.GotFocus -= FocusManager_GotFocus;
+            ClearContent();
+        }
+
+        private void FocusManager_GotFocus(object sender, FocusManagerGotFocusEventArgs e)
+        {
+            FocusOnControl(e.NewFocusedElement as FrameworkElement);
+        }
+
         private void ClearContent()
         {
             controlName.Text = string.Empty;
@@ -105,19 +115,8 @@ namespace Microsoft.Toolkit.Uwp.DeveloperTools
             controlFirstParentWithName.Text = string.Empty;
         }
 
-        private void UpdateTimer_Tick(object sender, object e)
+        private void FocusOnControl(FrameworkElement focusedControl)
         {
-            FrameworkElement focusedControl;
-
-            if (Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Windows.UI.Xaml.UIElement", "XamlRoot") && XamlRoot != null)
-            {
-                focusedControl = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
-            }
-            else
-            {
-                focusedControl = FocusManager.GetFocusedElement() as FrameworkElement;
-            }
-
             if (focusedControl == null)
             {
                 ClearContent();

--- a/Microsoft.Toolkit.Uwp.SampleApp/App.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/App.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp.SampleApp.Common;
 using Microsoft.Toolkit.Uwp.SampleApp.SamplePages;
@@ -163,7 +164,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
         /// </summary>
         /// <param name="sender">The source of the suspend request.</param>
         /// <param name="e">Details about the suspend request.</param>
-        private void OnSuspending(object sender, SuspendingEventArgs e)
+        private async void OnSuspending(object sender, SuspendingEventArgs e)
         {
             var deferral = e.SuspendingOperation.GetDeferral();
 
@@ -179,7 +180,18 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 // ignore
             }
 
-            deferral.Complete();
+            try
+            {
+                await Task.Delay(2000);
+            }
+            catch
+            {
+                // ignore
+            }
+            finally
+            {
+                deferral.Complete();
+            }
         }
     }
 }


### PR DESCRIPTION
## Fixes #3884
Updates the FocusTracker control to use a different API which won't constantly try and spam calls to look for the FocusedElement, unclear if that or the DispatcherQueueTimer were to blame for original issue, but hopefully this should be resolved now, was no longer able to reproduce.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes) 
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?
FocusTracker was using a DispatcherQueueTimer (updated from DispatcherTimer late in 7.0) to constantly update what the FocusedElement it was tracking was.

## What is the new behavior?
Use the new `FocusManager.GotFocus` event added in 1809 (our new min version) to only update the control when the focused element has changed. This should provide a better more stable experience with similar practical results.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information
Also added an extra hang delay protection as called out in https://dotnetapp.com/hang-on article to Sample App itself, just in case.