### PR TITLE
Fix notification settings disabled for unpackaged apps on 19042 and older

### DIFF
--- a/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/Desktop/Win32AppInfo.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/Desktop/Win32AppInfo.cs
@@ -37,21 +37,21 @@ namespace Microsoft.Toolkit.Uwp.Notifications
 
             // First get the app ID
             IApplicationResolver appResolver = (IApplicationResolver)new CAppResolver();
-            appResolver.GetAppIDForProcess(Convert.ToUInt32(process.Id), out string appId, out _, out bool explicitAppId, out _);
+            appResolver.GetAppIDForProcess(Convert.ToUInt32(process.Id), out string appId, out _, out _, out _);
 
             string aumid;
 
-            // If it has an explicit app ID
-            if (explicitAppId)
+            // If it contains a backslash
+            if (appId.Contains('\\'))
             {
-                // Use as-is
-                aumid = appId;
+                // For versions 19042 and older of Windows 10, we can't use backslashes - Issue #3870
+                // So we change it to not include those
+                aumid = appId.Replace('\\', '/');
             }
             else
             {
-                // Otherwise, it's a full-path, like C:\Program Files\..., and for versions 19042 and older of
-                // Windows 10, we can't use a full path - Issue #3870, so we change it to not be recognized as a path.
-                aumid = appId.Replace('\\', '/');
+                // Use as-is
+                aumid = appId;
             }
 
             // If the AUMID is too long

--- a/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/Desktop/Win32AppInfo.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/Desktop/Win32AppInfo.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Toolkit.Uwp.Notifications
 
         public string Aumid { get; set; }
 
+        /// <summary>
+        /// Gets the AUMID before it was fixed up with the backslash issue
+        /// </summary>
+        public string Pre7_0_1Aumid { get; private set; }
+
         public string DisplayName { get; set; }
 
         public string IconPath { get; set; }
@@ -40,6 +45,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             appResolver.GetAppIDForProcess(Convert.ToUInt32(process.Id), out string appId, out _, out _, out _);
 
             string aumid;
+            string pre7_0_1Aumid = null;
 
             // If the app ID is too long
             if (appId.Length > AUMID_MAX_LENGTH)
@@ -54,6 +60,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
                 // For versions 19042 and older of Windows 10, we can't use backslashes - Issue #3870
                 // So we change it to not include those
                 aumid = appId.Replace('\\', '/');
+                pre7_0_1Aumid = appId;
             }
             else
             {
@@ -128,6 +135,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             return new Win32AppInfo()
             {
                 Aumid = aumid,
+                Pre7_0_1Aumid = pre7_0_1Aumid,
                 DisplayName = displayName,
                 IconPath = iconPath
             };

--- a/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/Desktop/Win32AppInfo.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/Desktop/Win32AppInfo.cs
@@ -41,8 +41,15 @@ namespace Microsoft.Toolkit.Uwp.Notifications
 
             string aumid;
 
-            // If it contains a backslash
-            if (appId.Contains('\\'))
+            // If the app ID is too long
+            if (appId.Length > AUMID_MAX_LENGTH)
+            {
+                // Hash the AUMID
+                aumid = HashAppId(appId);
+            }
+
+            // Else if it contains a backslash
+            else if (appId.Contains('\\'))
             {
                 // For versions 19042 and older of Windows 10, we can't use backslashes - Issue #3870
                 // So we change it to not include those
@@ -52,13 +59,6 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             {
                 // Use as-is
                 aumid = appId;
-            }
-
-            // If the AUMID is too long
-            if (aumid.Length > AUMID_MAX_LENGTH)
-            {
-                // Hash the AUMID
-                aumid = HashAppId(aumid);
             }
 
             // Then try to get the shortcut (for display name and icon)

--- a/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotificationManagerCompat.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotificationManagerCompat.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
                         if (win32AppInfo.Pre7_0_1Aumid != null)
                         {
                             // Uninstall the old AUMID
+                            CleanUpOldAumid(win32AppInfo.Pre7_0_1Aumid);
                         }
 
                         // Set that it has the fix so we don't try uninstalling again in the future

--- a/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotificationManagerCompat.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Toasts/Compat/ToastNotificationManagerCompat.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
 #if WIN32
         private const string TOAST_ACTIVATED_LAUNCH_ARG = "-ToastActivated";
         private const string REG_HAS_SENT_NOTIFICATION = "HasSentNotification";
+        private const string REG_HAS_7_0_1_FIX = "Has7.0.1Fix";
         internal const string DEFAULT_GROUP = "toolkitGroupNull";
 
         private const int CLASS_E_NOAGGREGATION = -2147221232;
@@ -175,6 +176,22 @@ namespace Microsoft.Toolkit.Uwp.Notifications
 
                     // Additionally, we need to read whether they've sent a notification before
                     _hasSentNotification = rootKey.GetValue(REG_HAS_SENT_NOTIFICATION) != null;
+
+                    // And read if we've already applied the 7_0_1 fix
+                    bool has7_0_1fix = rootKey.GetValue(REG_HAS_7_0_1_FIX) != null;
+
+                    // If it doesn't have the fix yet
+                    if (!has7_0_1fix)
+                    {
+                        // If the AUMID changed
+                        if (win32AppInfo.Pre7_0_1Aumid != null)
+                        {
+                            // Uninstall the old AUMID
+                        }
+
+                        // Set that it has the fix so we don't try uninstalling again in the future
+                        rootKey.SetValue(REG_HAS_7_0_1_FIX, 1);
+                    }
                 }
 
                 rootKey.SetValue("CustomActivator", string.Format("{{{0}}}", activatorType.GUID));
@@ -183,7 +200,12 @@ namespace Microsoft.Toolkit.Uwp.Notifications
 
         private static string GetRegistrySubKey()
         {
-            return @"Software\Classes\AppUserModelId\" + _win32Aumid;
+            return GetRegistrySubKey(_win32Aumid);
+        }
+
+        private static string GetRegistrySubKey(string win32Aumid)
+        {
+            return @"Software\Classes\AppUserModelId\" + win32Aumid;
         }
 
         private static Type CreateActivatorType()
@@ -516,20 +538,70 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             {
             }
 
-            if (!DesktopBridgeHelpers.HasIdentity() && _win32Aumid != null)
+            try
             {
-                try
+                // Delete any of the app files
+                var appDataFolderPath = Win32AppInfo.GetAppDataFolderPath(_win32Aumid);
+                if (Directory.Exists(appDataFolderPath))
                 {
-                    // Delete any of the app files
-                    var appDataFolderPath = Win32AppInfo.GetAppDataFolderPath(_win32Aumid);
-                    if (Directory.Exists(appDataFolderPath))
+                    Directory.Delete(appDataFolderPath, recursive: true);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private static void CleanUpOldAumid(string oldAumid)
+        {
+            try
+            {
+                // Remove all scheduled notifications (do this first before clearing current notifications)
+                var notifier = ToastNotificationManager.CreateToastNotifier(oldAumid);
+                foreach (var scheduled in notifier.GetScheduledToastNotifications())
+                {
+                    try
                     {
-                        Directory.Delete(appDataFolderPath, recursive: true);
+                        notifier.RemoveFromSchedule(scheduled);
+                    }
+                    catch
+                    {
                     }
                 }
-                catch
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                // Clear all current notifications
+                ToastNotificationManager.History.Clear(oldAumid);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                // Remove registry key
+                Registry.CurrentUser.DeleteSubKey(GetRegistrySubKey(oldAumid));
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                // Delete any of the app files
+                var appDataFolderPath = Win32AppInfo.GetAppDataFolderPath(oldAumid);
+                if (Directory.Exists(appDataFolderPath))
                 {
+                    Directory.Delete(appDataFolderPath, recursive: true);
                 }
+            }
+            catch
+            {
             }
         }
 #endif


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #3870
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

On versions 19042 and older of Windows 10, when an unpackaged desktop app used an AUMID that contained `\` (common occurrence since AUMID is the EXE path unless app has a shortcut with an AUMID set), the notifications settings would consider this as a disabled app and not allow toggling settings.

Fixed this by automatically replacing `\` with `/` in AUMIDs, and using that instead. That change means that apps that were using 7.0.0 and update to 7.0.1 would be treated as "new" apps though, so added some migration logic to at least clean up the old notifications, so that users don't see two apps in Action Center and don't continue to receive scheduled notifications from the old app.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current behavior described in #3870


## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->

Settings page is now usable (tested on 19042). And when upgrading from 7.0.0 to 7.0.1, all current notifications and scheduled notifications will be deleted (similar to if the notification database was simply wiped).


## PR Checklist

How tested: Manually tested using an app built against 7.0.0 and then updating to app built using this branch, tested on 19042 and also tested on latest internal Insider builds, and on build 17763.

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
