### PR TITLE
Fixed narrator not announcing RangeSelector values / changes

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.Input.Drag.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.Input.Drag.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             return _containerCanvas.ActualWidth - _maxThumb.Width;
         }
 
-        private double DragThumb(Thumb thumb, double min, double max, double nextPos)
+        private double DragThumb(RangeThumb thumb, double min, double max, double nextPos)
         {
             nextPos = Math.Max(min, nextPos);
             nextPos = Math.Min(max, nextPos);
@@ -89,7 +89,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             return Minimum + ((nextPos / DragWidth()) * (Maximum - Minimum));
         }
 
-        private void Thumb_DragStarted(Thumb thumb)
+        private void Thumb_DragStarted(RangeThumb thumb)
         {
             var useMin = thumb == _minThumb;
             var otherThumb = useMin ? _maxThumb : _minThumb;

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private Border _outOfRangeContentContainer;
         private Rectangle _activeRectangle;
-        private Thumb _minThumb;
-        private Thumb _maxThumb;
+        private RangeThumb _minThumb;
+        private RangeThumb _maxThumb;
         private Canvas _containerCanvas;
         private Grid _controlGrid;
         private double _oldValue;
@@ -98,8 +98,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             _outOfRangeContentContainer = GetTemplateChild("OutOfRangeContentContainer") as Border;
             _activeRectangle = GetTemplateChild("ActiveRectangle") as Rectangle;
-            _minThumb = GetTemplateChild("MinThumb") as Thumb;
-            _maxThumb = GetTemplateChild("MaxThumb") as Thumb;
+            _minThumb = GetTemplateChild("MinThumb") as RangeThumb;
+            _maxThumb = GetTemplateChild("MaxThumb") as RangeThumb;
             _containerCanvas = GetTemplateChild("ContainerCanvas") as Canvas;
             _controlGrid = GetTemplateChild("ControlGrid") as Grid;
             _toolTip = GetTemplateChild("ToolTip") as Grid;

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.xaml
@@ -2,6 +2,21 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
+    <Style x:Key="RangeThumbStyle"
+           TargetType="controls:RangeThumb">
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="Height" Value="24" />
+        <Setter Property="Width" Value="8" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="controls:RangeThumb">
+                    <Thumb x:Name="InternalThumb"
+                           Style="{StaticResource SliderThumbStyle}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="SliderThumbStyle"
            TargetType="Thumb">
         <Setter Property="UseSystemFocusVisuals" Value="True" />
@@ -34,45 +49,6 @@
                 <ControlTemplate TargetType="controls:RangeSelector">
                     <Grid x:Name="ControlGrid"
                           Height="24">
-                        <Border x:Name="OutOfRangeContentContainer"
-                                Grid.Column="1"
-                                Background="Transparent">
-                            <Rectangle x:Name="BackgroundElement"
-                                       Height="2"
-                                       Fill="{TemplateBinding Background}" />
-                        </Border>
-
-                        <Canvas x:Name="ContainerCanvas"
-                                Grid.Column="1"
-                                Background="Transparent">
-                            <Rectangle x:Name="ActiveRectangle"
-                                       Height="2"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="Center"
-                                       Fill="{TemplateBinding Foreground}" />
-
-                            <Grid x:Name="ToolTip"
-                                  Margin="0,-44,0,8"
-                                  Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
-                                  BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
-                                  BorderThickness="1"
-                                  Visibility="Collapsed">
-                                <TextBlock x:Name="ToolTipText"
-                                           Margin="8"
-                                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-                            </Grid>
-
-                            <Thumb x:Name="MinThumb"
-                                   AutomationProperties.Name="Min thumb"
-                                   IsTabStop="True"
-                                   Style="{StaticResource SliderThumbStyle}"
-                                   TabIndex="0" />
-                            <Thumb x:Name="MaxThumb"
-                                   AutomationProperties.Name="Max thumb"
-                                   IsTabStop="True"
-                                   Style="{StaticResource SliderThumbStyle}"
-                                   TabIndex="1" />
-                        </Canvas>
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -142,6 +118,53 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
+
+                        <Border x:Name="OutOfRangeContentContainer"
+                                Grid.Column="1"
+                                Background="Transparent">
+                            <Rectangle x:Name="BackgroundElement"
+                                       Height="2"
+                                       Fill="{TemplateBinding Background}" />
+                        </Border>
+
+                        <Canvas x:Name="ContainerCanvas"
+                                Grid.Column="1"
+                                Background="Transparent">
+                            <Rectangle x:Name="ActiveRectangle"
+                                       Height="2"
+                                       HorizontalAlignment="Stretch"
+                                       VerticalAlignment="Center"
+                                       Fill="{TemplateBinding Foreground}" />
+
+                            <Grid x:Name="ToolTip"
+                                  Margin="0,-44,0,8"
+                                  Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+                                  BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+                                  BorderThickness="1"
+                                  Visibility="Collapsed">
+                                <TextBlock x:Name="ToolTipText"
+                                           Margin="8"
+                                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+                            </Grid>
+
+                            <controls:RangeThumb x:Name="MinThumb"
+                                                 AutomationProperties.Name="Min thumb"
+                                                 IsTabStop="True"
+                                                 Maximum="{Binding Maximum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Minimum="{Binding Minimum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Style="{StaticResource RangeThumbStyle}"
+                                                 TabIndex="0"
+                                                 Value="{Binding RangeStart, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+
+                            <controls:RangeThumb x:Name="MaxThumb"
+                                                 AutomationProperties.Name="Max thumb"
+                                                 IsTabStop="True"
+                                                 Maximum="{Binding Maximum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Minimum="{Binding Minimum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Style="{StaticResource RangeThumbStyle}"
+                                                 TabIndex="1"
+                                                 Value="{Binding RangeEnd, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+                        </Canvas>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeSelector.xaml
@@ -150,20 +150,20 @@
                             <controls:RangeThumb x:Name="MinThumb"
                                                  AutomationProperties.Name="Min thumb"
                                                  IsTabStop="True"
-                                                 Maximum="{Binding Maximum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                                 Minimum="{Binding Minimum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Maximum="{Binding Maximum, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Minimum="{Binding Minimum, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                                  Style="{StaticResource RangeThumbStyle}"
                                                  TabIndex="0"
-                                                 Value="{Binding RangeStart, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+                                                 Value="{Binding RangeStart, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
 
                             <controls:RangeThumb x:Name="MaxThumb"
                                                  AutomationProperties.Name="Max thumb"
                                                  IsTabStop="True"
-                                                 Maximum="{Binding Maximum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                                 Minimum="{Binding Minimum, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Maximum="{Binding Maximum, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                                 Minimum="{Binding Minimum, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                                  Style="{StaticResource RangeThumbStyle}"
                                                  TabIndex="1"
-                                                 Value="{Binding RangeEnd, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+                                                 Value="{Binding RangeEnd, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
                         </Canvas>
                     </Grid>
                 </ControlTemplate>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeThumb.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeThumb.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Controls.Primitives;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// A thumb that represents a value within a range.
+    /// </summary>
+    [TemplatePart(Name = "InternalThumb", Type = typeof(Thumb))]
+    public class RangeThumb : RangeBase
+    {
+        private Thumb _thumb;
+
+        /// <inheritdoc cref="Thumb.DragStarted"/>
+        public event EventHandler<DragStartedEventArgs> DragStarted;
+
+        /// <inheritdoc cref="Thumb.DragCompleted"/>
+        public event EventHandler<DragCompletedEventArgs> DragCompleted;
+
+        /// <inheritdoc cref="Thumb.DragDelta"/>
+        public event EventHandler<DragDeltaEventArgs> DragDelta;
+
+        /// <inheritdoc/>
+        protected override void OnApplyTemplate()
+        {
+            _thumb = GetTemplateChild("InternalThumb") as Thumb;
+
+            if (_thumb is not null)
+            {
+                AttachEvents(_thumb);
+            }
+
+            Unloaded += RangeThumb_Unloaded;
+
+            base.OnApplyTemplate();
+        }
+
+        private void AttachEvents(Thumb thumb)
+        {
+            thumb.DragCompleted += Thumb_DragCompleted;
+            thumb.DragStarted += Thumb_DragStarted;
+            thumb.DragDelta += Thumb_DragDelta;
+        }
+
+        private void DetachEvents(Thumb thumb)
+        {
+            thumb.DragCompleted -= Thumb_DragCompleted;
+            thumb.DragStarted -= Thumb_DragStarted;
+            thumb.DragDelta -= Thumb_DragDelta;
+        }
+
+        private void Thumb_DragStarted(object sender, DragStartedEventArgs e) => DragStarted?.Invoke(this, e);
+
+        private void Thumb_DragDelta(object sender, DragDeltaEventArgs e) => DragDelta?.Invoke(this, e);
+
+        private void Thumb_DragCompleted(object sender, DragCompletedEventArgs e) => DragCompleted?.Invoke(this, e);
+
+        private void RangeThumb_Unloaded(object sender, RoutedEventArgs e)
+        {
+            if (_thumb is not null)
+            {
+                DetachEvents(_thumb);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new RangeThumbAutomationPeer(this);
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeThumbAutomationPeer.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Input/RangeSelector/RangeThumbAutomationPeer.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Controls.Primitives;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// A class that provides a Microsoft UI Automation peer implementation for <see cref="RangeThumb"/>.
+    /// </summary>
+    public class RangeThumbAutomationPeer : RangeBaseAutomationPeer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RangeThumbAutomationPeer"/> class.
+        /// </summary>
+        /// <param name="owner">The owner element to create for.</param>
+        public RangeThumbAutomationPeer(RangeThumb owner)
+            : base(owner)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Slider;
+
+        /// <inheritdoc/>
+        protected override string GetClassNameCore()
+        {
+            return nameof(RangeThumb);
+        }
+    }
+}


### PR DESCRIPTION

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

### Overview

Bugfix, Fixes #3538

### Current behavior
Narrator does not announce range selector values or updates to the values.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

### New behavior
Narrator now announces range selector values and updates.
<!-- Describe how was this issue resolved or changed? -->

To do this, I've

- **Added a new `RangeThumb` control** - derives from `RangeBase`. 
    - Binds min/max/value to the range selector.
    - Wraps around a `Windows.UI.Xaml.Controls.Primitives.Thumb` control, using the existing style.
    - Relays the needed events from the wrapped `Thumb` for range selector to use.
- **Added a new `RangeThumbAutomationPeer`** class - takes in a `RangeThumb` and is treated like a slider.
- **Swapped `Thumb` with `RangeThumb`** - in RangeSelector, `RangeThumb` has been implemented and fully integrated.
- **Tested the new behavior** -- to make sure Narrator now works as expected. 

Short demo of the new behavior:

https://user-images.githubusercontent.com/9384894/147699997-10854a37-bf6b-4396-a2ec-78be00e8d5c0.mp4




## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->


<!-- Please add any other information that might be helpful to reviewers. -->
