### PR TITLE
Fix Remote Doc/Image Caching in Sample App

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Microsoft.Toolkit.Uwp.SampleApp.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;REMOTE_DOCS</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -63,7 +63,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
     <OutputPath>bin\ARM\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;REMOTE_DOCS</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -89,7 +89,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;REMOTE_DOCS</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -1484,7 +1484,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
     <OutputPath>bin\ARM64\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;REMOTE_DOCS</DefineConstants>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>;2008</NoWarn>

--- a/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
             set
             {
-#if DEBUG
+#if !REMOTE_DOCS
                 _codeUrl = value;
 #else
                 var regex = new Regex("^https://github.com/windows-toolkit/WindowsCommunityToolkit/(tree|blob)/(?<branch>.+?)/(?<path>.*)");
@@ -221,12 +221,13 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             if (docMatch.Success)
             {
                 filepath = docMatch.Groups["file"].Value;
-                filename = Path.GetFileName(RemoteDocumentationPath);
+                filename = Path.GetFileName(filepath);
+
                 RemoteDocumentationPath = Path.GetDirectoryName(filepath);
-                LocalDocumentationFilePath = $"ms-appx:///docs/{RemoteDocumentationPath}/";
+                LocalDocumentationFilePath = $"ms-appx:///docs/{filepath}/";
             }
 
-#if !DEBUG // use the docs repo in release mode
+#if REMOTE_DOCS // use the docs repo in release mode
             string modifiedDocumentationUrl = $"{_docsOnlineRoot}live/docs/{filepath}";
 
             // Read from Cache if available.
@@ -285,6 +286,11 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             return _cachedDocumentation;
         }
 
+        public Uri GetOnlineResourcePath(string relativePath)
+        {
+            return new Uri($"{_docsOnlineRoot}live/docs/{RemoteDocumentationPath}/{relativePath}");
+        }
+
         /// <summary>
         /// Gets the image data from a Uri, with Caching.
         /// </summary>
@@ -301,10 +307,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             }
 
             IRandomAccessStream imageStream = null;
-            var localPath = $"{uri.Host}/{uri.LocalPath}";
+            var localPath = $"{uri.Host}/{uri.LocalPath}".Replace("//", "/");
 
-            // Cache only in Release
-#if !DEBUG
+            if (localPath.StartsWith(_docsOnlineRoot.Substring(8)))
+            {
+                // If we're looking for docs we should look in our local area first.
+                localPath = localPath.Substring(_docsOnlineRoot.Length - 3); // want to chop "live/" but missing https:// as well.
+            }
+
+            // Try cache only in Release (using remote docs)
+#if REMOTE_DOCS
             try
             {
                 imageStream = await StreamHelper.GetLocalCacheFileStreamAsync(localPath, Windows.Storage.FileAccessMode.Read);
@@ -312,12 +324,12 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             catch
             {
             }
-#endif
 
             if (imageStream == null)
             {
                 try
                 {
+                    // Our docs don't reference any external images, this should only be for getting latest image from repo.
                     using (var response = await client.GetAsync(uri))
                     {
                         if (response.IsSuccessStatusCode)
@@ -325,16 +337,26 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                             var imageCopy = await CopyStream(response.Content);
                             imageStream = imageCopy.AsRandomAccessStream();
 
-                            // Cache only in Release
-#if !DEBUG
                             // Takes a second copy of the image stream, so that is can save the image data to cache.
                             using (var saveStream = await CopyStream(response.Content))
                             {
                                 await SaveImageToCache(localPath, saveStream);
                             }
-#endif
                         }
                     }
+                }
+                catch
+                {
+                }
+            }
+#endif
+
+            // If we don't have internet, then try to see if we have a packaged copy
+            if (imageStream == null)
+            {
+                try
+                {
+                    imageStream = await StreamHelper.GetPackagedFileStreamAsync(localPath);
                 }
                 catch
                 {

--- a/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Pages/SampleController.xaml.cs
@@ -453,15 +453,21 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             // Determine if the link is not absolute, meaning it is relative.
             if (!Uri.TryCreate(e.Url, UriKind.Absolute, out Uri url))
             {
-                url = new Uri(CurrentSample.LocalDocumentationFilePath + e.Url);
-            }
+                var imageStream = await CurrentSample.GetImageStream(CurrentSample.GetOnlineResourcePath(e.Url));
 
-            if (url.Scheme == "ms-appx")
+                if (imageStream != null)
+                {
+                    image = new BitmapImage();
+                    await image.SetSourceAsync(imageStream);
+                }
+            }
+            else if (url.Scheme == "ms-appx")
             {
                 image = new BitmapImage(url);
             }
             else
             {
+                // Cache a remote image from the internet.
                 var imageStream = await CurrentSample.GetImageStream(url);
 
                 if (imageStream != null)


### PR DESCRIPTION
## Fixes #3848
Create Remote_DOCS compiler directive to make it easier to debug, now Debug mode only uses local packages assets, and can add compiler directive to test remote doc scenarios and caching while in Debug mode still.
Fixes issue where images wouldn't be pulled from packaged assets in offline mode.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
- Sample app changes
<!-- - Other... Please describe: -->

## What is the current behavior?
Images weren't showing up in released app.

## What is the new behavior?
Images are properly cached and retrieved from package if offline.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
