### PR TITLE
Add Byte[] To Image Converter

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Converters/ByteArrayToImageConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Converters/ByteArrayToImageConverter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Converters
         /// <returns>BitmapImage</returns>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            if (value is byte[] byteArray && byteArray is not null)
+            if (value is byte[] byteArray)
             {
                 using InMemoryRandomAccessStream stream = new();
                 using (DataWriter writer = new(stream.GetOutputStreamAt(0)))


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Feature

## What is the current behavior?
It takes a byte[] and try to turn it into BitmapImage as described here https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4111

## PR Checklist
- [x] Tested code with current [supported SDKs](../#supported)
- [x] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

tested it in WinUI 3 app loading image as byte array from litedb/sqlserver and loading it into image control and so far no problems