### PR TITLE
Fixed ExpressionNode.EnsureReferenceInfo() crash with .NET Native

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ExpressionNode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ExpressionNode.cs
@@ -282,14 +282,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
                 }
 
                 // Create a map to store the generated paramNames for each CompObj
-                uint id = 0;
                 _compObjToParamNameMap = new Dictionary<CompositionObject, string>();
                 foreach (var compObj in compObjects)
                 {
-                    // compObj.ToString() will return something like "Windows.UI.Composition.SpriteVisual"
-                    // Make it look like "SpriteVisual_1"
-                    string paramName = compObj.ToString();
-                    paramName = $"{paramName.Substring(paramName.LastIndexOf('.') + 1)}_{++id}";       // make sure the created param name doesn't overwrite a custom name
+                    string paramName = Guid.NewGuid().ToUppercaseAsciiLetters();
 
                     _compObjToParamNameMap.Add(compObj, paramName);
                 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/System/GuidExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/System/GuidExtensions.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Toolkit.Uwp.UI.Media
+namespace Microsoft.Toolkit.Uwp.UI.Animations
 {
     /// <summary>
     /// An extension <see langword="class"/> for the <see cref="Guid"/> type

--- a/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Effects.Internals.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Effects.Internals.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas.Effects;
+using Microsoft.Toolkit.Uwp.UI.Animations;
 using Windows.Graphics.Effects;
 using Windows.UI;
 using Windows.UI.Composition;

--- a/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Effects.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Effects.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas.Effects;
+using Microsoft.Toolkit.Uwp.UI.Animations;
 using Windows.Graphics.Effects;
 using Windows.UI;
 using Windows.UI.Composition;

--- a/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Initialization.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Initialization.cs
@@ -8,6 +8,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Effects;
+using Microsoft.Toolkit.Uwp.UI.Animations;
 using Microsoft.Toolkit.Uwp.UI.Media.Helpers;
 using Microsoft.Toolkit.Uwp.UI.Media.Helpers.Cache;
 using Windows.Graphics.Effects;

--- a/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Merge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.Merge.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas.Effects;
+using Microsoft.Toolkit.Uwp.UI.Animations;
 using Windows.Graphics.Effects;
 using Windows.UI.Composition;
 using CanvasBlendEffect = Microsoft.Graphics.Canvas.Effects.BlendEffect;

--- a/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Media/Pipelines/PipelineBuilder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.UI.Animations;
 using Windows.Graphics.Effects;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;


### PR DESCRIPTION
## Closes #4011
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Crash with .NET Native, documented in the related issue.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
The logic has been changed to not rely on APIs that might have a behavioral change under .NET Native.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
