### PR TITLE
WinUI - Fix DataGrid scroll performance issue

### DIFF
--- a/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridDataConnection.cs
+++ b/CommunityToolkit.WinUI.UI.Controls.DataGrid/DataGrid/DataGridDataConnection.cs
@@ -123,13 +123,11 @@ namespace CommunityToolkit.WinUI.UI.Controls.DataGridInternals
                     return list.Count;
                 }
 
-#if FEATURE_PAGEDCOLLECTIONVIEW
-                PagedCollectionView collectionView = this.DataSource as PagedCollectionView;
+                var collectionView = this.DataSource as ICollectionView;
                 if (collectionView != null)
                 {
                     return collectionView.Count;
                 }
-#endif
 
                 int count = 0;
                 IEnumerable enumerable = this.DataSource;
@@ -498,13 +496,11 @@ namespace CommunityToolkit.WinUI.UI.Controls.DataGridInternals
                 return (index < list.Count) ? list[index] : null;
             }
 
-#if FEATURE_PAGEDCOLLECTIONVIEW
-            PagedCollectionView collectionView = this.DataSource as PagedCollectionView;
+            var collectionView = this.DataSource as ICollectionView;
             if (collectionView != null)
             {
-                return (index < collectionView.Count) ? collectionView.GetItemAt(index) : null;
+                return (index < collectionView.Count) ? collectionView[index] : null;
             }
-#endif
 
             IEnumerable enumerable = this.DataSource;
             if (enumerable != null)
@@ -579,13 +575,11 @@ namespace CommunityToolkit.WinUI.UI.Controls.DataGridInternals
                 return list.IndexOf(dataItem);
             }
 
-#if FEATURE_PAGEDCOLLECTIONVIEW
-            PagedCollectionView cv = this.DataSource as PagedCollectionView;
-            if (cv != null)
+            var collectionView = this.DataSource as ICollectionView;
+            if (collectionView != null)
             {
-                return cv.IndexOf(dataItem);
+                return collectionView.IndexOf(dataItem);
             }
-#endif
 
             IEnumerable enumerable = this.DataSource;
             if (enumerable != null && dataItem != null)


### PR DESCRIPTION
## Fixes #2122

Fixes DataGrid scroll performance issue for large data sources.

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

The DataSource set in `DataGridDataConnection` class is (almost) always of type `ICollectionView` which implements generic `IList<>` but doesn't implement `IList`. This causes fallback to list enumeration to reach the current index..

https://user-images.githubusercontent.com/35062625/231341802-cf6072c8-2ed7-4426-86ea-ac3d8733cb4b.mp4

## What is the new behavior?

The fix adds support for `ICollectionView` DataSource and accesses the items directly by their index.
An approach for `PagedCollectionView` (from Silverlight) can be merged with the fix as it implements the same interface.

https://user-images.githubusercontent.com/35062625/231342564-3ea0703c-980a-4a62-be40-bfdc32570266.mp4

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [x] Contains **NO** breaking changes

## Other information


