### PR TITLE
Fixed incorrect default easing for XAML animation types

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Xaml/Abstract/Animation{TValue,TKeyFrame}.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Xaml/Abstract/Animation{TValue,TKeyFrame}.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
             if (from is not null)
             {
-                builder.KeyFrame(0.0, from.Value, default, default);
+                builder.KeyFrame(0.0, from.Value);
             }
 
             return builder;

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Xaml/Abstract/ImplicitAnimation{TValue,TKeyFrame}.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Xaml/Abstract/ImplicitAnimation{TValue,TKeyFrame}.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 if (from is not null)
                 {
-                    builder.KeyFrame(0.0, from.Value, default, default);
+                    builder.KeyFrame(0.0, from.Value, DefaultEasingType, DefaultEasingMode);
                 }
 
                 foreach (var keyFrame in KeyFrames)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

There are a few callsites in the animation APIs in the `Microsoft.Toolkit.Uwp.UI.Animations` package where a value of `default` is accidentally being passed to the easing mode and easing type when inserting keyframes into animations built using the XAML mapping types. This causes the easing mode being selected to be "ease in" (as it's the first in its declaring type) and not "ease in out", which is special cased to map to the default easing function for the composition layer when combined with the default easing type. This makes it so that in some cases, inserted keyframes end up using a custom beizer curve easing function instead of just `null`, which would let the framework automatically use whatever the default easing mode is on that current OS version. This is currently harder to spot as the custom animation approximates what the default one looks like, but it's technically not correct and might become more apparent in the future in case an OS update tweaked the way the default easing function works.

## What is the new behavior?

XAML animation types where no custom easing type/mode are set just pass `null` as the composition easing function.
This lets the framework just apply whatever default easing it wants to use.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [X] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [X] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes
