### PR TITLE
Added VisualExtensions.Translation attached property

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Visual Extensions/VisualExtensionsCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Visual Extensions/VisualExtensionsCode.bind
@@ -5,15 +5,49 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:ani="using:Microsoft.Toolkit.Uwp.UI.Animations"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     mc:Ignorable="d">
 
-  <Grid>
+  <StackPanel Spacing="120" VerticalAlignment="Center">
+    
+    <!--This is a static element, with some Visual properties being modified through
+        the VisualExtensions class. You can modify their values to see how the position,
+        orientation and alignment of the Border element changes.-->
     <Border Height="100"
             Width="100"
             Background="Purple"
+            ui:VisualExtensions.CenterPoint="50,50,0"
+            ui:VisualExtensions.Offset="50"
             ui:VisualExtensions.Opacity="0.5"
             ui:VisualExtensions.RotationAngleInDegrees="80"
             ui:VisualExtensions.Scale="2, 0.5, 1"
-            ui:VisualExtensions.NormalizedCenterPoint="0.5" />
-  </Grid>
+            ui:VisualExtensions.NormalizedCenterPoint="0.5"
+            ui:VisualExtensions.Translation="20,12,0"/>
+    
+    <!--This Button demonstrates the VisualExtensions.Translation property in combination with a translation
+        animation. The Translation property is set to indicate the starting position of the element (relative
+        to its offset), and the animation will modify that to reach the specified translation value. Note how
+        the animation doesn't have an explicit starting value, as it will just start animating the translation
+        from the current value set via the VisualExtensions.Translation attached property.-->
+    <Button Height="120"
+            Width="360"
+            Background="Green"
+            Content="Click me!"
+            FontSize="32"
+            ui:VisualExtensions.Translation="20,-40,0">
+      <ani:Explicit.Animations>
+        <ani:AnimationSet x:Name="MoveAnimation">
+          <ani:TranslationAnimation To="480,80,0" Duration="0:0:2"/>
+        </ani:AnimationSet>
+      </ani:Explicit.Animations>
+      <interactivity:Interaction.Behaviors>
+        <interactions:EventTriggerBehavior EventName="Click">
+          <behaviors:StartAnimationAction Animation="{Binding ElementName=MoveAnimation}"/>
+        </interactions:EventTriggerBehavior>
+      </interactivity:Interaction.Behaviors>
+    </Button>
+  </StackPanel>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Visual Extensions/VisualExtensionsPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Visual Extensions/VisualExtensionsPage.xaml
@@ -3,11 +3,15 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:ani="using:Microsoft.Toolkit.Uwp.UI.Animations"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+    <StackPanel Spacing="120" VerticalAlignment="Center">
         <Border Height="100"
                 Width="100"
                 Background="Purple"
@@ -16,6 +20,25 @@
                 ui:VisualExtensions.Opacity="0.5"
                 ui:VisualExtensions.RotationAngleInDegrees="80"
                 ui:VisualExtensions.Scale="2, 0.5, 1"
-                ui:VisualExtensions.NormalizedCenterPoint="0.5"/>
-    </Grid>
+                ui:VisualExtensions.NormalizedCenterPoint="0.5"
+                ui:VisualExtensions.Translation="20,12,0"/>
+        <Button
+            Height="120"
+            Width="360"
+            Background="Green"
+            Content="Click me!"
+            FontSize="32"
+            ui:VisualExtensions.Translation="20,-40,0">
+            <ani:Explicit.Animations>
+                <ani:AnimationSet x:Name="MoveAnimation">
+                    <ani:TranslationAnimation To="480,80,0" Duration="0:0:2"/>
+                </ani:AnimationSet>
+            </ani:Explicit.Animations>
+            <interactivity:Interaction.Behaviors>
+                <interactions:EventTriggerBehavior EventName="Click">
+                    <behaviors:StartAnimationAction Animation="{Binding ElementName=MoveAnimation}"/>
+                </interactions:EventTriggerBehavior>
+            </interactivity:Interaction.Behaviors>
+        </Button>
+    </StackPanel>
 </Page>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/VisualExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/VisualExtensions.cs
