### PR TITLE
Expose public indexer and length properties on RefEnumerable<T> and ReadOnlyRefEnumerable<T>

### DIFF
--- a/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
             return ref MemoryMarshal.GetReference(this.span);
 #else
-            return ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.Instance, this.Offset);
+            return ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
 #endif
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
             ref T r0 = ref MemoryMarshal.GetReference(this.span);
 #else
-            ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.Instance, this.Offset);
+            ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
 #endif
             // Here we just offset by shifting down as if we were traversing a 2D array with a
             // a single column, with the width of each row represented by the step, the height

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// </summary>
         /// <remarks>The <see cref="ReadOnlySpan{T}.Length"/> field maps to the total available length.</remarks>
         private readonly ReadOnlySpan<T> span;
+
+        /// <summary>
+        /// The total available length for the sequence.
+        /// </summary>
+        public int Length => span.Length;
 #else
         /// <summary>
         /// The target <see cref="object"/> instance, if present.
@@ -43,7 +48,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// <summary>
         /// The total available length for the sequence.
         /// </summary>
-        private readonly int length;
+        public int Length { get; }
 #endif
 
         /// <summary>
@@ -51,6 +56,40 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// </summary>
         /// <remarks>The distance refers to <typeparamref name="T"/> items, not byte offset.</remarks>
         private readonly int step;
+
+        /// <summary>
+        /// Gets the element at the specified zero-based index.
+        /// </summary>
+        /// <returns>A reference to the element at the specified index.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Thrown when <paramref name="index"/> is invalid.
+        /// </exception>
+        public ref readonly T this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)Length)
+                {
+                    ThrowHelper.ThrowIndexOutOfRangeException();
+                }
+
+                return ref DangerousGetReferenceAt(index);
+            }
+        }
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Gets the element at the specified zero-based index.
+        /// </summary>
+        /// <returns>A reference to the element at the specified index.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Thrown when <paramref name="index"/> is invalid.
+        /// </exception>
+        public ref readonly T this[Index index]
+        {
+            get => ref this[index.GetOffset(Length)];
+        }
+#endif
 
 #if SPAN_RUNTIME_SUPPORT
         /// <summary>
@@ -116,21 +155,52 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         {
             this.instance = instance;
             this.offset = offset;
-            this.length = length;
+            Length = length;
             this.step = step;
         }
 #endif
+
+        /// <summary>
+        /// Returns a reference to the first element within the current instance, with no bounds check.
+        /// </summary>
+        /// <returns>A reference to the first element within the current instance.</returns>
+        internal ref readonly T DangerousGetReference()
+        {
+#if SPAN_RUNTIME_SUPPORT
+            return ref MemoryMarshal.GetReference(this.span);
+#else
+            return ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.Instance, this.Offset);
+#endif
+        }
+
+        /// <summary>
+        /// Returns a reference to a specified element within the current instance, with no bounds check.
+        /// </summary>
+        /// <returns>A reference to the element at the specified index.</returns>
+        internal ref readonly T DangerousGetReferenceAt(int index)
+        {
+#if SPAN_RUNTIME_SUPPORT
+            ref T r0 = ref MemoryMarshal.GetReference(this.span);
+#else
+            ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.Instance, this.Offset);
+#endif
+            // Here we just offset by shifting down as if we were traversing a 2D array with a
+            // a single column, with the width of each row represented by the step, the height
+            // represented by the current position, and with only the first element of each row
+            // being inspected. We can perform all the indexing operations in this type as nint,
+            // as the maximum offset is guaranteed never to exceed the maximum value, since on
+            // 32 bit architectures it's not possible to allocate that much memory anyway.
+            nint offset = (nint)(uint)index * (nint)(uint)this.step;
+            ref T ri = ref Unsafe.Add(ref r0, offset);
+            return ref ri;
+        }
 
         /// <inheritdoc cref="System.Collections.IEnumerable.GetEnumerator"/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Enumerator GetEnumerator()
         {
-#if SPAN_RUNTIME_SUPPORT
-            return new Enumerator(this.span, this.step);
-#else
-            return new Enumerator(this.instance, this.offset, this.length, this.step);
-#endif
+            return new Enumerator(this);
         }
 
         /// <summary>
@@ -166,7 +236,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             ref T sourceRef = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
             ref T destinationRef = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(destination.Instance, destination.Offset);
             int
-                sourceLength = this.length,
+                sourceLength = Length,
                 destinationLength = destination.Length;
 #endif
 
@@ -191,7 +261,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
                 destinationLength = destination.Span.Length;
 #else
             int
