### PR TITLE
Update ExecuteOnUIThreadAsync to EnqueueAsync

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherQueueHelper/DispatcherQueueHelperCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherQueueHelper/DispatcherQueueHelperCode.bind
@@ -6,7 +6,7 @@ int crossThreadReturnedValue = await Task.Run<int>( async () =>
 	{
 		// Task.Run() will guarantee the given piece of code be executed on a separate thread pool. 
 		// This is used to simulate the scenario of updating the UI element from a different thread.
-		int returnedFromUIThread = await dispatcherQueue.ExecuteOnUIThreadAsync<int>(() =>
+		int returnedFromUIThread = await dispatcherQueue.EnqueueAsync<int>(() =>
 			{
 				NormalTextBlock.Text = "Updated from a random thread!";
 				return 1;


### PR DESCRIPTION
## Fixes #
This will fix the oversight in the documentation after the 7.0 breaking change

## PR Type
Documentation content changes 
Sample app changes

## What is the current behavior?
The sample app documentation use the old ExecuteOnUIThreadAsync methos

## What is the new behavior?
The sample app documentation use the new EnqueueAsync method