@@ -115,6 +115,36 @@ namespace Microsoft.Toolkit.Uwp.UI
         }
 
         /// <summary>
+        /// Gets the <see cref="Visual.TransformMatrix"/>.<see cref="Matrix4x4.Translation"/> property of a <see cref="UIElement"/> in a <see cref="string"/> form.
+        /// </summary>
+        /// <param name="obj">The <see cref="DependencyObject"/> instance.</param>
+        /// <returns>A <see cref="Vector3"/> <see cref="string"/> representation of the <see cref="Visual.TransformMatrix"/>.<see cref="Matrix4x4.Translation"/> property.</returns>
+        public static string GetTranslation(DependencyObject obj)
+        {
+            if (!DesignTimeHelpers.IsRunningInLegacyDesignerMode && obj is UIElement element)
+            {
+                return GetTranslationForElement(element);
+            }
+
+            return (string)obj.GetValue(TranslationProperty);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="Visual.TransformMatrix"/>.<see cref="Matrix4x4.Translation"/> property of a <see cref="UIElement"/> in a <see cref="string"/> form.
+        /// </summary>
+        /// <param name="obj">The <see cref="DependencyObject"/> instance.</param>
+        /// <param name="value">The <see cref="string"/> representation of the <see cref="Vector3"/> to be set.</param>
+        public static void SetTranslation(DependencyObject obj, string value)
+        {
+            if (!DesignTimeHelpers.IsRunningInLegacyDesignerMode && obj is UIElement element)
+            {
+                SetTranslationForElement(value, element);
+            }
+
+            obj.SetValue(TranslationProperty, value);
+        }
+
+        /// <summary>
         /// Gets the <see cref="Visual.Opacity"/> of a UIElement
         /// </summary>
         /// <param name="obj">The <see cref="UIElement"/></param>
@@ -335,6 +365,12 @@ namespace Microsoft.Toolkit.Uwp.UI
             DependencyProperty.RegisterAttached("Offset", typeof(string), typeof(VisualExtensions), new PropertyMetadata(null, OnOffsetChanged));
 
         /// <summary>
+        /// Identifies the Translation attached property.
+        /// </summary>
+        public static readonly DependencyProperty TranslationProperty =
+            DependencyProperty.RegisterAttached("Translation", typeof(string), typeof(VisualExtensions), new PropertyMetadata(null, OnTranslationChanged));
+
+        /// <summary>
         /// Identifies the Opacity attached property.
         /// </summary>
         public static readonly DependencyProperty OpacityProperty =
@@ -397,6 +433,14 @@ namespace Microsoft.Toolkit.Uwp.UI
             if (e.NewValue is string str)
             {
                 SetOffset(d, str);
+            }
+        }
+
+        private static void OnTranslationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is string str)
+            {
+                SetTranslation(d, str);
             }
         }
 
@@ -501,6 +545,23 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             var visual = GetVisual(element);
             visual.Offset = value.ToVector3();
+        }
+
+        private static string GetTranslationForElement(UIElement element)
+        {
+            return GetVisual(element).TransformMatrix.Translation.ToString();
+        }
+
+        private static void SetTranslationForElement(string value, UIElement element)
+        {
+            ElementCompositionPreview.SetIsTranslationEnabled(element, true);
+
+            Visual visual = GetVisual(element);
+            Matrix4x4 transform = visual.TransformMatrix;
+
+            transform.Translation = value.ToVector3();
+
+            visual.TransformMatrix = transform;
         }
 
         private static double GetOpacityForElement(UIElement element)