-                sourceLength = this.length,
+                sourceLength = Length,
                 destinationLength = destination.Length;
 #endif
 
@@ -226,7 +296,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             int length = this.span.Length;
 #else
             ref T sourceRef = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
-            int length = this.length;
+            int length = Length;
 #endif
             if ((uint)destination.Length < (uint)length)
             {
@@ -248,7 +318,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
             int length = this.span.Length;
 #else
-            int length = this.length;
+            int length = Length;
 #endif
 
             if (destination.Length >= length)
@@ -268,7 +338,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
             int length = this.span.Length;
 #else
-            int length = this.length;
+            int length = Length;
 #endif
 
             // Empty array if no data is mapped
@@ -303,22 +373,10 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// </summary>
         public ref struct Enumerator
         {
-#if SPAN_RUNTIME_SUPPORT
-            /// <inheritdoc cref="ReadOnlyRefEnumerable{T}.span"/>
-            private readonly ReadOnlySpan<T> span;
-#else
-            /// <inheritdoc cref="ReadOnlyRefEnumerable{T}.instance"/>
-            private readonly object? instance;
-
-            /// <inheritdoc cref="ReadOnlyRefEnumerable{T}.offset"/>
-            private readonly IntPtr offset;
-
-            /// <inheritdoc cref="ReadOnlyRefEnumerable{T}.length"/>
-            private readonly int length;
-#endif
-
-            /// <inheritdoc cref="ReadOnlyRefEnumerable{T}.step"/>
-            private readonly int step;
+            /// <summary>
+            /// The <see cref="ReadOnlyRefEnumerable{T}"/> used by this enumerator.
+            /// </summary>
+            private readonly ReadOnlyRefEnumerable<T> enumerable;
 
             /// <summary>
             /// The current position in the sequence.
@@ -333,10 +391,8 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             /// <param name="step">The distance between items in the sequence to enumerate.</param>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal Enumerator(ReadOnlySpan<T> span, int step)
+                : this(new ReadOnlyRefEnumerable<T>(span, step))
             {
-                this.span = span;
-                this.step = step;
-                this.position = -1;
             }
 #else
             /// <summary>
@@ -348,23 +404,25 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             /// <param name="step">The distance between items in the sequence to enumerate.</param>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal Enumerator(object? instance, IntPtr offset, int length, int step)
+                : this(new ReadOnlyRefEnumerable<T>(instance, offset, length, step))
             {
-                this.instance = instance;
-                this.offset = offset;
-                this.length = length;
-                this.step = step;
-                this.position = -1;
             }
 #endif
+
+            internal Enumerator(ReadOnlyRefEnumerable<T> enumerable)
+            {
+                this.enumerable = enumerable;
+                this.position = -1;
+            }
 
             /// <inheritdoc cref="System.Collections.IEnumerator.MoveNext"/>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool MoveNext()
             {
 #if SPAN_RUNTIME_SUPPORT
-                return ++this.position < this.span.Length;
+                return ++this.position < this.enumerable.span.Length;
 #else
-                return ++this.position < this.length;
+                return ++this.position < this.enumerable.Length;
 #endif
             }
 
@@ -372,18 +430,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             public readonly ref readonly T Current
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get
-                {
-#if SPAN_RUNTIME_SUPPORT
-                    ref T r0 = ref this.span.DangerousGetReference();
-#else
-                    ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
-#endif
-                    nint offset = (nint)(uint)this.position * (nint)(uint)this.step;
-                    ref T ri = ref Unsafe.Add(ref r0, offset);
-
-                    return ref ri;
-                }
+                get => ref this.enumerable.DangerousGetReferenceAt(this.position);
             }
         }
 

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         private readonly ReadOnlySpan<T> span;
 
         /// <summary>
-        /// The total available length for the sequence.
+        /// Gets the total available length for the sequence.
         /// </summary>
         public int Length => span.Length;
 #else
@@ -46,7 +46,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         private readonly IntPtr offset;
 
         /// <summary>
-        /// The total available length for the sequence.
+        /// Gets the total available length for the sequence.
         /// </summary>
         public int Length { get; }
 #endif

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         internal readonly Span<T> Span;
 
         /// <summary>
-        /// The total available length for the sequence.
+        /// Gets the total available length for the sequence.
         /// </summary>
         public int Length => Span.Length;
 #else
@@ -46,7 +46,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         internal readonly IntPtr Offset;
 
         /// <summary>
