### PR TITLE
Fixed NRE when setting text on Wide tile only via TileContentBuilder

### DIFF
--- a/Microsoft.Toolkit.Uwp.Notifications/Tiles/Builder/TileContentBuilder.cs
+++ b/Microsoft.Toolkit.Uwp.Notifications/Tiles/Builder/TileContentBuilder.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
                 GetAdaptiveTileContent(MediumTile).Children.Add(child);
             }
 
-            if (size.HasFlag(TileSize.Wide) && WideTile != null && GetAdaptiveTileContent(MediumTile) != null)
+            if (size.HasFlag(TileSize.Wide) && WideTile != null && GetAdaptiveTileContent(WideTile) != null)
             {
                 GetAdaptiveTileContent(WideTile).Children.Add(child);
             }

--- a/UnitTests/UnitTests.Notifications.Shared/TestTileContentBuilder.cs
+++ b/UnitTests/UnitTests.Notifications.Shared/TestTileContentBuilder.cs
@@ -1,0 +1,113 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.Toolkit.Uwp.Notifications;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests.Notifications
+{
+#if !WINRT
+    [TestClass]
+    public class TestTileContentBuilder
+    {
+        [TestMethod]
+        public void AddTextTest_OnSmallTileOnly()
+        {
+            // Arrange
+            string text = "text on small tile";
+            TileContentBuilder builder = new TileContentBuilder();
+            builder.AddTile(TileSize.Small);
+
+            // Act
+            builder.AddText(text);
+
+            // Assert
+            var tileText = GetTileAdaptiveText(builder, TileSize.Small);
+            Assert.IsNotNull(tileText);
+            Assert.AreSame("text on small tile", (string)tileText.Text);
+        }
+
+        [TestMethod]
+        public void AddTextTest_OnMediumTileOnly()
+        {
+            // Arrange
+            string text = "text on medium tile";
+            TileContentBuilder builder = new TileContentBuilder();
+            builder.AddTile(TileSize.Medium);
+
+            // Act
+            builder.AddText(text);
+
+            // Assert
+            var tileText = GetTileAdaptiveText(builder, TileSize.Medium);
+            Assert.IsNotNull(tileText);
+            Assert.AreSame("text on medium tile", (string)tileText.Text);
+        }
+
+        [TestMethod]
+        public void AddTextTest_OnWideTileOnly()
+        {
+            // Arrange
+            string text = "text on wide tile";
+            TileContentBuilder builder = new TileContentBuilder();
+            builder.AddTile(TileSize.Wide);
+
+            // Act
+            builder.AddText(text);
+
+            // Assert
+            var tileText = GetTileAdaptiveText(builder, TileSize.Wide);
+            Assert.IsNotNull(tileText);
+            Assert.AreSame("text on wide tile", (string)tileText.Text);
+        }
+
+        [TestMethod]
+        public void AddTextTest_OnLargeTileOnly()
+        {
+            // Arrange
+            string text = "text on large tile";
+            TileContentBuilder builder = new TileContentBuilder();
+            builder.AddTile(TileSize.Large);
+
+            // Act
+            builder.AddText(text);
+
+            // Assert
+            var tileText = GetTileAdaptiveText(builder, TileSize.Large);
+            Assert.IsNotNull(tileText);
+            Assert.AreSame("text on large tile", (string)tileText.Text);
+        }
+
+        private static AdaptiveText GetTileAdaptiveText(TileContentBuilder builder, TileSize size)
+        {
+            TileBinding tileBinding;
+            switch (size)
+            {
+                case TileSize.Small:
+                    tileBinding = builder.Content.Visual.TileSmall;
+                    break;
+
+                case TileSize.Medium:
+                    tileBinding = builder.Content.Visual.TileMedium;
+                    break;
+
+                case TileSize.Wide:
+                    tileBinding = builder.Content.Visual.TileWide;
+                    break;
+
+                case TileSize.Large:
+                    tileBinding = builder.Content.Visual.TileLarge;
+                    break;
+
+                default:
+                    return null;
+            }
+
+            var content = (TileBindingContentAdaptive)tileBinding.Content;
+            return content.Children.FirstOrDefault() as AdaptiveText;
+        }
+    }
+#endif
+}

--- a/UnitTests/UnitTests.Notifications.Shared/UnitTests.Notifications.Shared.projitems
+++ b/UnitTests/UnitTests.Notifications.Shared/UnitTests.Notifications.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)TestAssertHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestMail.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestTileContentBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestToastArguments.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestToastContentBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestWeather.cs" />


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 📝 It is preferred if you keep the "☑️ Allow edits by maintainers" checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork.  This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->


## Fixes #3955 
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
- Unit test added

<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue #3955 

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Text on **Wide tile** is correctly set without throwing `NullReferenceException`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


## Other information
