### PR TITLE
[Draft] [WinUI3] Window cleanup after test runs

### DIFF
--- a/UnitTests/UnitTests.Notifications.WinUI/App.xaml.cs
+++ b/UnitTests/UnitTests.Notifications.WinUI/App.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 
 namespace UnitTests.Notifications.WinUI
@@ -48,6 +49,18 @@ namespace UnitTests.Notifications.WinUI
 
             // replace back with e.Arguments when https://github.com/microsoft/microsoft-ui-xaml/issues/3368 is fixed
             Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
+        }
+
+        [AssemblyCleanup]
+        public static void CleanupWindow()
+        {
+            if (_window != null)
+            {
+                _window.DispatcherQueue.TryEnqueue(() =>
+                {
+                    _window.Close();
+                });
+            }
         }
     }
 }

--- a/UnitTests/UnitTests.WinUI/App.xaml.cs
+++ b/UnitTests/UnitTests.WinUI/App.xaml.cs
@@ -6,6 +6,7 @@ using System;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using UnitTests.WinUI;
@@ -89,6 +90,18 @@ namespace UnitTests
 
             // replace back with e.Arguments when https://github.com/microsoft/microsoft-ui-xaml/issues/3368 is fixed
             Microsoft.VisualStudio.TestPlatform.TestExecutor.UnitTestClient.Run(Environment.CommandLine);
+        }
+
+        [AssemblyCleanup]
+        public static void CleanupWindow()
+        {
+            if(_window != null)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    _window.Close();
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## Fixes

When running the UI tests, the test apps window stays open and do not get cleaned up. There are two ways a window get's "leaked" when running tests from Visual Studio:
1. Test discovery starts app but does not close it
2. Test run finished (also does not close app)

This PR tries to address this, in it's current form, the second case would be fixed. Point one still occurs.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Two windows spawn when running tests through Visual Studio, both stay open after test run finished.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

One window stays open, the other get's closed.
<!-- Describe how was this issue resolved or changed? -->

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [x] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [X] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->

Case 
