### PR TITLE
Fixed scrolled DataGrid not displaying cells from last columns when resized

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumns.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumns.cs
@@ -1245,6 +1245,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                             _horizontalOffset -= GetEdgedColumnWidth(dataGridColumn);
                             dataGridColumn = this.ColumnsInternal.GetPreviousVisibleScrollingColumn(dataGridColumn);
                         }
+
+                        if (_horizontalOffset == 0 && cx < displayWidth)
+                        {
+                            // if the columns have been scrolled, and all visible columns are fully rendered in the available space,
+                            // then HorizontalAdjustment needs to be updated so that DataGridCellsPresenter.ShouldDisplayCell
+                            // don't hide columns based on the old value.
+                            HorizontalAdjustment = displayWidth - cx;
+                        }
                     }
 
                     // third try to partially scroll in first scrolled off column


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes #5010
![datagrid cell mia on resize](https://github.com/user-attachments/assets/6fbbd3cf-2ca7-49e4-8cd7-252a72e794d7)

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
In certain situation, when the data-grid resizes from needing a scrollbar to not, certain cells is no longer visible.

## What is the new behavior?
Scrolled cells will remain visible after resize.

## PR Checklist
Please check if your PR fulfills the following requirements: <!-- and remove the ones that are not applicable to the current PR -->
- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] Tested code with current [supported SDKs](../#supported)
- [ ] New component
  - [ ] Pull Request has been submitted to the documentation repository [instructions](../blob/main/Contributing.md#docs). Link: <!-- docs PR link -->
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
  - [ ] If control, added to Visual Studio Design project
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] New major technical changes in the toolkit have or will be added to the [Wiki](https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki) e.g. build changes, source generators, testing infrastructure, sample creation changes, etc...
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information
<!-- Please add any other information that might be helpful to reviewers. -->
