### PR TITLE
TextIconExtension to use Segoe Fluent Icons by default

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/Abstract/TextIconExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/Abstract/TextIconExtension.cs
@@ -20,14 +20,14 @@ namespace Microsoft.Toolkit.Uwp.UI
         public double FontSize { get; set; }
 
         [ThreadStatic]
-        private static FontFamily segoeMDL2AssetsFontFamily;
+        private static FontFamily symbolThemeFontFamily;
 
         /// <summary>
         /// Gets the reusable "Segoe MDL2 Assets" <see cref="FontFamily"/> instance.
         /// </summary>
-        protected static FontFamily SegoeMDL2AssetsFontFamily
+        protected static FontFamily SymbolThemeFontFamily
         {
-            get => segoeMDL2AssetsFontFamily ??= new FontFamily("Segoe MDL2 Assets");
+            get => symbolThemeFontFamily ??= new FontFamily("Segoe Fluent Icons,Segoe MDL2 Assets");
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/Abstract/TextIconExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/Abstract/TextIconExtension.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         private static FontFamily symbolThemeFontFamily;
 
         /// <summary>
-        /// Gets the reusable "Segoe MDL2 Assets" <see cref="FontFamily"/> instance.
+        /// Gets the reusable "Segoe Fluent Icons,Segoe MDL2 Assets" <see cref="FontFamily"/> instance.
         /// </summary>
         protected static FontFamily SymbolThemeFontFamily
         {

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconExtension.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         public string Glyph { get; set; }
 
         /// <summary>
-        /// Gets or sets the font family to use to display the icon. If <see langword="null"/>, "Segoe MDL2 Assets" will be used.
+        /// Gets or sets the font family to use to display the icon. If <see langword="null"/>, "Segoe Fluent Icons,Segoe MDL2 Assets" will be used.
         /// </summary>
         public FontFamily FontFamily { get; set; }
 

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconExtension.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var fontIcon = new FontIcon
             {
                 Glyph = Glyph,
-                FontFamily = FontFamily ?? SegoeMDL2AssetsFontFamily,
+                FontFamily = FontFamily ?? SymbolThemeFontFamily,
                 FontWeight = FontWeight,
                 FontStyle = FontStyle,
                 IsTextScaleFactorEnabled = IsTextScaleFactorEnabled,

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconSourceExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconSourceExtension.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         public string Glyph { get; set; }
 
         /// <summary>
-        /// Gets or sets the font family to use to display the icon. If <see langword="null"/>, "Segoe MDL2 Assets" will be used.
+        /// Gets or sets the font family to use to display the icon. If <see langword="null"/>, "Segoe Fluent Icons,Segoe MDL2 Assets" will be used.
         /// </summary>
         public FontFamily FontFamily { get; set; }
 

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconSourceExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/FontIconSourceExtension.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var fontIcon = new FontIconSource
             {
                 Glyph = Glyph,
-                FontFamily = FontFamily ?? SegoeMDL2AssetsFontFamily,
+                FontFamily = FontFamily ?? SymbolThemeFontFamily,
                 FontWeight = FontWeight,
                 FontStyle = FontStyle,
                 IsTextScaleFactorEnabled = IsTextScaleFactorEnabled,

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/SymbolIconExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/SymbolIconExtension.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var fontIcon = new FontIcon
             {
                 Glyph = unchecked((char)Symbol).ToString(),
-                FontFamily = SegoeMDL2AssetsFontFamily,
+                FontFamily = SymbolThemeFontFamily,
                 FontWeight = FontWeight,
                 FontStyle = FontStyle,
                 IsTextScaleFactorEnabled = IsTextScaleFactorEnabled,

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/SymbolIconSourceExtension.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Markup/SymbolIconSourceExtension.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             var fontIcon = new FontIconSource
             {
                 Glyph = unchecked((char)Symbol).ToString(),
-                FontFamily = SegoeMDL2AssetsFontFamily,
+                FontFamily = SymbolThemeFontFamily,
                 FontWeight = FontWeight,
                 FontStyle = FontStyle,
                 IsTextScaleFactorEnabled = IsTextScaleFactorEnabled,

--- a/UnitTests/UnitTests.UWP/Extensions/Test_FontIconExtensionMarkupExtension.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_FontIconExtensionMarkupExtension.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Extensions
     {
         [TestCategory("FontIconExtensionMarkupExtension")]
         [UITestMethod]
-        public void Test_FontIconExtension_MarkupExtension_ProvideSegoeMdl2Asset()
+        public void Test_FontIconExtension_MarkupExtension_ProvideSymbolThemeFont()
         {
             var treeroot = XamlReader.Load(@"<Page
     xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
@@ -35,7 +35,7 @@ namespace UnitTests.Extensions
             Assert.IsNotNull(icon, $"Could not find the {nameof(FontIcon)} element in button.");
 
             Assert.AreEqual(icon.Glyph, "\uE105", "Expected icon glyph to be E105.");
-            Assert.AreEqual(icon.FontFamily.Source, "Segoe MDL2 Assets", "Expected font family to be Segoe MDL2 Assets");
+            Assert.AreEqual(icon.FontFamily.Source, "Segoe Fluent Icons,Segoe MDL2 Assets", "Expected font family to be \"Segoe Fluent Icons,Segoe MDL2 Assets\"");
         }
 
         [TestCategory("FontIconExtensionMarkupExtension")]

--- a/UnitTests/UnitTests.UWP/Extensions/Test_FontIconSourceExtensionMarkupExtension.cs
+++ b/UnitTests/UnitTests.UWP/Extensions/Test_FontIconSourceExtensionMarkupExtension.cs
@@ -18,7 +18,7 @@ namespace UnitTests.Extensions
     {
         [TestCategory("FontIconSourceExtensionMarkupExtension")]
         [UITestMethod]
-        public void Test_FontIconSourceExtension_MarkupExtension_ProvideSegoeMdl2Asset()
+        public void Test_FontIconSourceExtension_MarkupExtension_ProvideSymbolThemeFont()
         {
             var treeRoot = XamlReader.Load(@"<Page
     xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
@@ -37,7 +37,7 @@ namespace UnitTests.Extensions
             Assert.IsNotNull(icon, $"Could not find the {nameof(FontIcon)} element in button.");
 
             Assert.AreEqual(icon.Glyph, "\uE105", "Expected icon glyph to be E105.");
-            Assert.AreEqual(icon.FontFamily.Source, "Segoe MDL2 Assets", "Expected font family to be Segoe MDL2 Assets");
+            Assert.AreEqual(icon.FontFamily.Source, "Segoe Fluent Icons,Segoe MDL2 Assets", "Expected font family to be \"Segoe Fluent Icons,Segoe MDL2 Assets\"");
         }
 
         [TestCategory("FontIconSourceExtensionMarkupExtension")]


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4509 

<!-- Add the relevant issue number after the word "Fixes" mentioned above (for ex: `## Fixes #0000`) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->
Icon extensions should support the new Fluent icons introduced in Windows 11.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one or more options below that apply to this PR. -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
All icon extensions use "Segoe MDL2 Assets" font by default.

## What is the new behavior?

<!-- Describe how was this issue resolved or changed? -->
`FontIcon` and `SymbolIcon` extensions will now use "Segoe Fluent Icons" by default and fallback to "Segoe MDL2 Assets" if necessary.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [ ] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->
