### PR TITLE
Improve Messenger tests

### DIFF
--- a/Microsoft.Toolkit.Mvvm/Messaging/Messages/AsyncCollectionRequestMessage{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Messaging/Messages/AsyncCollectionRequestMessage{T}.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Toolkit.Mvvm.Messaging.Messages
 
             List<T> results = new(this.responses.Count);
 
-            await foreach (var response in this.WithCancellation(cancellationToken))
+            await foreach (var response in this.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
                 results.Add(response);
             }

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.Request.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_Messenger.Request.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Mvvm.Messaging;
 using Microsoft.Toolkit.Mvvm.Messaging.Messages;
@@ -73,6 +74,8 @@ namespace UnitTests.Mvvm
             messenger.Register<NumberRequestMessage>(recipient, Receive);
 
             int result = messenger.Send<NumberRequestMessage>();
+
+            GC.KeepAlive(recipient);
         }
 
         public class NumberRequestMessage : RequestMessage<int>
@@ -102,6 +105,8 @@ namespace UnitTests.Mvvm
             int result = await messenger.Send<AsyncNumberRequestMessage>();
 
             Assert.AreEqual(result, 42);
+
+            GC.KeepAlive(recipient);
         }
 
         [TestCategory("Mvvm")]
@@ -134,6 +139,8 @@ namespace UnitTests.Mvvm
             int result = await messenger.Send<AsyncNumberRequestMessage>();
 
             Assert.AreEqual(result, 42);
+
+            GC.KeepAlive(recipient);
         }
 
         [TestCategory("Mvvm")]
@@ -167,6 +174,8 @@ namespace UnitTests.Mvvm
             messenger.Register<AsyncNumberRequestMessage>(recipient, Receive);
 
             int result = await messenger.Send<AsyncNumberRequestMessage>();
+
+            GC.KeepAlive(recipient);
         }
 
         public class AsyncNumberRequestMessage : AsyncRequestMessage<int>
@@ -191,6 +200,8 @@ namespace UnitTests.Mvvm
             var results = messenger.Send<NumbersCollectionRequestMessage>().Responses;
 
             Assert.AreEqual(results.Count, 0);
+
+            GC.KeepAlive(recipient);
         }
 
         [TestCategory("Mvvm")]
@@ -266,6 +277,8 @@ namespace UnitTests.Mvvm
             var results = await messenger.Send<AsyncNumbersCollectionRequestMessage>().GetResponsesAsync();
 
             Assert.AreEqual(results.Count, 0);
+
+            GC.KeepAlive(recipient);
         }
 
         [TestCategory("Mvvm")]
@@ -273,6 +286,46 @@ namespace UnitTests.Mvvm
         [DataRow(typeof(StrongReferenceMessenger))]
         [DataRow(typeof(WeakReferenceMessenger))]
         public async Task Test_Messenger_AsyncCollectionRequestMessage_Ok_MultipleReplies(Type type)
+        {
+            var messenger = (IMessenger)Activator.CreateInstance(type);
+            object
+                recipient1 = new object(),
+                recipient2 = new object(),
+                recipient3 = new object(),
+                recipient4 = new object();
+
+            async Task<int> GetNumberAsync()
+            {
+                await Task.Delay(100);
+
+                return 3;
+            }
+
+            void Receive1(object recipient, AsyncNumbersCollectionRequestMessage m) => m.Reply(1);
+            void Receive2(object recipient, AsyncNumbersCollectionRequestMessage m) => m.Reply(Task.FromResult(2));
+            void Receive3(object recipient, AsyncNumbersCollectionRequestMessage m) => m.Reply(GetNumberAsync());
+            void Receive4(object recipient, AsyncNumbersCollectionRequestMessage m) => m.Reply(_ => GetNumberAsync());
+
+            messenger.Register<AsyncNumbersCollectionRequestMessage>(recipient1, Receive1);
+            messenger.Register<AsyncNumbersCollectionRequestMessage>(recipient2, Receive2);
+            messenger.Register<AsyncNumbersCollectionRequestMessage>(recipient3, Receive3);
+            messenger.Register<AsyncNumbersCollectionRequestMessage>(recipient4, Receive4);
+
+            var responses = await messenger.Send<AsyncNumbersCollectionRequestMessage>().GetResponsesAsync();
+
+            CollectionAssert.AreEquivalent(responses.ToArray(), new[] { 1, 2, 3, 3 });
+
+            GC.KeepAlive(recipient1);
+            GC.KeepAlive(recipient2);
+            GC.KeepAlive(recipient3);
+            GC.KeepAlive(recipient4);
+        }
+
+        [TestCategory("Mvvm")]
+        [TestMethod]
+        [DataRow(typeof(StrongReferenceMessenger))]
+        [DataRow(typeof(WeakReferenceMessenger))]
+        public async Task Test_Messenger_AsyncCollectionRequestMessage_Ok_MultipleReplies_Enumerate(Type type)
         {
             var messenger = (IMessenger)Activator.CreateInstance(type);
             object
@@ -306,6 +359,11 @@ namespace UnitTests.Mvvm
             }
 
             CollectionAssert.AreEquivalent(responses, new[] { 1, 2, 3, 3 });
+
+            GC.KeepAlive(recipient1);
+            GC.KeepAlive(recipient2);
+            GC.KeepAlive(recipient3);
+            GC.KeepAlive(recipient4);
         }
 
         public class AsyncNumbersCollectionRequestMessage : AsyncCollectionRequestMessage<int>


### PR DESCRIPTION
## Fixes #4017
<!-- Add the relevant issue number after the "#" mentioned above (for ex: Fixes #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR. -->

- Test improvements
<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The messenger tests don't properly keep recipients alive until the end of each test.
This can be problematic for `WeakReferenceMessenger`, and can cause statistical bugs to happen.

## What is the new behavior?
<!-- Describe how was this issue resolved or changed? -->
Added missing `GC.KeepAlive(object)` calls where needed.
Also added a missing `.ConfigureAwait(false)` to a message type.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] ~~Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->~~
- [ ] ~~Sample in sample app has been added / updated (for bug fixes / features)~~
    - [ ] ~~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~~
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes
