### PR TITLE
Fix [ReadOnly]Span2D<T>.TryGetSpan on legacy frameworks

### DIFF
--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -906,7 +906,10 @@ namespace Microsoft.Toolkit.HighPerformance
                 // Without Span<T> runtime support, we can only get a Span<T> from a T[] instance
                 if (this.instance.GetType() == typeof(T[]))
                 {
-                    span = Unsafe.As<T[]>(this.instance).AsSpan((int)this.offset, (int)Length);
+                    T[] array = Unsafe.As<T[]>(this.instance)!;
+                    int index = array.AsSpan().IndexOf(ref ObjectMarshal.DangerousGetObjectDataReferenceAt<T>(array, this.offset));
+
+                    span = array.AsSpan(index, (int)Length);
 
                     return true;
                 }

--- a/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -1062,7 +1062,10 @@ namespace Microsoft.Toolkit.HighPerformance
                 // Without Span<T> runtime support, we can only get a Span<T> from a T[] instance
                 if (this.Instance.GetType() == typeof(T[]))
                 {
-                    span = Unsafe.As<T[]>(this.Instance).AsSpan((int)this.Offset, (int)Length);
+                    T[] array = Unsafe.As<T[]>(this.Instance)!;
+                    int index = array.AsSpan().IndexOf(ref ObjectMarshal.DangerousGetObjectDataReferenceAt<T>(array, this.Offset));
+
+                    span = array.AsSpan(index, (int)Length);
 
                     return true;
                 }

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -605,7 +605,7 @@ namespace UnitTests.HighPerformance
         {
             int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(1, 0, 3, 2);
+            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(1, 0, 2, 3);
 
             bool success = span2d.TryGetSpan(out ReadOnlySpan<int> span);
 
@@ -620,7 +620,7 @@ namespace UnitTests.HighPerformance
         {
             int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(0, 1, 2, 3);
+            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(0, 1, 3, 2);
 
             bool success = span2d.TryGetSpan(out ReadOnlySpan<int> span);
 

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -586,7 +586,51 @@ namespace UnitTests.HighPerformance
 
         [TestCategory("ReadOnlySpan2DT")]
         [TestMethod]
-        public void Test_ReadOnlySpan2DT_TryGetReadOnlySpan_1()
+        public void Test_ReadOnlySpan2DT_TryGetSpan_From1DArray_1()
+        {
+            int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3);
+
+            bool success = span2d.TryGetSpan(out ReadOnlySpan<int> span);
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(span.Length, span2d.Length);
+            Assert.IsTrue(Unsafe.AreSame(ref array[0], ref Unsafe.AsRef(in span[0])));
+        }
+
+        [TestCategory("ReadOnlySpan2DT")]
+        [TestMethod]
+        public void Test_ReadOnlySpan2DT_TryGetSpan_From1DArray_2()
+        {
+            int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(1, 0, 2, 3);
+
+            bool success = span2d.TryGetSpan(out ReadOnlySpan<int> span);
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(span.Length, span2d.Length);
+            Assert.IsTrue(Unsafe.AreSame(ref array[3], ref Unsafe.AsRef(in span[0])));
+        }
+
+        [TestCategory("ReadOnlySpan2DT")]
+        [TestMethod]
+        public void Test_ReadOnlySpan2DT_TryGetSpan_From1DArray_3()
+        {
+            int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(0, 1, 3, 2);
+
+            bool success = span2d.TryGetSpan(out ReadOnlySpan<int> span);
+
+            Assert.IsFalse(success);
+            Assert.AreEqual(span.Length, 0);
+        }
+
+        [TestCategory("ReadOnlySpan2DT")]
+        [TestMethod]
+        public void Test_ReadOnlySpan2DT_TryGetReadOnlySpan_From2DArray_1()
         {
             int[,] array =
             {
@@ -610,7 +654,7 @@ namespace UnitTests.HighPerformance
 
         [TestCategory("ReadOnlySpan2DT")]
         [TestMethod]
-        public void Test_ReadOnlySpan2DT_TryGetReadOnlySpan_2()
+        public void Test_ReadOnlySpan2DT_TryGetReadOnlySpan_From2DArray_2()
         {
             int[,] array =
             {

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -605,7 +605,7 @@ namespace UnitTests.HighPerformance
         {
             int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(1, 0, 2, 3);
+            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(1, 0, 3, 2);
 
             bool success = span2d.TryGetSpan(out ReadOnlySpan<int> span);
 
@@ -620,7 +620,7 @@ namespace UnitTests.HighPerformance
         {
             int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(0, 1, 3, 2);
+            ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 3, 3).Slice(0, 1, 2, 3);
 
             bool success = span2d.TryGetSpan(out ReadOnlySpan<int> span);
 

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Span2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Span2D{T}.cs
@@ -803,6 +803,21 @@ namespace UnitTests.HighPerformance
             Assert.AreEqual(span.Length, 0);
         }
 
+        // See https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/3947
+        [TestCategory("Span2DT")]
+        [TestMethod]
+        public void Test_Span2DT_TryGetSpan_From1DArray_4()
+        {
+            int[] array = new int[128];
+            Span2D<int> span2d = new Span2D<int>(array, 8, 16);
+
+            bool success = span2d.TryGetSpan(out Span<int> span);
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(span.Length, span2d.Length);
+            Assert.IsTrue(Unsafe.AreSame(ref array[0], ref span[0]));
+        }
+
         [TestCategory("Span2DT")]
         [TestMethod]
         public void Test_Span2DT_TryGetSpan_From2DArray_1()

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Span2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Span2D{T}.cs
@@ -761,7 +761,51 @@ namespace UnitTests.HighPerformance
 
         [TestCategory("Span2DT")]
         [TestMethod]
-        public void Test_Span2DT_TryGetSpan_1()
+        public void Test_Span2DT_TryGetSpan_From1DArray_1()
+        {
+            int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            Span2D<int> span2d = new Span2D<int>(array, 3, 3);
+
+            bool success = span2d.TryGetSpan(out Span<int> span);
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(span.Length, span2d.Length);
+            Assert.IsTrue(Unsafe.AreSame(ref array[0], ref span[0]));
+        }
+
+        [TestCategory("Span2DT")]
+        [TestMethod]
+        public void Test_Span2DT_TryGetSpan_From1DArray_2()
+        {
+            int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            Span2D<int> span2d = new Span2D<int>(array, 3, 3).Slice(1, 0, 2, 3);
+
+            bool success = span2d.TryGetSpan(out Span<int> span);
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(span.Length, span2d.Length);
+            Assert.IsTrue(Unsafe.AreSame(ref array[3], ref span[0]));
+        }
+
+        [TestCategory("Span2DT")]
+        [TestMethod]
+        public void Test_Span2DT_TryGetSpan_From1DArray_3()
+        {
+            int[] array = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            Span2D<int> span2d = new Span2D<int>(array, 3, 3).Slice(0, 1, 3, 2);
+
+            bool success = span2d.TryGetSpan(out Span<int> span);
+
+            Assert.IsFalse(success);
+            Assert.AreEqual(span.Length, 0);
+        }
+
+        [TestCategory("Span2DT")]
+        [TestMethod]
+        public void Test_Span2DT_TryGetSpan_From2DArray_1()
         {
             int[,] array =
             {
@@ -790,7 +834,7 @@ namespace UnitTests.HighPerformance
 
         [TestCategory("Span2DT")]
         [TestMethod]
-        public void Test_Span2DT_TryGetSpan_2()
+        public void Test_Span2DT_TryGetSpan_From2DArray_2()
         {
             int[,] array =
             {


### PR DESCRIPTION
## Fixes #3947
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`[ReadOnly]Span2D<T>.TryGetSpan` throws an exception when wrapping a `T[]` instance on legacy frameworks.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
`[ReadOnly]Span2D<T>.TryGetSpan` works correctly on legacy frameworks.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
