### PR TITLE
fix(DataGrid): tabbing doesnt properly bring cell into view, when cell expanded in edit-mode

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGrid.cs
@@ -253,6 +253,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private ValidationSummaryItem _selectedValidationSummaryItem;
 #endif
 
+        private DateTime _scrollAdjustmentTimeWindow = DateTime.MinValue;
+        private FrameworkElement _scrollAdjustmentTarget;
+
         // An approximation of the sum of the heights in pixels of the scrolling rows preceding
         // the first displayed scrolling row.  Since the scrolled off rows are discarded, the grid
         // does not know their actual height. The heights used for the approximation are the ones
@@ -5914,6 +5917,49 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             PreparingCellForEditPrivate(element);
         }
 
+        private void EditingElement_SizeChanged(object sender, SizeChangedEventArgs args)
+        {
+            if (sender is not FrameworkElement element)
+            {
+                return;
+            }
+
+            if (_scrollAdjustmentTarget != element ||
+                _scrollAdjustmentTimeWindow < DateTime.Now)
+            {
+                element.SizeChanged -= EditingElement_SizeChanged;
+                return;
+            }
+
+            // Workaround for https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/4983
+            // Scroll-into-view is based the cell's size in normal mode. For cell that expands in edit-mode,
+            // the scroll h/v offsets could be off. So we scroll again using with newly updated size.
+            if (_editingColumnIndex != -1 &&
+                EditingRow?.Cells[_editingColumnIndex] is { Content: FrameworkElement editor } cell &&
+                editor == element)
+            {
+                var shouldScroll = new
+                {
+                    Horizontally = args.PreviousSize.Width < args.NewSize.Width,
+                    Vertically = args.PreviousSize.Height < args.NewSize.Height,
+                };
+                if (shouldScroll.Horizontally || shouldScroll.Vertically)
+                {
+                    ComputeScrollBarsLayout();
+                }
+
+                if (shouldScroll.Horizontally)
+                {
+                    ScrollColumnIntoView(cell.ColumnIndex);
+                }
+
+                if (shouldScroll.Vertically)
+                {
+                    ScrollSlotIntoView(cell.RowIndex, scrolledHorizontally: false);
+                }
+            }
+        }
+
         private bool EndCellEdit(DataGridEditAction editAction, bool exitEditingMode, bool keepFocus, bool raiseEvents)
         {
             if (_editingColumnIndex == -1)
@@ -6700,8 +6746,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         element.SetStyleWithType(dataGridBoundColumn.EditingElementStyle);
                     }
 
+                    _scrollAdjustmentTimeWindow = DateTime.Now.AddSeconds(.5);
+                    _scrollAdjustmentTarget = element;
+
                     // Subscribe to the new element's events
                     element.Loaded += new RoutedEventHandler(EditingElement_Loaded);
+                    element.SizeChanged += new SizeChangedEventHandler(EditingElement_SizeChanged);
                 }
             }
             else


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #4983

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When moving to the next cell using <kbd>Tab</kbd> and this cell's size changing from entering edit-mode, the scroll-into-view is performed based on its previous size from the normal-mode.

## What is the new behavior?
The scroll-into-view is performed again, if the cell size grows within a short time frame.

## PR Checklist

Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->
- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

## Other information
related: https://github.com/unoplatform/uno/issues/14311