### PR TITLE
Fixed TaskExtensions.GetResultOrDefault() for Task.CompletedTask

### DIFF
--- a/UnitTests/UnitTests.Shared/Extensions/Test_TaskExtensions.cs
+++ b/UnitTests/UnitTests.Shared/Extensions/Test_TaskExtensions.cs
@@ -39,6 +39,13 @@ namespace UnitTests.Extensions
 
         [TestCategory("TaskExtensions")]
         [TestMethod]
+        public void Test_TaskExtensions_ResultOrDefault_FromTaskCompleted()
+        {
+            Assert.AreEqual(null, Task.CompletedTask.GetResultOrDefault());
+        }
+
+        [TestCategory("TaskExtensions")]
+        [TestMethod]
         public async Task Test_TaskExtensions_ResultOrDefault_FromAsyncTaskMethodBuilder()
         {
             var tcs = new TaskCompletionSource<object>();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`TaskExtensions.GetResultOrDefault()` incorrectly returns a boxed `VoidTaskResult` when used on `Task.CompletedTask`.
This is because this instance is actually a cached `Task<T>` with some internal type.
For the implementation detail, [see here](https://github.com/dotnet/runtime/blob/19caa608b9d226d0041d5ed1c7b0d5911fb13d2b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L1457-L1462).

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
This PR adds special handling for `Task.CompletedTask` to ensure that `null` is returned.
There is also a new unit test for the extension in this case.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes