### PR TITLE
Add "PreviousVersionInstalled" to SystemInformation

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
@@ -35,10 +35,10 @@
         public bool IsAppUpdated => SystemInformation.Instance.IsAppUpdated;
 
         // To get the first version installed
-        public PackageVersion FirstVersionInstalled => SystemInformation.Instance.FirstVersionInstalled;
+        public string FirstVersionInstalled => SystemInformation.Instance.FirstVersionInstalled.ToFormattedString();
 
         // To get the previous version installed
-        public PackageVersion PreviousVersionInstalled => SystemInformation.Instance.PreviousVersionInstalled;
+        public string PreviousVersionInstalled => SystemInformation.Instance.PreviousVersionInstalled.ToFormattedString();
 
         // To get the first time the app was launched
         public DateTime FirstUseTime => SystemInformation.Instance.FirstUseTime;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
@@ -38,7 +38,7 @@
         public PackageVersion FirstVersionInstalled => SystemInformation.Instance.FirstVersionInstalled;
 
         // To get the previous version installed
-        public string PreviousVersionInstalled => SystemInformation.Instance.PreviousVersionInstalled.ToFormattedString();
+        public PackageVersion PreviousVersionInstalled => SystemInformation.Instance.PreviousVersionInstalled;
 
         // To get the first time the app was launched
         public DateTime FirstUseTime => SystemInformation.Instance.FirstUseTime;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
@@ -37,6 +37,9 @@
         // To get the first version installed
         public PackageVersion FirstVersionInstalled => SystemInformation.Instance.FirstVersionInstalled;
 
+        // To get the previous version installed
+        public string PreviousVersionInstalled => SystemInformation.Instance.PreviousVersionInstalled.ToFormattedString();
+
         // To get the first time the app was launched
         public DateTime FirstUseTime => SystemInformation.Instance.FirstUseTime;
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
@@ -172,6 +172,18 @@
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
                                FontWeight="Bold"
+                               Text="Previous version installed:"
+                               TextWrapping="Wrap" />
+                    <TextBlock Margin="20,0"
+                               FontSize="18"
+                               Text="{x:Bind PreviousVersionInstalled}"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+                <StackPanel x:Name="Stack14"
+                            Margin="10"
+                            Orientation="Horizontal">
+                    <TextBlock FontSize="18"
+                               FontWeight="Bold"
                                Text="First use time:"
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
@@ -179,7 +191,7 @@
                                Text="{x:Bind FirstUseTime}"
                                TextWrapping="Wrap" />
                 </StackPanel>
-                <StackPanel x:Name="Stack14"
+                <StackPanel x:Name="Stack15"
                             Margin="10"
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
@@ -191,7 +203,7 @@
                                Text="{x:Bind LaunchTime}"
                                TextWrapping="Wrap" />
                 </StackPanel>
-                <StackPanel x:Name="Stack15"
+                <StackPanel x:Name="Stack16"
                             Margin="10"
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
@@ -203,7 +215,7 @@
                                Text="{x:Bind LastLaunchTime}"
                                TextWrapping="Wrap" />
                 </StackPanel>
-                <StackPanel x:Name="Stack16"
+                <StackPanel x:Name="Stack17"
                             Margin="10"
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
@@ -215,7 +227,7 @@
                                Text="{x:Bind LastResetTime, Mode=OneWay}"
                                TextWrapping="Wrap" />
                 </StackPanel>
-                <StackPanel x:Name="Stack17"
+                <StackPanel x:Name="Stack18"
                             Margin="10"
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
@@ -227,7 +239,7 @@
                                Text="{x:Bind LaunchCount, Mode=OneWay}"
                                TextWrapping="Wrap" />
                 </StackPanel>
-                <StackPanel x:Name="Stack18"
+                <StackPanel x:Name="Stack19"
                             Margin="10"
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
@@ -239,7 +251,7 @@
                                Text="{x:Bind TotalLaunchCount}"
                                TextWrapping="Wrap" />
                 </StackPanel>
