### PR TITLE
Enabled correct WeakReferenceMessenger path on .NET 5

### DIFF
--- a/Microsoft.Toolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/WeakReferenceMessenger.cs
@@ -9,10 +9,10 @@ using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Microsoft.Collections.Extensions;
 using Microsoft.Toolkit.Mvvm.Messaging.Internals;
-#if NETSTANDARD2_1
-using RecipientsTable = System.Runtime.CompilerServices.ConditionalWeakTable<object, Microsoft.Collections.Extensions.IDictionarySlim>;
-#else
+#if NETSTANDARD2_0
 using RecipientsTable = Microsoft.Toolkit.Mvvm.Messaging.WeakReferenceMessenger.ConditionalWeakTable<object, Microsoft.Collections.Extensions.IDictionarySlim>;
+#else
+using RecipientsTable = System.Runtime.CompilerServices.ConditionalWeakTable<object, Microsoft.Collections.Extensions.IDictionarySlim>;
 #endif
 
 namespace Microsoft.Toolkit.Mvvm.Messaging
@@ -288,7 +288,7 @@ namespace Microsoft.Toolkit.Mvvm.Messaging
             }
         }
 
-#if !NETSTANDARD2_1
+#if NETSTANDARD2_0
         /// <summary>
         /// A wrapper for <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey,TValue}"/>
         /// that backports the enumerable support to .NET Standard 2.0 through an auxiliary list.
@@ -470,7 +470,7 @@ namespace Microsoft.Toolkit.Mvvm.Messaging
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static ArrayPoolBufferWriter<T> Create()
             {
-                return new ArrayPoolBufferWriter<T> { array = ArrayPool<T>.Shared.Rent(DefaultInitialBufferSize) };
+                return new() { array = ArrayPool<T>.Shared.Rent(DefaultInitialBufferSize) };
             }
 
             /// <summary>


### PR DESCRIPTION
## Follow up for #3424 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix-ish
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Overview
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The .NET 5 target currently uses the .NET Standard 2.0 code path within `WeakReferenceMessenger`.
Not technically a bug since the implementation does work, but it can be greatly simplified like on .NET Standard 2.1.
This should also make the code add slightly less GC pressure over time due to less additional data structures in use.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