--- a/UnitTests/UnitTests.UWP/UI/Extensions/Test_VisualExtensions.cs
+++ b/UnitTests/UnitTests.UWP/UI/Extensions/Test_VisualExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Toolkit.Uwp;
+using Windows.UI.Xaml.Controls;
+using Microsoft.Toolkit.Uwp.UI;
+using System.Numerics;
+
+namespace UnitTests.UWP.UI
+{
+    [TestClass]
+    [TestCategory("Test_VisualExtensions")]
+    public class Test_VisualExtensions : VisualUITestBase
+    {
+        [TestMethod]
+        public async Task SetAndGetTranslation()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var button = new Button();
+                var grid = new Grid() { Children = { button } };
+
+                VisualExtensions.SetTranslation(button, "80, 20, 0");
+
+                await SetTestContentAsync(grid);
+
+                Assert.AreEqual(button.GetVisual().TransformMatrix.Translation, new Vector3(80, 20, 0));
+
+                string translation = VisualExtensions.GetTranslation(button);
+
+                Assert.AreEqual(translation, new Vector3(80, 20, 0).ToString());
+            });
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UI/Extensions/Test_VisualExtensions.cs
+++ b/UnitTests/UnitTests.UWP/UI/Extensions/Test_VisualExtensions.cs
@@ -8,6 +8,8 @@ using Microsoft.Toolkit.Uwp;
 using Windows.UI.Xaml.Controls;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Numerics;
+using Windows.UI.Composition;
+using Microsoft.Toolkit.Uwp.UI.Animations;
 
 namespace UnitTests.UWP.UI
 {
@@ -15,6 +17,19 @@ namespace UnitTests.UWP.UI
     [TestCategory("Test_VisualExtensions")]
     public class Test_VisualExtensions : VisualUITestBase
     {
+        [TestMethod]
+        public async Task GetDefaultTranslation()
+        {
+            await App.DispatcherQueue.EnqueueAsync(() =>
+            {
+                var button = new Button();
+
+                string text = VisualExtensions.GetTranslation(button);
+
+                Assert.AreEqual(text, "<0, 0, 0>");
+            });
+        }
+
         [TestMethod]
         public async Task SetAndGetTranslation()
         {
@@ -27,11 +42,41 @@ namespace UnitTests.UWP.UI
 
                 await SetTestContentAsync(grid);
 
-                Assert.AreEqual(button.GetVisual().TransformMatrix.Translation, new Vector3(80, 20, 0));
+                var success = button.GetVisual().Properties.TryGetVector3("Translation", out Vector3 translation);
 
-                string translation = VisualExtensions.GetTranslation(button);
+                Assert.AreEqual(success, CompositionGetValueStatus.Succeeded);
+                Assert.AreEqual(translation, new Vector3(80, 20, 0));
 
-                Assert.AreEqual(translation, new Vector3(80, 20, 0).ToString());
+                string text = VisualExtensions.GetTranslation(button);
+
+                Assert.AreEqual(text, new Vector3(80, 20, 0).ToString());
+            });
+        }
+
+        [TestMethod]
+        public async Task SetAndAnimateTranslation()
+        {
+            await App.DispatcherQueue.EnqueueAsync(async () =>
+            {
+                var button = new Button();
+                var grid = new Grid() { Children = { button } };
+
+                VisualExtensions.SetTranslation(button, "80, 20, 0");
+
+                await SetTestContentAsync(grid);
+
+                await AnimationBuilder.Create()
+                    .Translation(to: new Vector3(11, 22, 0))
+                    .StartAsync(button);
+
+                var success = button.GetVisual().Properties.TryGetVector3("Translation", out Vector3 translation);
+
+                Assert.AreEqual(success, CompositionGetValueStatus.Succeeded);
+                Assert.AreEqual(translation, new Vector3(11, 22, 0));
+
+                string text = VisualExtensions.GetTranslation(button);
+
+                Assert.AreEqual(text, new Vector3(11, 22, 0).ToString());
             });
         }
     }

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -211,6 +211,7 @@
     <Compile Include="UI\Controls\Test_UniformGrid_Dimensions.cs" />
     <Compile Include="UI\Controls\Test_WrapPanel_Visibility.cs" />
     <Compile Include="UI\Controls\Test_WrapPanel_BasicLayout.cs" />
+    <Compile Include="UI\Extensions\Test_VisualExtensions.cs" />
     <Compile Include="UI\Person.cs" />
     <Compile Include="UI\Test_AdvancedCollectionView.cs" />
     <Compile Include="UnitTestApp.xaml.cs">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

<!-- - Bugfix -->
 - Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `VisualExtensions` class lacks an attached property to set the `"Translation"` property of a UI element.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
This PR adds a `VisualExtensions.Translation` attached property.
The behavior and implementation mirrors that of the other extensions.

Here's a GIF that shows both XAML hot-reload and this extension being combined with the animation system 🚀 🚀 🚀

![HWNH1d4bur](https://user-images.githubusercontent.com/10199417/115721302-37110080-a37e-11eb-974d-40825b3a7c26.gif)

## Additional info

This extension now works just fine, and can be combined with the existing animation APIs to start a translation animation with an implicit starting point just fine. The reason why it wasn't originally working was because I incorrectly assumed that the "Translation" property in question was `Visual.TransformMatrix.Translation`, but turns out that wasn't the case 😄
When setting [`ElementCompositionPreview.SetIsTranslationEnabled`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.hosting.elementcompositionpreview.setistranslationenabled), the Composition layer adds a new "Translation" property to [`CompositionObject.Properties`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.composition.compositionobject.properties) (`Visual` is a `CompositionObject` too), and **that's** the property that is actually being animated in this case. In fact, you can set/animate both this property and [`Visual.TransformMatrix`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.composition.visual.transformmatrix) at the same time, and the final translation position for the object will just be the combination of the transform matrix + the additional explicit translation from this "hidden" property. That also explains why the animation didn't seem to work before: in fact it was working, but it was animating a different target ("Translation" instead of `TransformMatrix.Translation`) which was already at `0` (as it had never been set before), so it seemed as though the animation was just not doing anything. This also explains the final value for that transform matrix being unchanged 🙂

Marking this PR as ready for review, as this functionality is now working correctly! 🎉

<details>
    <summary><b>Original (outdated) notes (click to expand):</b></summary>
<br/>

This attached property comes with a caveat, which is that if it's used to set thee `"Translation"` property of a `Visual` before an animation, and then the animation is started _without_ an initial value, the animation will just not run. In fact, the `"Translation"` property won't even be changed at all to the final value of the animation once it completes (though it still takes the expected duration for the animation to complete, it just... Does nothing). This only happens for `"Translation"`, whereas doing exactly the same with eg. `Visual.Offset` works just fine. For instance, consider this repro code:

```xml
<Grid>
    <Button
        VerticalAlignment="Top"
        HorizontalAlignment="Left"
        Height="120"
        Width="360"
        Background="Green"
        Content="CLICK ME"
        FontSize="32"
        Click="Button_Click"
        ui:VisualExtensions.Translation="160,80,0">
    </Button>
</Grid>
```
```csharp
private async void Button_Click(object sender, RoutedEventArgs e)
{
    var before = ((Button)sender).GetVisual().TransformMatrix.Translation;

    await AnimationBuilder.Create()
        .Translation(to: Vector3.Zero, duration: TimeSpan.FromSeconds(2))
        .StartAsync((Button)sender);

    var after = ((Button)sender).GetVisual().TransformMatrix.Translation;
}
```

Running this and clicking on the button will have the button remain in the same initial position, and those `before` and `after` values will still be exactly the same (so `160,80,0` in this case). If you try to change the target property to `Offset` in both XAML and C# instead, the animation will run as expected, and the `after` value will in fact change to `0`.

This seems an issue with the framework, or at the very least a very specific behavior for `"Translation"` that's not consistent with the other `Visual` properties, and that I don't see documented on the MS docs for either `Visual.TransformMatrix` or `ElementCompositionPreview.SetIsTranslationEnabled`. I might open an issue in the WinUI repo about this, at least to try to get more information on this, but opening this PR in the meantime to gather feedbacks and because the actual `VisualExtensions.Translation` property itself does work, so we might also just want to merge it in the meantime 🙂
</details>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