-        /// The total available length for the sequence.
+        /// Gets the total available length for the sequence.
         /// </summary>
         public int Length { get; }
 #endif

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// </summary>
         /// <remarks>The <see cref="Span{T}.Length"/> field maps to the total available length.</remarks>
         internal readonly Span<T> Span;
+
+        /// <summary>
+        /// The total available length for the sequence.
+        /// </summary>
+        public int Length => Span.Length;
 #else
         /// <summary>
         /// The target <see cref="object"/> instance, if present.
@@ -43,7 +48,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// <summary>
         /// The total available length for the sequence.
         /// </summary>
-        internal readonly int Length;
+        public int Length { get; }
 #endif
 
         /// <summary>
@@ -51,6 +56,40 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// </summary>
         /// <remarks>The distance refers to <typeparamref name="T"/> items, not byte offset.</remarks>
         internal readonly int Step;
+
+        /// <summary>
+        /// Gets the element at the specified zero-based index.
+        /// </summary>
+        /// <returns>A reference to the element at the specified index.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Thrown when <paramref name="index"/> is invalid.
+        /// </exception>
+        public ref T this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)Length)
+                {
+                    ThrowHelper.ThrowIndexOutOfRangeException();
+                }
+
+                return ref DangerousGetReferenceAt(index);
+            }
+        }
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Gets the element at the specified zero-based index.
+        /// </summary>
+        /// <returns>A reference to the element at the specified index.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// Thrown when <paramref name="index"/> is invalid.
+        /// </exception>
+        public ref T this[Index index]
+        {
+            get => ref this[index.GetOffset(Length)];
+        }
+#endif
 
 #if SPAN_RUNTIME_SUPPORT
         /// <summary>
@@ -63,6 +102,18 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         internal RefEnumerable(ref T reference, int length, int step)
         {
             Span = MemoryMarshal.CreateSpan(ref reference, length);
+            Step = step;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefEnumerable{T}"/> struct.
+        /// </summary>
+        /// <param name="span">The <see cref="Span{T}"/> instance pointing to the first item in the target memory area.</param>
+        /// <param name="step">The distance between items in the sequence to enumerate.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal RefEnumerable(Span<T> span, int step)
+        {
+            Span = span;
             Step = step;
         }
 
@@ -109,16 +160,47 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         }
 #endif
 
+        /// <summary>
+        /// Returns a reference to the first element within the current instance, with no bounds check.
+        /// </summary>
+        /// <returns>A reference to the first element within the current instance.</returns>
+        internal ref T DangerousGetReference()
+        {
+#if SPAN_RUNTIME_SUPPORT
+            return ref MemoryMarshal.GetReference(this.Span);
+#else
+            return ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.Instance, this.Offset);
+#endif
+        }
+
+        /// <summary>
+        /// Returns a reference to a specified element within the current instance, with no bounds check.
+        /// </summary>
+        /// <returns>A reference to the element at the specified index.</returns>
+        internal ref T DangerousGetReferenceAt(int index)
+        {
+#if SPAN_RUNTIME_SUPPORT
+            ref T r0 = ref MemoryMarshal.GetReference(this.Span);
+#else
+            ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.Instance, this.Offset);
+#endif
+            // Here we just offset by shifting down as if we were traversing a 2D array with a
+            // a single column, with the width of each row represented by the step, the height
+            // represented by the current position, and with only the first element of each row
+            // being inspected. We can perform all the indexing operations in this type as nint,
+            // as the maximum offset is guaranteed never to exceed the maximum value, since on
+            // 32 bit architectures it's not possible to allocate that much memory anyway.
+            nint offset = (nint)(uint)index * (nint)(uint)this.Step;
+            ref T ri = ref Unsafe.Add(ref r0, offset);
+            return ref ri;
+        }
+
         /// <inheritdoc cref="System.Collections.IEnumerable.GetEnumerator"/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Enumerator GetEnumerator()
         {
-#if SPAN_RUNTIME_SUPPORT
-            return new Enumerator(this.Span, this.Step);
-#else
-            return new Enumerator(this.Instance, this.Offset, this.Length, this.Step);
-#endif
+            return new Enumerator(this);
         }
 
         /// <summary>
