### PR TITLE
Turned off layout rounding for failing tests

### DIFF
--- a/UnitTests/UnitTests.UWP/UI/Controls/Test_WrapPanel_Visibility.cs
+++ b/UnitTests/UnitTests.UWP/UI/Controls/Test_WrapPanel_Visibility.cs
@@ -37,6 +37,8 @@ namespace UnitTests.UI.Controls
     </controls:WrapPanel>
 </Page>") as FrameworkElement;
 
+                treeRoot.UseLayoutRounding = false;
+
                 var expected = new (int u, int v, int w, int h)[]
                 {
                     (0, 0, 0, 0), // Collapsed
@@ -94,6 +96,8 @@ namespace UnitTests.UI.Controls
     </controls:WrapPanel>
 </Page>") as FrameworkElement;
 
+                treeRoot.UseLayoutRounding = false;
+
                 var expected = new (int u, int v, int w, int h)[]
                 {
                     (0, 0, 150, 50),
@@ -148,6 +152,8 @@ namespace UnitTests.UI.Controls
         <Border Width=""50"" Height=""50"" Visibility=""Collapsed""/>
     </controls:WrapPanel>
 </Page>") as FrameworkElement;
+
+                treeRoot.UseLayoutRounding = false;
 
                 var expected = new (int u, int v, int w, int h)[]
                 {


### PR DESCRIPTION
Some tests were failing if your resolution was 150% (not 100%).
This fixes the 3 failing tests.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Tests fail if your display scale is 150%

## What is the new behavior?
Tests pass independently from your display scale.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