-                <StackPanel x:Name="Stack19"
+                <StackPanel x:Name="Stack20"
                             Margin="10"
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
@@ -284,6 +296,9 @@
                         <Setter Target="Stack15.Orientation" Value="Vertical" />
                         <Setter Target="Stack16.Orientation" Value="Vertical" />
                         <Setter Target="Stack17.Orientation" Value="Vertical" />
+                        <Setter Target="Stack18.Orientation" Value="Vertical" />
+                        <Setter Target="Stack19.Orientation" Value="Vertical" />
+                        <Setter Target="Stack20.Orientation" Value="Vertical" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
@@ -54,6 +54,9 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         // To get the first version installed
         public string FirstVersionInstalled => SystemInformation.Instance.FirstVersionInstalled.ToFormattedString();
 
+        // To get the previous version installed
+        public string PreviousVersionInstalled => SystemInformation.Instance.PreviousVersionInstalled.ToFormattedString();
+
         // To get the first time the app was launched
         public string FirstUseTime => SystemInformation.Instance.FirstUseTime.ToString(Culture.DateTimeFormat);
 

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Windows.Storage;
 
@@ -77,7 +75,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="key">Key of the object</param>
         /// <param name="default">Default value of the object</param>
         /// <returns>The T object</returns>
-        public T Read<T>(string key, T @default = default(T))
+        public T Read<T>(string key, T @default = default)
         {
             if (!Settings.Values.TryGetValue(key, out var value) || value == null)
             {
@@ -95,7 +93,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="key">Key of the object</param>
         /// <param name="default">Default value of the object</param>
         /// <returns>The T object</returns>
-        public T Read<T>(string compositeKey, string key, T @default = default(T))
+        public T Read<T>(string compositeKey, string key, T @default = default)
         {
             ApplicationDataCompositeValue composite = (ApplicationDataCompositeValue)Settings.Values[compositeKey];
             if (composite != null)
@@ -120,9 +118,6 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="value">Object to save</param>
         public void Save<T>(string key, T value)
         {
-            var type = typeof(T);
-            var typeInfo = type.GetTypeInfo();
-
             Settings.Values[key] = serializer.Serialize(value);
         }
 
@@ -182,7 +177,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="filePath">Path to the file that contains the object</param>
         /// <param name="default">Default value of the object</param>
         /// <returns>Waiting task until completion with the object in the file</returns>
-        public async Task<T> ReadFileAsync<T>(string filePath, T @default = default(T))
+        public async Task<T> ReadFileAsync<T>(string filePath, T @default = default)
         {
             string value = await StorageFileHelper.ReadTextFromFileAsync(Folder, filePath);
             return (value != null) ? serializer.Deserialize<T>(value) : @default;

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/LocalObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/LocalObjectStorageHelper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
 using Windows.Storage;
 
 namespace Microsoft.Toolkit.Uwp.Helpers

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
     {
         private readonly LocalObjectStorageHelper _localObjectStorageHelper = new LocalObjectStorageHelper(new SystemSerializer());
         private DateTime _sessionStart;
+        private PackageVersion _previousVersionInstalled;
 
         /// <summary>
         /// Launches the store app so the user can leave a review.
@@ -126,7 +127,11 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// This will be the current version if a previous version of the app was installed
         /// before using <see cref="SystemInformation"/> or if the app is not updated.
         /// </summary>
-        public PackageVersion PreviousVersionInstalled { get; }
+        public PackageVersion PreviousVersionInstalled 
+        {
+            get => _previousVersionInstalled;
+            private set => _previousVersionInstalled = value;
+        }
 
         /// <summary>
         /// Gets the DateTime (in UTC) when the app was launched for the first time.
@@ -317,7 +322,6 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             IsAppUpdated = DetectIfAppUpdated();
             FirstUseTime = DetectFirstUseTime();
             FirstVersionInstalled = DetectFirstVersionInstalled();
-            PreviousVersionInstalled = DetectPreviousVersionInstalled();
             InitializeValuesSetWithTrackAppUse();
         }
 
@@ -345,9 +349,9 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             else
             {
                 var lastVersion = _localObjectStorageHelper.Read<string>(nameof(currentVersion));
+                PreviousVersionInstalled = lastVersion.ToPackageVersion();
                 if (currentVersion != lastVersion)
                 {
-                    _localObjectStorageHelper.Save(nameof(PreviousVersionInstalled), lastVersion);
                     _localObjectStorageHelper.Save(nameof(currentVersion), currentVersion);
                     return true;
                 }
@@ -386,23 +390,6 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             {
                 result = ApplicationVersion;
                 _localObjectStorageHelper.Save(nameof(FirstVersionInstalled), ApplicationVersion.ToFormattedString());
-            }
-
-            return result;
-        }
-
-        private PackageVersion DetectPreviousVersionInstalled()
-        {
-            PackageVersion result;
-
-            if (_localObjectStorageHelper.KeyExists(nameof(PreviousVersionInstalled)))
-            {
-                result = _localObjectStorageHelper.Read<string>(nameof(PreviousVersionInstalled)).ToPackageVersion();
-            }
-            else
-            {
-                result = ApplicationVersion;
-                _localObjectStorageHelper.Save(nameof(PreviousVersionInstalled), ApplicationVersion.ToFormattedString());
             }
 
             return result;

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -122,6 +122,12 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         public PackageVersion FirstVersionInstalled { get; }
 
         /// <summary>
+        /// Gets the previous version of the app that was installed.
+        /// This will be the current version if a previous version of the app was installed before accessing this property.
+        /// </summary>
+        public PackageVersion PreviousVersionInstalled { get; }
+
+        /// <summary>
         /// Gets the DateTime (in UTC) when the app was launched for the first time.
         /// </summary>
         public DateTime FirstUseTime { get; }
@@ -310,6 +316,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             IsAppUpdated = DetectIfAppUpdated();
             FirstUseTime = DetectFirstUseTime();
             FirstVersionInstalled = DetectFirstVersionInstalled();
+            PreviousVersionInstalled = DetectPreviousVersionInstalled();
             InitializeValuesSetWithTrackAppUse();
         }
 
@@ -377,6 +384,23 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             {
                 result = ApplicationVersion;
                 _localObjectStorageHelper.Save(nameof(FirstVersionInstalled), ApplicationVersion.ToFormattedString());
+            }
+
+            return result;
+        }
+
+        private PackageVersion DetectPreviousVersionInstalled()
+        {
+            PackageVersion result;
+
+            if (_localObjectStorageHelper.KeyExists(nameof(PreviousVersionInstalled)))
+            {
+                result = _localObjectStorageHelper.Read<string>(nameof(PreviousVersionInstalled)).ToPackageVersion();
+            }
+            else
+            {
+                result = ApplicationVersion;
+                _localObjectStorageHelper.Save(nameof(PreviousVersionInstalled), ApplicationVersion.ToFormattedString());
             }
 
             return result;

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// This will be the current version if a previous version of the app was installed
         /// before using <see cref="SystemInformation"/> or if the app is not updated.
         /// </summary>
-        public PackageVersion PreviousVersionInstalled 
+        public PackageVersion PreviousVersionInstalled
         {
             get => _previousVersionInstalled;
             private set => _previousVersionInstalled = value;

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -50,7 +50,9 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             }
 
             DeviceFamily = AnalyticsInfo.VersionInfo.DeviceFamily;
+
             ulong version = ulong.Parse(AnalyticsInfo.VersionInfo.DeviceFamilyVersion);
+
             OperatingSystemVersion = new OSVersion
             {
                 Major = (ushort)((version & 0xFFFF000000000000L) >> 48),
@@ -58,8 +60,11 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 Build = (ushort)((version & 0x00000000FFFF0000L) >> 16),
                 Revision = (ushort)(version & 0x000000000000FFFFL)
             };
+
             OperatingSystemArchitecture = Package.Current.Id.Architecture;
-            EasClientDeviceInformation deviceInfo = new EasClientDeviceInformation();
+
+            EasClientDeviceInformation deviceInfo = new();
+
             OperatingSystem = deviceInfo.OperatingSystem;
             DeviceManufacturer = deviceInfo.SystemManufacturer;
             DeviceModel = deviceInfo.SystemProductName;
@@ -67,6 +72,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             (IsAppUpdated, PreviousVersionInstalled) = DetectIfAppUpdated();
             FirstUseTime = DetectFirstUseTime();
             FirstVersionInstalled = DetectFirstVersionInstalled();
+
             InitializeValuesSetWithTrackAppUse();
         }
 

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <summary>
         /// The <see cref="LocalObjectStorageHelper"/> instance used to save and retrieve application settings.
         /// </summary>
-        private readonly LocalObjectStorageHelper localObjectStorageHelper = new(new SystemSerializer());
+        private readonly LocalObjectStorageHelper _localObjectStorageHelper = new(new SystemSerializer());
 
         /// <summary>
         /// The starting time of the current application session (since app launch or last move to foreground).
         /// </summary>
-        private DateTime sessionStart;
+        private DateTime _sessionStart;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SystemInformation"/> class.
@@ -215,8 +215,8 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             {
                 if (LaunchCount > 0)
                 {
-                    var subSessionLength = DateTime.UtcNow.Subtract(this.sessionStart).Ticks;
-                    var uptimeSoFar = this.localObjectStorageHelper.Read<long>(nameof(AppUptime));
+                    var subSessionLength = DateTime.UtcNow.Subtract(_sessionStart).Ticks;
+                    var uptimeSoFar = _localObjectStorageHelper.Read<long>(nameof(AppUptime));
 
                     return new(uptimeSoFar + subSessionLength);
                 }
@@ -232,9 +232,9 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="duration">The amount to time to add</param>
         public void AddToAppUptime(TimeSpan duration)
         {
-            var uptimeSoFar = this.localObjectStorageHelper.Read<long>(nameof(AppUptime));
+            var uptimeSoFar = _localObjectStorageHelper.Read<long>(nameof(AppUptime));
 
-            this.localObjectStorageHelper.Save(nameof(AppUptime), uptimeSoFar + duration.Ticks);
+            _localObjectStorageHelper.Save(nameof(AppUptime), uptimeSoFar + duration.Ticks);
         }
 
         /// <summary>
@@ -245,8 +245,8 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             LastResetTime = DateTime.UtcNow;
             LaunchCount = 0;
 
-            this.localObjectStorageHelper.Save(nameof(LastResetTime), LastResetTime.ToFileTimeUtc());
-            this.localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
+            _localObjectStorageHelper.Save(nameof(LastResetTime), LastResetTime.ToFileTimeUtc());
+            _localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
         }
 
         /// <summary>
@@ -258,8 +258,8 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         {
             if (args.PreviousExecutionState is ApplicationExecutionState.ClosedByUser or ApplicationExecutionState.NotRunning)
             {
-                LaunchCount = this.localObjectStorageHelper.Read<long>(nameof(LaunchCount)) + 1;
-                TotalLaunchCount = this.localObjectStorageHelper.Read<long>(nameof(TotalLaunchCount)) + 1;
+                LaunchCount = _localObjectStorageHelper.Read<long>(nameof(LaunchCount)) + 1;
+                TotalLaunchCount = _localObjectStorageHelper.Read<long>(nameof(TotalLaunchCount)) + 1;
 
                 // In case we upgraded the properties, make TotalLaunchCount is correct
                 if (TotalLaunchCount < LaunchCount)
@@ -267,21 +267,21 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                     TotalLaunchCount = LaunchCount;
                 }
 
-                this.localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
-                this.localObjectStorageHelper.Save(nameof(TotalLaunchCount), TotalLaunchCount);
+                _localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
+                _localObjectStorageHelper.Save(nameof(TotalLaunchCount), TotalLaunchCount);
 
                 LaunchTime = DateTime.UtcNow;
 
-                var lastLaunch = this.localObjectStorageHelper.Read<long>(nameof(LastLaunchTime));
+                var lastLaunch = _localObjectStorageHelper.Read<long>(nameof(LastLaunchTime));
 
                 LastLaunchTime = lastLaunch != 0
                     ? DateTime.FromFileTimeUtc(lastLaunch)
                     : LaunchTime;
 
-                this.localObjectStorageHelper.Save(nameof(LastLaunchTime), LaunchTime.ToFileTimeUtc());
-                this.localObjectStorageHelper.Save(nameof(AppUptime), 0L);
+                _localObjectStorageHelper.Save(nameof(LastLaunchTime), LaunchTime.ToFileTimeUtc());
+                _localObjectStorageHelper.Save(nameof(AppUptime), 0L);
 
-                var lastResetTime = this.localObjectStorageHelper.Read<long>(nameof(LastResetTime));
+                var lastResetTime = _localObjectStorageHelper.Read<long>(nameof(LastResetTime));
 
                 LastResetTime = lastResetTime != 0
                     ? DateTime.FromFileTimeUtc(lastResetTime)
@@ -316,25 +316,25 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         {
             if (visible)
             {
-                this.sessionStart = DateTime.UtcNow;
+                _sessionStart = DateTime.UtcNow;
             }
             else
             {
-                var subSessionLength = DateTime.UtcNow.Subtract(this.sessionStart).Ticks;
-                var uptimeSoFar = this.localObjectStorageHelper.Read<long>(nameof(AppUptime));
+                var subSessionLength = DateTime.UtcNow.Subtract(_sessionStart).Ticks;
+                var uptimeSoFar = _localObjectStorageHelper.Read<long>(nameof(AppUptime));
 
-                this.localObjectStorageHelper.Save(nameof(AppUptime), uptimeSoFar + subSessionLength);
+                _localObjectStorageHelper.Save(nameof(AppUptime), uptimeSoFar + subSessionLength);
             }
         }
 
         private bool DetectIfFirstUse()
         {
-            if (this.localObjectStorageHelper.KeyExists(nameof(IsFirstRun)))
+            if (_localObjectStorageHelper.KeyExists(nameof(IsFirstRun)))
             {
                 return false;
             }
 
-            this.localObjectStorageHelper.Save(nameof(IsFirstRun), true);
+            _localObjectStorageHelper.Save(nameof(IsFirstRun), true);
 
             return true;
         }
@@ -347,13 +347,13 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             // is ever called. That is, this is either the first time the app has been launched, or the first
             // time a previously existing app has run this method (or has run it after a new update of the app).
             // In this case, save the current version and report the same version as previous version installed.
-            if (!this.localObjectStorageHelper.KeyExists(nameof(currentVersion)))
+            if (!_localObjectStorageHelper.KeyExists(nameof(currentVersion)))
             {
-                this.localObjectStorageHelper.Save(nameof(currentVersion), currentVersion);
+                _localObjectStorageHelper.Save(nameof(currentVersion), currentVersion);
             }
             else
             {
-                var previousVersion = this.localObjectStorageHelper.Read<string>(nameof(currentVersion));
+                var previousVersion = _localObjectStorageHelper.Read<string>(nameof(currentVersion));
 
                 // There are two possible cases if the "currentVersion" key exists:
                 //   1) The previous version is different than the current one. This means that the application
@@ -363,7 +363,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 //      In this case we have nothing to do and just return the previous version installed to be the same.
                 if (currentVersion != previousVersion)
                 {
-                    this.localObjectStorageHelper.Save(nameof(currentVersion), currentVersion);
+                    _localObjectStorageHelper.Save(nameof(currentVersion), currentVersion);
 
                     return (true, previousVersion.ToPackageVersion());
                 }
@@ -374,28 +374,28 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
         private DateTime DetectFirstUseTime()
         {
-            if (this.localObjectStorageHelper.KeyExists(nameof(FirstUseTime)))
+            if (_localObjectStorageHelper.KeyExists(nameof(FirstUseTime)))
             {
-                var firstUse = this.localObjectStorageHelper.Read<long>(nameof(FirstUseTime));
+                var firstUse = _localObjectStorageHelper.Read<long>(nameof(FirstUseTime));
 
                 return DateTime.FromFileTimeUtc(firstUse);
             }
 
             DateTime utcNow = DateTime.UtcNow;
 
-            this.localObjectStorageHelper.Save(nameof(FirstUseTime), utcNow.ToFileTimeUtc());
+            _localObjectStorageHelper.Save(nameof(FirstUseTime), utcNow.ToFileTimeUtc());
 
             return utcNow;
         }
 
         private PackageVersion DetectFirstVersionInstalled()
         {
-            if (this.localObjectStorageHelper.KeyExists(nameof(FirstVersionInstalled)))
+            if (_localObjectStorageHelper.KeyExists(nameof(FirstVersionInstalled)))
             {
-                return this.localObjectStorageHelper.Read<string>(nameof(FirstVersionInstalled)).ToPackageVersion();
+                return _localObjectStorageHelper.Read<string>(nameof(FirstVersionInstalled)).ToPackageVersion();
             }
 
-            this.localObjectStorageHelper.Save(nameof(FirstVersionInstalled), ApplicationVersion.ToFormattedString());
+            _localObjectStorageHelper.Save(nameof(FirstVersionInstalled), ApplicationVersion.ToFormattedString());
 
             return ApplicationVersion;
         }

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <summary>
         /// Gets the previous version of the app that was installed.
         /// This will be the current version if a previous version of the app was installed
-        /// before using <see cref="SystemInformation"/>  or if the app is not updated.
+        /// before using <see cref="SystemInformation"/> or if the app is not updated.
         /// </summary>
         public PackageVersion PreviousVersionInstalled { get; }
 

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <summary>
         /// Gets the previous version of the app that was installed.
         /// This will be the current version if a previous version of the app was installed
-        /// before using SystemInformation or if the app is not updated.
+        /// before using <see cref="SystemInformation"/>  or if the app is not updated.
         /// </summary>
         public PackageVersion PreviousVersionInstalled { get; }
 

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -123,7 +123,8 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
         /// <summary>
         /// Gets the previous version of the app that was installed.
-        /// This will be the current version if a previous version of the app was installed before accessing this property.
+        /// This will be the current version if a previous version of the app was installed
+        /// before using SystemInformation or if the app is not updated.
         /// </summary>
         public PackageVersion PreviousVersionInstalled { get; }
 
@@ -346,6 +347,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 var lastVersion = _localObjectStorageHelper.Read<string>(nameof(currentVersion));
                 if (currentVersion != lastVersion)
                 {
+                    _localObjectStorageHelper.Save(nameof(PreviousVersionInstalled), lastVersion);
                     _localObjectStorageHelper.Save(nameof(currentVersion), currentVersion);
                     return true;
                 }

--- a/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
+++ b/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
@@ -5,7 +5,7 @@
     <Title>Windows Community Toolkit</Title>
     <Description>This package includes code only helpers such as Colors conversion tool, Storage file handling, a Stream helper class, etc.</Description>
     <PackageTags>Windows;Community;Toolkit;WCT;UWP</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitTests/UnitTests.UWP/Helpers/Test_SystemInformation.cs
+++ b/UnitTests/UnitTests.UWP/Helpers/Test_SystemInformation.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Toolkit.Uwp.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.ApplicationModel;
+using Windows.Storage;
+
+namespace UnitTests.Helpers
+{
+    [TestClass]
+    public class Test_SystemInformation
+    {
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_SystemInformation_ConsistentInfoForFirstStartup()
+        {
+            ApplicationData.Current.LocalSettings.Values.Clear();
+
+            var systemInformation = (SystemInformation)Activator.CreateInstance(typeof(SystemInformation), nonPublic: true);
+            var currentAppVersion = Package.Current.Id.Version;
+
+            Assert.IsTrue(systemInformation.IsFirstRun);
+            Assert.IsFalse(systemInformation.IsAppUpdated);
+            Assert.AreEqual(systemInformation.ApplicationVersion, currentAppVersion);
+            Assert.AreEqual(systemInformation.PreviousVersionInstalled, currentAppVersion);
+            Assert.AreEqual(systemInformation.FirstVersionInstalled, currentAppVersion);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_SystemInformation_ConsistentInfoForStartupWithNoUpdate()
+        {
+            ApplicationData.Current.LocalSettings.Values.Clear();
+
+            // Simulate a first app startup
+            _ = (SystemInformation)Activator.CreateInstance(typeof(SystemInformation), nonPublic: true);
+
+            var systemInformation = (SystemInformation)Activator.CreateInstance(typeof(SystemInformation), nonPublic: true);
+            var currentAppVersion = Package.Current.Id.Version;
+
+            Assert.IsFalse(systemInformation.IsFirstRun);
+            Assert.IsFalse(systemInformation.IsAppUpdated);
+            Assert.AreEqual(systemInformation.ApplicationVersion, currentAppVersion);
+            Assert.AreEqual(systemInformation.PreviousVersionInstalled, currentAppVersion);
+            Assert.AreEqual(systemInformation.FirstVersionInstalled, currentAppVersion);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_SystemInformation_ConsistentInfoForStartupWithUpdate()
+        {
+            ApplicationData.Current.LocalSettings.Values.Clear();
+
+            // Simulate a first app startup
+            _ = (SystemInformation)Activator.CreateInstance(typeof(SystemInformation), nonPublic: true);
+
+            LocalObjectStorageHelper localObjectStorageHelper = new(new SystemSerializer());
+            PackageVersion previousVersion = new() { Build = 42, Major = 1111, Minor = 2222, Revision = 12345 };
+
+            localObjectStorageHelper.Save("currentVersion", previousVersion.ToFormattedString());
+
+            var systemInformation = (SystemInformation)Activator.CreateInstance(typeof(SystemInformation), nonPublic: true);
+            var currentAppVersion = Package.Current.Id.Version;
+
+            Assert.IsFalse(systemInformation.IsFirstRun);
+            Assert.IsTrue(systemInformation.IsAppUpdated);
+            Assert.AreEqual(systemInformation.ApplicationVersion, currentAppVersion);
+            Assert.AreEqual(systemInformation.PreviousVersionInstalled, previousVersion);
+            Assert.AreEqual(systemInformation.FirstVersionInstalled, currentAppVersion);
+        }
+    }
+}

--- a/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
+++ b/UnitTests/UnitTests.UWP/UnitTests.UWP.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Helpers\Test_ConnectionHelper.cs" />
     <Compile Include="Helpers\Test_ScreenUnitHelper.cs" />
     <Compile Include="Helpers\Test_StorageFileHelper.cs" />
+    <Compile Include="Helpers\Test_SystemInformation.cs" />
     <Compile Include="Helpers\Test_StorageHelper.cs" />
     <Compile Include="Helpers\Test_StreamHelper.cs" />
     <Compile Include="Helpers\Test_DeepLinkParser.cs" />


### PR DESCRIPTION
## Fixes #3999 

Doc # [511](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/511)

Add "PreviousVersionInstalled" to SystemInformation to understand which version the app is updated from, to handle specific migration/changes.

## PR Type
Feature 

## What is the current behavior?
SystemInformation doesn't expose the PreviousVersionInstalled property


## What is the new behavior?
Expose "PreviousVersionInstalled" property


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Pull Request has been submitted to the documentation repository [link](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/511)
- [x] Sample in sample app has been added / updated (for bug fixes / features)    
- [x] Contains **NO** breaking changes