@@ -389,22 +471,10 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// </summary>
         public ref struct Enumerator
         {
-#if SPAN_RUNTIME_SUPPORT
-            /// <inheritdoc cref="RefEnumerable{T}.Span"/>
-            private readonly Span<T> span;
-#else
-            /// <inheritdoc cref="RefEnumerable{T}.Instance"/>
-            private readonly object? instance;
-
-            /// <inheritdoc cref="RefEnumerable{T}.Offset"/>
-            private readonly IntPtr offset;
-
-            /// <inheritdoc cref="RefEnumerable{T}.Length"/>
-            private readonly int length;
-#endif
-
-            /// <inheritdoc cref="RefEnumerable{T}.Step"/>
-            private readonly int step;
+            /// <summary>
+            /// The <see cref="RefEnumerable{T}"/> used by this enumerator.
+            /// </summary>
+            private readonly RefEnumerable<T> enumerable;
 
             /// <summary>
             /// The current position in the sequence.
@@ -419,10 +489,8 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             /// <param name="step">The distance between items in the sequence to enumerate.</param>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal Enumerator(Span<T> span, int step)
+                : this(new RefEnumerable<T>(span, step))
             {
-                this.span = span;
-                this.step = step;
-                this.position = -1;
             }
 #else
             /// <summary>
@@ -434,23 +502,28 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             /// <param name="step">The distance between items in the sequence to enumerate.</param>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal Enumerator(object? instance, IntPtr offset, int length, int step)
+                : this(new RefEnumerable<T>(instance, offset, length, step))
             {
-                this.instance = instance;
-                this.offset = offset;
-                this.length = length;
-                this.step = step;
-                this.position = -1;
             }
 #endif
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Enumerator"/> struct.
+            /// </summary>
+            internal Enumerator(RefEnumerable<T> enumerable)
+            {
+                this.enumerable = enumerable;
+                this.position = -1;
+            }
 
             /// <inheritdoc cref="System.Collections.IEnumerator.MoveNext"/>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool MoveNext()
             {
 #if SPAN_RUNTIME_SUPPORT
-                return ++this.position < this.span.Length;
+                return ++this.position < this.enumerable.Span.Length;
 #else
-                return ++this.position < this.length;
+                return ++this.position < this.enumerable.Length;
 #endif
             }
 
@@ -458,25 +531,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             public readonly ref T Current
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get
-                {
-#if SPAN_RUNTIME_SUPPORT
-                    ref T r0 = ref this.span.DangerousGetReference();
-#else
-                    ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
-#endif
-
-                    // Here we just offset by shifting down as if we were traversing a 2D array with a
-                    // a single column, with the width of each row represented by the step, the height
-                    // represented by the current position, and with only the first element of each row
-                    // being inspected. We can perform all the indexing operations in this type as nint,
-                    // as the maximum offset is guaranteed never to exceed the maximum value, since on
-                    // 32 bit architectures it's not possible to allocate that much memory anyway.
-                    nint offset = (nint)(uint)this.position * (nint)(uint)this.step;
-                    ref T ri = ref Unsafe.Add(ref r0, offset);
-
-                    return ref ri;
-                }
+                get => ref this.enumerable.DangerousGetReferenceAt(this.position);
             }
         }
 

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
@@ -9,9 +9,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #endif
 using Microsoft.Toolkit.HighPerformance.Helpers.Internals;
-#if SPAN_RUNTIME_SUPPORT
 using Microsoft.Toolkit.HighPerformance.Memory.Internals;
-#else
+
+#if !SPAN_RUNTIME_SUPPORT
 using RuntimeHelpers = Microsoft.Toolkit.HighPerformance.Helpers.Internals.RuntimeHelpers;
 #endif
 


### PR DESCRIPTION
## Closes #4043
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Currently, `RefEnumerable<T>` (and its read-only variant) do not expose an indexer or their length. This can make it difficult to implement certain APIs against them, such as a function to reverse their data.

## What is the new behavior?
This PR exposes public length and indexer properties (for both `int` and `System.Index`) on both `RefEnumerable<T>` and `ReadOnlyRefEnumerable<T>`.

```diff
public partial readonly ref struct RefEnumerable<T>
{
+   public int Length { get; }
+   public ref T this[int index] { get; }
+   public ref T this[Index index] { get; }
}

public partial readonly ref struct ReadOnlyRefEnumerable<T>
{
+   public int Length { get; }
+   public ref readonly T this[int index] { get; }
+   public ref readonly T this[Index index] { get; }
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] ~Sample in sample app has been added / updated (for bug fixes / features)~
    - [ ] ~Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)~
- [ ] ~New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/windows-toolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...~
- [ ] ~Tests for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Header has been added to all new source files (run *build/UpdateHeaders.bat*)~
- [x] Contains **NO** breaking changes

## Other information
It may be worthwhile to additionally expose the `Step` field and the newly-added `DangerousGetReference`/`DangerousGetReferenceAt` methods. This would allow for an implementation of `Reverse` that avoids bounds-checking.